### PR TITLE
[FEATURE] Encrypted data and config files

### DIFF
--- a/benchmark/BTree_index_benchmark_test.go
+++ b/benchmark/BTree_index_benchmark_test.go
@@ -12,7 +12,7 @@ import (
 func BenchmarkConcurrentIndexOps(b *testing.B) {
 	_ = os.Remove("benchmark_index.dat")
 
-	idx, err := index.NewBTreeIndex("benchmark_index.dat")
+	idx, err := index.NewBTreeIndex("benchmark_index.dat", nil)
 	if err != nil {
 		b.Fatalf("Failed to create index: %v", err)
 	}

--- a/cmd/server/persistence.go
+++ b/cmd/server/persistence.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/shibudb.org/shibudb-server/internal/atrest"
 )
 
 // ConnectionConfig stores persistent connection settings
@@ -31,8 +33,15 @@ func SaveConnectionLimit(dataDir string, limit int32) error {
 		return fmt.Errorf("failed to marshal config: %v", err)
 	}
 
-	if err := os.WriteFile(cfgFile, data, 0644); err != nil {
-		return fmt.Errorf("failed to write config file: %v", err)
+	mgr := atrest.RuntimeManager()
+	if mgr != nil && mgr.Enabled() {
+		if err := mgr.WriteFile(cfgFile, data, 0600, "connection-limit"); err != nil {
+			return fmt.Errorf("failed to write encrypted config file: %v", err)
+		}
+	} else {
+		if err := os.WriteFile(cfgFile, data, 0644); err != nil {
+			return fmt.Errorf("failed to write config file: %v", err)
+		}
 	}
 
 	fmt.Printf("Connection limit saved to: %s\n", cfgFile)
@@ -44,7 +53,16 @@ func SaveConnectionLimit(dataDir string, limit int32) error {
 // (so callers can distinguish “no persisted config” from a real on-disk limit).
 func LoadConnectionLimit(dataDir string) (int32, error) {
 	cfgFile := filepath.Join(dataDir, "connection_limit.json")
-	data, err := os.ReadFile(cfgFile)
+	var (
+		data []byte
+		err  error
+	)
+	mgr := atrest.RuntimeManager()
+	if mgr != nil && mgr.Enabled() {
+		data, err = mgr.ReadFile(cfgFile, "connection-limit")
+	} else {
+		data, err = os.ReadFile(cfgFile)
+	}
 	if err != nil {
 		if os.IsNotExist(err) {
 			return 0, err

--- a/internal/atrest/manager.go
+++ b/internal/atrest/manager.go
@@ -1,0 +1,283 @@
+package atrest
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"golang.org/x/crypto/scrypt"
+)
+
+const (
+	EnvMasterKey          = "SHIBUDB_MASTER_KEY"
+	EnvMasterPassphrase   = "SHIBUDB_MASTER_PASSPHRASE"
+	fileMagic             = "SDBENC1"
+	manifestFileName      = "encryption.manifest.json"
+	defaultScryptN        = 1 << 15
+	defaultScryptR        = 8
+	defaultScryptP        = 1
+	defaultDerivedKeySize = 32
+)
+
+type Config struct {
+	Enabled       bool
+	DataDir       string
+	Passphrase    string
+	MasterKey     string
+	MasterKeyFile string
+}
+
+type Manifest struct {
+	Version int    `json:"version"`
+	KDF     string `json:"kdf"`
+	SaltB64 string `json:"salt_b64"`
+}
+
+type Manager struct {
+	enabled bool
+	aead    cipher.AEAD
+}
+
+var (
+	runtimeMu      sync.RWMutex
+	runtimeManager *Manager
+)
+
+func NewManager(cfg Config) (*Manager, error) {
+	if !cfg.Enabled {
+		return &Manager{enabled: false}, nil
+	}
+
+	key, err := resolveKey(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if len(key) != 32 {
+		return nil, fmt.Errorf("master key must be 32 bytes, got %d", len(key))
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	return &Manager{enabled: true, aead: aead}, nil
+}
+
+func SetRuntimeManager(m *Manager) {
+	runtimeMu.Lock()
+	defer runtimeMu.Unlock()
+	runtimeManager = m
+}
+
+func RuntimeManager() *Manager {
+	runtimeMu.RLock()
+	defer runtimeMu.RUnlock()
+	return runtimeManager
+}
+
+func (m *Manager) Enabled() bool {
+	return m != nil && m.enabled
+}
+
+func (m *Manager) Seal(plaintext []byte, aad string) ([]byte, error) {
+	if !m.Enabled() {
+		out := make([]byte, len(plaintext))
+		copy(out, plaintext)
+		return out, nil
+	}
+	nonce := make([]byte, m.aead.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, err
+	}
+	ciphertext := m.aead.Seal(nil, nonce, plaintext, []byte(aad))
+	out := make([]byte, 0, len(fileMagic)+1+1+len(nonce)+len(ciphertext))
+	out = append(out, []byte(fileMagic)...)
+	out = append(out, byte(1))
+	out = append(out, byte(len(nonce)))
+	out = append(out, nonce...)
+	out = append(out, ciphertext...)
+	return out, nil
+}
+
+func (m *Manager) Open(payload []byte, aad string) ([]byte, error) {
+	if len(payload) < len(fileMagic)+2 {
+		return nil, errors.New("encrypted payload too short")
+	}
+	if string(payload[:len(fileMagic)]) != fileMagic {
+		return nil, errors.New("payload is not encrypted with shibudb envelope")
+	}
+	version := payload[len(fileMagic)]
+	if version != 1 {
+		return nil, fmt.Errorf("unsupported encryption envelope version: %d", version)
+	}
+	nonceSize := int(payload[len(fileMagic)+1])
+	start := len(fileMagic) + 2
+	if len(payload) < start+nonceSize {
+		return nil, errors.New("invalid encrypted payload")
+	}
+	nonce := payload[start : start+nonceSize]
+	ciphertext := payload[start+nonceSize:]
+	return m.aead.Open(nil, nonce, ciphertext, []byte(aad))
+}
+
+func (m *Manager) ReadFile(path, aad string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if !m.Enabled() {
+		return data, nil
+	}
+	if !isEncryptedPayload(data) {
+		return nil, fmt.Errorf("plaintext file found while encryption-at-rest is enabled: %s", path)
+	}
+	return m.Open(data, aad)
+}
+
+func (m *Manager) WriteFile(path string, plaintext []byte, perm os.FileMode, aad string) error {
+	data := plaintext
+	var err error
+	if m.Enabled() {
+		data, err = m.Seal(plaintext, aad)
+		if err != nil {
+			return err
+		}
+	}
+	return writeFileAtomic(path, data, perm)
+}
+
+func IsEncryptedFile(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	return isEncryptedPayload(data)
+}
+
+func isEncryptedPayload(data []byte) bool {
+	return len(data) >= len(fileMagic) && string(data[:len(fileMagic)]) == fileMagic
+}
+
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
+func resolveKey(cfg Config) ([]byte, error) {
+	if strings.TrimSpace(cfg.MasterKey) != "" {
+		return parseRawKey(cfg.MasterKey)
+	}
+	if envKey := strings.TrimSpace(os.Getenv(EnvMasterKey)); envKey != "" {
+		return parseRawKey(envKey)
+	}
+	if strings.TrimSpace(cfg.MasterKeyFile) != "" {
+		b, err := os.ReadFile(cfg.MasterKeyFile)
+		if err != nil {
+			return nil, err
+		}
+		return parseRawKey(strings.TrimSpace(string(b)))
+	}
+	pass := strings.TrimSpace(cfg.Passphrase)
+	if pass == "" {
+		pass = strings.TrimSpace(os.Getenv(EnvMasterPassphrase))
+	}
+	if pass == "" {
+		return nil, errors.New("no encryption key source configured: provide master key env/file or passphrase")
+	}
+	return deriveFromPassphrase(cfg.DataDir, pass)
+}
+
+func parseRawKey(v string) ([]byte, error) {
+	if decoded, err := hex.DecodeString(v); err == nil && len(decoded) == 32 {
+		return decoded, nil
+	}
+	if decoded, err := base64.StdEncoding.DecodeString(v); err == nil && len(decoded) == 32 {
+		return decoded, nil
+	}
+	if len(v) == 32 {
+		return []byte(v), nil
+	}
+	return nil, errors.New("raw master key must be 32-byte plain, 64-char hex, or base64")
+}
+
+func deriveFromPassphrase(dataDir, pass string) ([]byte, error) {
+	manifestPath := filepath.Join(dataDir, manifestFileName)
+	manifest, err := loadOrCreateManifest(manifestPath)
+	if err != nil {
+		return nil, err
+	}
+	salt, err := base64.StdEncoding.DecodeString(manifest.SaltB64)
+	if err != nil {
+		return nil, err
+	}
+	return scrypt.Key([]byte(pass), salt, defaultScryptN, defaultScryptR, defaultScryptP, defaultDerivedKeySize)
+}
+
+func loadOrCreateManifest(path string) (*Manifest, error) {
+	if _, err := os.Stat(path); err == nil {
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+		var m Manifest
+		if err := json.Unmarshal(b, &m); err != nil {
+			return nil, err
+		}
+		return &m, nil
+	}
+	salt := make([]byte, 16)
+	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
+		return nil, err
+	}
+	m := Manifest{
+		Version: 1,
+		KDF:     "scrypt",
+		SaltB64: base64.StdEncoding.EncodeToString(salt),
+	}
+	b, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	if err := writeFileAtomic(path, b, 0600); err != nil {
+		return nil, err
+	}
+	return &m, nil
+}

--- a/internal/atrest/manager_test.go
+++ b/internal/atrest/manager_test.go
@@ -1,0 +1,58 @@
+package atrest
+
+import (
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestManagerRoundTrip(t *testing.T) {
+	t.Setenv(EnvMasterKey, hex.EncodeToString([]byte("12345678901234567890123456789012")))
+
+	mgr, err := NewManager(Config{Enabled: true, DataDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+
+	ciphertext, err := mgr.Seal([]byte("hello"), "aad")
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	plain, err := mgr.Open(ciphertext, "aad")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if string(plain) != "hello" {
+		t.Fatalf("unexpected plaintext: %q", string(plain))
+	}
+}
+
+func TestReadWriteFileEncrypted(t *testing.T) {
+	t.Setenv(EnvMasterKey, hex.EncodeToString([]byte("12345678901234567890123456789012")))
+	tmpDir := t.TempDir()
+
+	mgr, err := NewManager(Config{Enabled: true, DataDir: tmpDir})
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+
+	path := filepath.Join(tmpDir, "payload.bin")
+	if err := mgr.WriteFile(path, []byte("secret"), 0600, "file-aad"); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read raw file: %v", err)
+	}
+	if string(raw) == "secret" {
+		t.Fatal("expected encrypted payload, got plaintext")
+	}
+	opened, err := mgr.ReadFile(path, "file-aad")
+	if err != nil {
+		t.Fatalf("read file via manager: %v", err)
+	}
+	if string(opened) != "secret" {
+		t.Fatalf("unexpected decrypted value: %q", string(opened))
+	}
+}

--- a/internal/auth/manager.go
+++ b/internal/auth/manager.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sync"
 
+	"github.com/shibudb.org/shibudb-server/internal/atrest"
 	"github.com/shibudb.org/shibudb-server/internal/models"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -127,7 +128,16 @@ func (a *AuthManager) load() error {
 	a.lock.Lock()
 	defer a.lock.Unlock()
 
-	data, err := os.ReadFile(a.filePath)
+	var (
+		data []byte
+		err  error
+	)
+	mgr := atrest.RuntimeManager()
+	if mgr != nil && mgr.Enabled() {
+		data, err = mgr.ReadFile(a.filePath, "auth-users")
+	} else {
+		data, err = os.ReadFile(a.filePath)
+	}
 	if err != nil {
 		return err
 	}
@@ -138,6 +148,10 @@ func (a *AuthManager) save() error {
 	data, err := json.MarshalIndent(a.users, "", "  ")
 	if err != nil {
 		return err
+	}
+	mgr := atrest.RuntimeManager()
+	if mgr != nil && mgr.Enabled() {
+		return mgr.WriteFile(a.filePath, data, 0600, "auth-users")
 	}
 	return os.WriteFile(a.filePath, data, 0644)
 }

--- a/internal/index/BTreeIndex.go
+++ b/internal/index/BTreeIndex.go
@@ -2,7 +2,10 @@ package index
 
 import (
 	"encoding/binary"
+	"fmt"
+
 	"github.com/google/btree"
+	"github.com/shibudb.org/shibudb-server/internal/atrest"
 	"golang.org/x/sys/unix"
 	"os"
 	"sync"
@@ -16,6 +19,7 @@ type BTreeIndex struct {
 	file        *os.File
 	mmapData    []byte
 	writeOffset int // Track where to write next
+	encryptMgr  *atrest.Manager
 }
 
 type Item struct {
@@ -27,7 +31,7 @@ func (i Item) Less(other btree.Item) bool {
 	return i.Key < other.(Item).Key
 }
 
-func NewBTreeIndex(filename string) (*BTreeIndex, error) {
+func NewBTreeIndex(filename string, encryptMgr *atrest.Manager) (*BTreeIndex, error) {
 	file, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE, 0666)
 	if err != nil {
 		return nil, err
@@ -48,9 +52,10 @@ func NewBTreeIndex(filename string) (*BTreeIndex, error) {
 	}
 
 	idx := &BTreeIndex{
-		btree:    btree.New(2),
-		file:     file,
-		mmapData: mmapData,
+		btree:      btree.New(2),
+		file:       file,
+		mmapData:   mmapData,
+		encryptMgr: encryptMgr,
 	}
 
 	idx.writeOffset = idx.BatchLoadFromMmap()
@@ -74,6 +79,12 @@ func (idx *BTreeIndex) BatchLoadFromMmap() int {
 		}
 
 		key := string(idx.mmapData[offset : offset+int(keySize)])
+		if idx.encryptMgr != nil && idx.encryptMgr.Enabled() && keySize > 0 {
+			opened, err := idx.encryptMgr.Open([]byte(key), "btree-index-key")
+			if err == nil {
+				key = string(opened)
+			}
+		}
 		offset += int(keySize)
 
 		idx.btree.ReplaceOrInsert(Item{Key: key, Value: int64(pos)})
@@ -139,6 +150,13 @@ func (idx *BTreeIndex) persistIndex() error {
 
 func (idx *BTreeIndex) appendIndexEntry(key string, pos int64) error {
 	keyBytes := []byte(key)
+	if idx.encryptMgr != nil && idx.encryptMgr.Enabled() {
+		sealed, err := idx.encryptMgr.Seal(keyBytes, "btree-index-key")
+		if err != nil {
+			return fmt.Errorf("failed to encrypt btree key: %w", err)
+		}
+		keyBytes = sealed
+	}
 	keySize := uint32(len(keyBytes))
 	entrySize := 8 + len(keyBytes)
 

--- a/internal/index/btreeindex_test.go
+++ b/internal/index/btreeindex_test.go
@@ -12,7 +12,7 @@ func TestBTreeIndex(t *testing.T) {
 	os.Remove("test_index.dat")
 
 	// Initialize BTreeIndex
-	idx, err := NewBTreeIndex("test_index.dat")
+	idx, err := NewBTreeIndex("test_index.dat", nil)
 	if err != nil {
 		t.Fatalf("Failed to create index: %v", err)
 	}
@@ -86,7 +86,7 @@ func TestBTreeIndex(t *testing.T) {
 		idx.Close()
 
 		// Reload the index from file
-		idx, err = NewBTreeIndex("test_index.dat")
+		idx, err = NewBTreeIndex("test_index.dat", nil)
 		if err != nil {
 			t.Fatalf("Failed to reload index: %v", err)
 		}
@@ -121,7 +121,7 @@ func TestBTreeIndex(t *testing.T) {
 		os.Remove("test_index_persistence.dat")
 
 		// Initialize BTreeIndex
-		idx, err := NewBTreeIndex("test_index_persistence.dat")
+		idx, err := NewBTreeIndex("test_index_persistence.dat", nil)
 		if err != nil {
 			t.Fatalf("Failed to create index: %v", err)
 		}
@@ -143,7 +143,7 @@ func TestBTreeIndex(t *testing.T) {
 		}
 
 		// Reopen the index
-		idx, err = NewBTreeIndex("test_index_persistence.dat")
+		idx, err = NewBTreeIndex("test_index_persistence.dat", nil)
 		if err != nil {
 			t.Fatalf("Failed to reopen index: %v", err)
 		}
@@ -159,7 +159,7 @@ func TestBTreeIndex(t *testing.T) {
 	t.Run("ConcurrentUpdates", func(t *testing.T) {
 		os.Remove("test_index_concurrent.dat")
 
-		idx, err := NewBTreeIndex("test_index_concurrent.dat")
+		idx, err := NewBTreeIndex("test_index_concurrent.dat", nil)
 		if err != nil {
 			t.Fatalf("Failed to create index: %v", err)
 		}

--- a/internal/spaces/space_manager.go
+++ b/internal/spaces/space_manager.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/shibudb.org/shibudb-server/internal/atrest"
 	"github.com/shibudb.org/shibudb-server/internal/storage"
 
 	"github.com/DataIntelligenceCrew/go-faiss"
@@ -118,7 +119,16 @@ func NewSpaceManager(basePath string) *SpaceManager {
 }
 
 func (sm *SpaceManager) loadSpaceMetas() {
-	data, err := os.ReadFile(sm.metaFilePath)
+	var (
+		data []byte
+		err  error
+	)
+	mgr := atrest.RuntimeManager()
+	if mgr != nil && mgr.Enabled() {
+		data, err = mgr.ReadFile(sm.metaFilePath, "space-metadata")
+	} else {
+		data, err = os.ReadFile(sm.metaFilePath)
+	}
 	if err != nil {
 		return // file might not exist yet
 	}
@@ -170,6 +180,11 @@ func (sm *SpaceManager) saveSpaceMetas() {
 		metas = append(metas, meta)
 	}
 	data, _ := json.MarshalIndent(metas, "", "  ")
+	mgr := atrest.RuntimeManager()
+	if mgr != nil && mgr.Enabled() {
+		_ = mgr.WriteFile(sm.metaFilePath, data, 0600, "space-metadata")
+		return
+	}
 	_ = os.WriteFile(sm.metaFilePath, data, 0644)
 }
 

--- a/internal/storage/key_value_storage.go
+++ b/internal/storage/key_value_storage.go
@@ -11,6 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/shibudb.org/shibudb-server/internal/atrest"
 	"github.com/shibudb.org/shibudb-server/internal/index"
 	"github.com/shibudb.org/shibudb-server/internal/wal"
 )
@@ -25,6 +26,7 @@ type ShibuDB struct {
 	quitChan     chan struct{}
 	flushRunning int32
 	closeOnce    sync.Once
+	encryptMgr   *atrest.Manager
 }
 
 func OpenDBWithPathsAndWAL(dataPath, walPath, indexPath string, enableWAL bool) (*ShibuDB, error) {
@@ -33,7 +35,8 @@ func OpenDBWithPathsAndWAL(dataPath, walPath, indexPath string, enableWAL bool) 
 		return nil, err
 	}
 
-	dbIndex, err := index.NewBTreeIndex(indexPath)
+	encryptMgr := atrest.RuntimeManager()
+	dbIndex, err := index.NewBTreeIndex(indexPath, encryptMgr)
 	if err != nil {
 		return nil, err
 	}
@@ -47,11 +50,12 @@ func OpenDBWithPathsAndWAL(dataPath, walPath, indexPath string, enableWAL bool) 
 	}
 
 	db := &ShibuDB{
-		file:     file,
-		index:    dbIndex,
-		wal:      dbWAL,
-		quitChan: make(chan struct{}),
-		batch:    make(map[string]string),
+		file:       file,
+		index:      dbIndex,
+		wal:        dbWAL,
+		quitChan:   make(chan struct{}),
+		batch:      make(map[string]string),
+		encryptMgr: encryptMgr,
 	}
 
 	db.index.BatchLoadFromMmap()
@@ -73,7 +77,8 @@ func OpenDBWithWAL(filename string, walFilename string, enableWAL bool) (*ShibuD
 	if err != nil {
 		return nil, err
 	}
-	dbIndex, err := index.NewBTreeIndex("index.dat")
+	encryptMgr := atrest.RuntimeManager()
+	dbIndex, err := index.NewBTreeIndex("index.dat", encryptMgr)
 	if err != nil {
 		return nil, err
 	}
@@ -85,11 +90,12 @@ func OpenDBWithWAL(filename string, walFilename string, enableWAL bool) (*ShibuD
 		}
 	}
 	db := &ShibuDB{
-		file:     file,
-		index:    dbIndex,
-		wal:      dbWAL,
-		quitChan: make(chan struct{}),
-		batch:    make(map[string]string),
+		file:       file,
+		index:      dbIndex,
+		wal:        dbWAL,
+		quitChan:   make(chan struct{}),
+		batch:      make(map[string]string),
+		encryptMgr: encryptMgr,
 	}
 	db.index.BatchLoadFromMmap()
 	if enableWAL {
@@ -178,6 +184,15 @@ func (db *ShibuDB) FlushBatch() error {
 	for key, value := range batchCopy {
 		keyBytes := []byte(key)
 		valBytes := []byte(value)
+		if db.encryptMgr != nil && db.encryptMgr.Enabled() {
+			serialized := serializeKV(keyBytes, valBytes)
+			sealed, err := db.encryptMgr.Seal(serialized, "kv-record")
+			if err != nil {
+				return err
+			}
+			keyBytes = nil
+			valBytes = sealed
+		}
 
 		keySize := uint32(len(keyBytes))
 		valSize := uint32(len(valBytes))
@@ -275,6 +290,26 @@ func (db *ShibuDB) Get(key string) (string, error) {
 	log.Println("Key found", string(keyBytes))
 	log.Println("Value found", string(valBytes))
 
+	if keySize == 0 {
+		if db.encryptMgr == nil || !db.encryptMgr.Enabled() {
+			return "", errors.New("encrypted key-value record found but encryption is disabled")
+		}
+		plain, err := db.encryptMgr.Open(valBytes, "kv-record")
+		if err != nil {
+			return "", err
+		}
+		decodedKey, decodedVal, err := deserializeKV(plain)
+		if err != nil {
+			return "", err
+		}
+		if string(decodedKey) != key {
+			return "", errors.New("key mismatch in encrypted record")
+		}
+		if len(decodedVal) == 0 {
+			return "", errors.New("key is deleted")
+		}
+		return string(decodedVal), nil
+	}
 	if string(keyBytes) == key {
 		value := string(valBytes)
 		if value == "__deleted__" {
@@ -303,13 +338,24 @@ func (db *ShibuDB) Delete(key string) error {
 	}
 
 	keyBytes := []byte(key)
+	valBytes := []byte{}
+	if db.encryptMgr != nil && db.encryptMgr.Enabled() {
+		serialized := serializeKV(keyBytes, valBytes)
+		sealed, err := db.encryptMgr.Seal(serialized, "kv-record")
+		if err != nil {
+			return err
+		}
+		keyBytes = nil
+		valBytes = sealed
+	}
 	keySize := uint32(len(keyBytes))
-	valSize := uint32(0)
+	valSize := uint32(len(valBytes))
 
-	buf := make([]byte, 8+len(keyBytes))
+	buf := make([]byte, 8+len(keyBytes)+len(valBytes))
 	binary.LittleEndian.PutUint32(buf[0:4], keySize)
 	binary.LittleEndian.PutUint32(buf[4:8], valSize)
 	copy(buf[8:], keyBytes)
+	copy(buf[8+len(keyBytes):], valBytes)
 
 	pos, err := db.file.Seek(0, 2)
 	if err != nil {
@@ -335,4 +381,29 @@ func (db *ShibuDB) Close() error {
 
 func (db *ShibuDB) Put(key, value string) error {
 	return db.PutBatch(key, value)
+}
+
+func serializeKV(key, value []byte) []byte {
+	buf := make([]byte, 8+len(key)+len(value))
+	binary.LittleEndian.PutUint32(buf[0:4], uint32(len(key)))
+	binary.LittleEndian.PutUint32(buf[4:8], uint32(len(value)))
+	copy(buf[8:8+len(key)], key)
+	copy(buf[8+len(key):], value)
+	return buf
+}
+
+func deserializeKV(data []byte) ([]byte, []byte, error) {
+	if len(data) < 8 {
+		return nil, nil, errors.New("invalid kv payload")
+	}
+	keySize := int(binary.LittleEndian.Uint32(data[0:4]))
+	valSize := int(binary.LittleEndian.Uint32(data[4:8]))
+	if len(data) < 8+keySize+valSize {
+		return nil, nil, errors.New("invalid kv payload sizes")
+	}
+	k := make([]byte, keySize)
+	v := make([]byte, valSize)
+	copy(k, data[8:8+keySize])
+	copy(v, data[8+keySize:8+keySize+valSize])
+	return k, v, nil
 }

--- a/internal/storage/vector_storage.go
+++ b/internal/storage/vector_storage.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"math"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -15,6 +16,7 @@ import (
 	"time"
 
 	"github.com/DataIntelligenceCrew/go-faiss"
+	"github.com/shibudb.org/shibudb-server/internal/atrest"
 	"github.com/shibudb.org/shibudb-server/internal/wal"
 )
 
@@ -58,9 +60,11 @@ type VectorEngineImpl struct {
 		id  int64
 		vec []float32
 	}
-	maxBatch int
-	maxDelay time.Duration
-	flushCh  chan struct{}
+	maxBatch          int
+	maxDelay          time.Duration
+	flushCh           chan struct{}
+	encryptMgr        *atrest.Manager
+	dataFileEncrypted bool
 }
 
 var _ VectorEngine = (*VectorEngineImpl)(nil)
@@ -72,10 +76,21 @@ func NewVectorEngine(dataPath, indexPath, walPath string, maxVectorSize int, ind
 		return nil, fmt.Errorf("open data file: %w", err)
 	}
 
+	encryptMgr := atrest.RuntimeManager()
 	// Create (or read) the ID-mapped index
 	var idmap faiss.Index
 	if _, err := os.Stat(indexPath); err == nil {
-		idmap, err = faiss.ReadIndex(indexPath, 0)
+		if encryptMgr != nil && encryptMgr.Enabled() && atrest.IsEncryptedFile(indexPath) {
+			tmpFile, tempPath, err := decryptIndexToTemp(indexPath, encryptMgr)
+			if err != nil {
+				return nil, err
+			}
+			tmpFile.Close()
+			defer os.Remove(tempPath)
+			idmap, err = faiss.ReadIndex(tempPath, 0)
+		} else {
+			idmap, err = faiss.ReadIndex(indexPath, 0)
+		}
 		if err != nil {
 			return nil, fmt.Errorf("failed to read FAISS index from file: %w", err)
 		}
@@ -109,10 +124,12 @@ func NewVectorEngine(dataPath, indexPath, walPath string, maxVectorSize int, ind
 		quitChan:      make(chan struct{}),
 
 		// batching defaults
-		maxBatch: 1024,
-		maxDelay: 50 * time.Millisecond,
-		flushCh:  make(chan struct{}, 1),
+		maxBatch:   1024,
+		maxDelay:   50 * time.Millisecond,
+		flushCh:    make(chan struct{}, 1),
+		encryptMgr: encryptMgr,
 	}
+	e.dataFileEncrypted = e.shouldUseEncryptedDataFile()
 
 	// Rebuild fileOffsets from data file (last record per id wins; tombstones mark deleted).
 	if err := e.rebuildOffsetsFromDataFile(); err != nil {
@@ -339,9 +356,8 @@ func (ve *VectorEngineImpl) GetVectorByID(id int64) ([]float32, error) {
 		return nil, fmt.Errorf("ID %d not found", id)
 	}
 
-	recordSize := 8 + 4*ve.maxVectorSize
-	buf := make([]byte, recordSize)
-	if _, err := ve.dataFile.ReadAt(buf, offset); err != nil {
+	buf, err := ve.readRecordAt(offset)
+	if err != nil {
 		return nil, fmt.Errorf("read vector at offset %d: %w", offset, err)
 	}
 	// Tombstone: same record format, first float32 is reserved marker (see tombstoneMarker).
@@ -422,12 +438,21 @@ func (ve *VectorEngineImpl) appendTombstoneToDataFile(id int64) error {
 	if err != nil {
 		return err
 	}
-	recordSize := 8 + 4*ve.maxVectorSize
-	buf := make([]byte, recordSize)
-	binary.LittleEndian.PutUint64(buf[0:8], uint64(id))
-	binary.LittleEndian.PutUint32(buf[8:12], tombstoneMarker)
-	// rest is zero; same size as a normal vector record
-	if _, err := ve.dataFile.Write(buf); err != nil {
+	plain := make([]byte, 8+4*ve.maxVectorSize)
+	binary.LittleEndian.PutUint64(plain[0:8], uint64(id))
+	binary.LittleEndian.PutUint32(plain[8:12], tombstoneMarker)
+	toWrite := plain
+	if ve.dataFileEncrypted {
+		sealed, err := ve.encryptMgr.Seal(plain, "vector-record")
+		if err != nil {
+			return err
+		}
+		prefix := make([]byte, 4+len(sealed))
+		binary.LittleEndian.PutUint32(prefix[0:4], uint32(len(sealed)))
+		copy(prefix[4:], sealed)
+		toWrite = prefix
+	}
+	if _, err := ve.dataFile.Write(toWrite); err != nil {
 		return err
 	}
 	if err := ve.dataFile.Sync(); err != nil {
@@ -486,8 +511,28 @@ func (ve *VectorEngineImpl) checkpoint() error {
 	defer ve.lock.Unlock()
 
 	// Persist the (ID-mapped) index
-	if err := faiss.WriteIndex(ve.idMapIndex, ve.indexFile); err != nil {
-		return fmt.Errorf("write index: %w", err)
+	if ve.encryptMgr != nil && ve.encryptMgr.Enabled() {
+		tmp, err := os.CreateTemp(filepath.Dir(ve.indexFile), ".faiss-*.tmp")
+		if err != nil {
+			return err
+		}
+		tmpPath := tmp.Name()
+		tmp.Close()
+		defer os.Remove(tmpPath)
+		if err := faiss.WriteIndex(ve.idMapIndex, tmpPath); err != nil {
+			return fmt.Errorf("write temp index: %w", err)
+		}
+		raw, err := os.ReadFile(tmpPath)
+		if err != nil {
+			return err
+		}
+		if err := ve.encryptMgr.WriteFile(ve.indexFile, raw, 0600, "vector-faiss-index"); err != nil {
+			return err
+		}
+	} else {
+		if err := faiss.WriteIndex(ve.idMapIndex, ve.indexFile); err != nil {
+			return fmt.Errorf("write index: %w", err)
+		}
 	}
 	// Ensure data file flushed
 	if err := ve.dataFile.Sync(); err != nil {
@@ -558,7 +603,18 @@ func (ve *VectorEngineImpl) appendToDataFile(id int64, vector []float32) error {
 	for i, v := range vector {
 		binary.LittleEndian.PutUint32(buf[8+i*4:], math.Float32bits(v))
 	}
-	if _, err := ve.dataFile.Write(buf); err != nil {
+	toWrite := buf
+	if ve.dataFileEncrypted {
+		sealed, err := ve.encryptMgr.Seal(buf, "vector-record")
+		if err != nil {
+			return err
+		}
+		prefix := make([]byte, 4+len(sealed))
+		binary.LittleEndian.PutUint32(prefix[0:4], uint32(len(sealed)))
+		copy(prefix[4:], sealed)
+		toWrite = prefix
+	}
+	if _, err := ve.dataFile.Write(toWrite); err != nil {
 		return err
 	}
 	ve.fileOffsets[id] = pos
@@ -570,10 +626,39 @@ func (ve *VectorEngineImpl) rebuildOffsetsFromDataFile() error {
 	if _, err := ve.dataFile.Seek(0, io.SeekStart); err != nil {
 		return err
 	}
-	recordSize := 8 + 4*ve.maxVectorSize
 	offset := int64(0)
 
 	for {
+		if ve.dataFileEncrypted {
+			lenBuf := make([]byte, 4)
+			n, err := ve.dataFile.Read(lenBuf)
+			if err != nil {
+				if err == io.EOF || (err == io.ErrUnexpectedEOF && n == 0) {
+					break
+				}
+				return fmt.Errorf("read encrypted length: %w", err)
+			}
+			if n < 4 {
+				break
+			}
+			cipherLen := int(binary.LittleEndian.Uint32(lenBuf))
+			if cipherLen <= 0 {
+				break
+			}
+			cipherBuf := make([]byte, cipherLen)
+			if _, err := io.ReadFull(ve.dataFile, cipherBuf); err != nil {
+				break
+			}
+			plain, err := ve.encryptMgr.Open(cipherBuf, "vector-record")
+			if err != nil || len(plain) < 8 {
+				break
+			}
+			id := int64(binary.LittleEndian.Uint64(plain[0:8]))
+			ve.fileOffsets[id] = offset
+			offset += int64(4 + cipherLen)
+			continue
+		}
+		recordSize := 8 + 4*ve.maxVectorSize
 		buf := make([]byte, recordSize)
 		n, err := ve.dataFile.Read(buf)
 		if err != nil {
@@ -581,13 +666,11 @@ func (ve *VectorEngineImpl) rebuildOffsetsFromDataFile() error {
 				break
 			}
 			if err == io.ErrUnexpectedEOF && n > 0 {
-				// Truncated tail — ignore the last partial record
 				break
 			}
 			return fmt.Errorf("read data file: %w", err)
 		}
 		if n < recordSize {
-			// Partial/truncated record — ignore
 			break
 		}
 		id := int64(binary.LittleEndian.Uint64(buf[0:8]))
@@ -595,6 +678,42 @@ func (ve *VectorEngineImpl) rebuildOffsetsFromDataFile() error {
 		offset += int64(recordSize)
 	}
 	return nil
+}
+
+func (ve *VectorEngineImpl) shouldUseEncryptedDataFile() bool {
+	if ve.encryptMgr == nil || !ve.encryptMgr.Enabled() {
+		return false
+	}
+	info, err := ve.dataFile.Stat()
+	if err != nil || info.Size() == 0 {
+		return true
+	}
+	plainRecordSize := int64(8 + 4*ve.maxVectorSize)
+	if info.Size()%plainRecordSize == 0 {
+		return false
+	}
+	return true
+}
+
+func (ve *VectorEngineImpl) readRecordAt(offset int64) ([]byte, error) {
+	if ve.dataFileEncrypted {
+		header := make([]byte, 4)
+		if _, err := ve.dataFile.ReadAt(header, offset); err != nil {
+			return nil, err
+		}
+		cipherLen := int(binary.LittleEndian.Uint32(header))
+		cipherBuf := make([]byte, cipherLen)
+		if _, err := ve.dataFile.ReadAt(cipherBuf, offset+4); err != nil {
+			return nil, err
+		}
+		return ve.encryptMgr.Open(cipherBuf, "vector-record")
+	}
+	recordSize := 8 + 4*ve.maxVectorSize
+	buf := make([]byte, recordSize)
+	if _, err := ve.dataFile.ReadAt(buf, offset); err != nil {
+		return nil, err
+	}
+	return buf, nil
 }
 
 // --- batched persistence ---
@@ -677,4 +796,24 @@ func bytesToFloat32Array(buf []byte) ([]float32, error) {
 		vec[i] = math.Float32frombits(binary.LittleEndian.Uint32(buf[i*4:]))
 	}
 	return vec, nil
+}
+
+func decryptIndexToTemp(indexPath string, mgr *atrest.Manager) (*os.File, string, error) {
+	raw, err := mgr.ReadFile(indexPath, "vector-faiss-index")
+	if err != nil {
+		return nil, "", err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(indexPath), ".faiss-dec-*.tmp")
+	if err != nil {
+		return nil, "", err
+	}
+	if _, err := tmp.Write(raw); err != nil {
+		tmp.Close()
+		return nil, "", err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return nil, "", err
+	}
+	return tmp, tmp.Name(), nil
 }

--- a/internal/wal/wal.go
+++ b/internal/wal/wal.go
@@ -2,9 +2,12 @@ package wal
 
 import (
 	"encoding/binary"
+	"fmt"
 	"io"
 	"os"
 	"sync"
+
+	"github.com/shibudb.org/shibudb-server/internal/atrest"
 )
 
 type WAL struct {
@@ -26,6 +29,16 @@ func (w *WAL) WriteEntry(key, value string) error {
 
 	keyBytes := []byte(key)
 	valBytes := []byte(value)
+	mgr := atrest.RuntimeManager()
+	if mgr != nil && mgr.Enabled() {
+		plain := serializeKV(keyBytes, valBytes)
+		sealed, err := mgr.Seal(plain, "wal-record")
+		if err != nil {
+			return err
+		}
+		keyBytes = nil
+		valBytes = sealed
+	}
 
 	keySize := uint32(len(keyBytes))
 	valSize := uint32(len(valBytes))
@@ -51,13 +64,26 @@ func (w *WAL) WriteDelete(key string) error {
 	defer w.lock.Unlock()
 
 	keyBytes := []byte(key)
+	valBytes := []byte{}
+	mgr := atrest.RuntimeManager()
+	if mgr != nil && mgr.Enabled() {
+		plain := serializeKV(keyBytes, valBytes)
+		sealed, err := mgr.Seal(plain, "wal-record")
+		if err != nil {
+			return err
+		}
+		keyBytes = nil
+		valBytes = sealed
+	}
 	keySize := uint32(len(keyBytes))
+	valSize := uint32(len(valBytes))
 
-	buf := make([]byte, 9+len(keyBytes))
+	buf := make([]byte, 9+len(keyBytes)+len(valBytes))
 	binary.LittleEndian.PutUint32(buf[0:4], keySize)
-	binary.LittleEndian.PutUint32(buf[4:8], 0) // value size 0
-	buf[8] = 'D'                               // 'D' means delete
-	copy(buf[9:], keyBytes)
+	binary.LittleEndian.PutUint32(buf[4:8], valSize)
+	buf[8] = 'D' // 'D' means delete
+	copy(buf[9:9+len(keyBytes)], keyBytes)
+	copy(buf[9+len(keyBytes):], valBytes)
 
 	_, err := w.file.Write(buf)
 	if err != nil {
@@ -130,6 +156,22 @@ func (w *WAL) Replay() ([][2]string, error) {
 			return nil, err
 		}
 
+		if keySize == 0 {
+			mgr := atrest.RuntimeManager()
+			if mgr == nil || !mgr.Enabled() {
+				return nil, fmt.Errorf("encrypted wal found but encryption manager is not enabled")
+			}
+			plain, err := mgr.Open(valBytes, "wal-record")
+			if err != nil {
+				return nil, err
+			}
+			decodedKey, decodedVal, err := deserializeKV(plain)
+			if err != nil {
+				return nil, err
+			}
+			entries = append(entries, [2]string{string(decodedKey), string(decodedVal)})
+			continue
+		}
 		entries = append(entries, [2]string{string(keyBytes), string(valBytes)})
 	}
 	return entries, nil
@@ -153,4 +195,29 @@ func (w *WAL) Close() error {
 	w.lock.Lock()
 	defer w.lock.Unlock()
 	return w.file.Close()
+}
+
+func serializeKV(key, value []byte) []byte {
+	buf := make([]byte, 8+len(key)+len(value))
+	binary.LittleEndian.PutUint32(buf[0:4], uint32(len(key)))
+	binary.LittleEndian.PutUint32(buf[4:8], uint32(len(value)))
+	copy(buf[8:8+len(key)], key)
+	copy(buf[8+len(key):], value)
+	return buf
+}
+
+func deserializeKV(data []byte) ([]byte, []byte, error) {
+	if len(data) < 8 {
+		return nil, nil, fmt.Errorf("invalid serialized wal kv")
+	}
+	keySize := int(binary.LittleEndian.Uint32(data[0:4]))
+	valSize := int(binary.LittleEndian.Uint32(data[4:8]))
+	if len(data) < 8+keySize+valSize {
+		return nil, nil, fmt.Errorf("invalid serialized wal kv lengths")
+	}
+	key := make([]byte, keySize)
+	value := make([]byte, valSize)
+	copy(key, data[8:8+keySize])
+	copy(value, data[8+keySize:8+keySize+valSize])
+	return key, value, nil
 }

--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ import (
 	"time"
 
 	"github.com/shibudb.org/shibudb-server/cmd/server"
+	"github.com/shibudb.org/shibudb-server/internal/atrest"
 	"github.com/shibudb.org/shibudb-server/internal/auth"
 	"github.com/shibudb.org/shibudb-server/internal/cliinput"
 	"github.com/shibudb.org/shibudb-server/internal/models"
@@ -50,10 +51,10 @@ type runtimePaths struct {
 	logDir  string
 	runDir  string
 
-	authFile string
+	authFile  string
 	tokenFile string
-	logFile  string
-	pidFile  string
+	logFile   string
+	pidFile   string
 }
 
 func defaultDataDir() string {
@@ -151,6 +152,9 @@ func main() {
 		dataDir := fs.String("data-dir", defaultDataDir(), "data directory root (stores files under lib/, log/, run/)")
 		adminUser := fs.String("admin-user", "", "admin username for initial bootstrap (non-interactive)")
 		adminPass := fs.String("admin-password", "", "admin password for initial bootstrap (non-interactive)")
+		encryptAtRest := fs.Bool("encrypt-at-rest", false, "enable encryption at rest")
+		encryptionPassphrase := fs.String("encryption-passphrase", "", "passphrase for encryption-at-rest")
+		masterKeyFile := fs.String("master-key-file", "", "path to 32-byte master key (hex/base64/plain)")
 		portFlag := fs.String("port", server.DefaultPort, "TCP port for client connections (1–65535)")
 		mgmtPortFlag := fs.String("management-port", server.DefaultManagementPort, "TCP port for the management HTTP API (1–65535; must differ from --port)")
 		maxConnFlag := fs.Int("max-connections", int(resolveDefaultMaxConnections()), "maximum number of concurrent connections (default comes from SHIBUDB_MAX_CONNECTIONS if set; persisted limit may override at runtime)")
@@ -178,7 +182,7 @@ func main() {
 			fmt.Println("Invalid --max-connections value. Must be a positive integer.")
 			return
 		}
-		startServer(port, mgmtPort, maxConnections, newRuntimePaths(*dataDir), *adminUser, *adminPass)
+		startServer(port, mgmtPort, maxConnections, newRuntimePaths(*dataDir), *adminUser, *adminPass, *encryptAtRest, *encryptionPassphrase, *masterKeyFile)
 
 	case "stop":
 		fs := flag.NewFlagSet("stop", flag.ExitOnError)
@@ -191,6 +195,9 @@ func main() {
 		dataDir := fs.String("data-dir", defaultDataDir(), "data directory root (stores files under lib/, log/, run/)")
 		adminUser := fs.String("admin-user", "", "admin username for initial bootstrap (non-interactive)")
 		adminPass := fs.String("admin-password", "", "admin password for initial bootstrap (non-interactive)")
+		encryptAtRest := fs.Bool("encrypt-at-rest", false, "enable encryption at rest")
+		encryptionPassphrase := fs.String("encryption-passphrase", "", "passphrase for encryption-at-rest")
+		masterKeyFile := fs.String("master-key-file", "", "path to 32-byte master key (hex/base64/plain)")
 		portFlag := fs.String("port", server.DefaultPort, "TCP port for client connections (1–65535)")
 		mgmtPortFlag := fs.String("management-port", server.DefaultManagementPort, "TCP port for the management HTTP API (1–65535; must differ from --port)")
 		maxConnFlag := fs.Int("max-connections", int(resolveDefaultMaxConnections()), "maximum number of concurrent connections (default comes from SHIBUDB_MAX_CONNECTIONS if set; persisted limit may override at runtime)")
@@ -219,6 +226,9 @@ func main() {
 			return
 		}
 		paths := newRuntimePaths(*dataDir)
+		if err := initEncryption(paths, *encryptAtRest, *encryptionPassphrase, *masterKeyFile); err != nil {
+			log.Fatalf("Failed to initialize encryption: %v", err)
+		}
 		// Pre-bootstrap admin non-interactively if credentials are provided.
 		// This ensures the auth file exists before StartServer's own NewAuthManager call.
 		if *adminUser != "" && *adminPass != "" {
@@ -287,12 +297,24 @@ func main() {
 		})
 		paths := newRuntimePaths(*dataDir)
 		authCfg := managerAuthConfig{
-			username: strings.TrimSpace(*username),
-			password: strings.TrimSpace(*password),
-			authFile: paths.authFile,
+			username:  strings.TrimSpace(*username),
+			password:  strings.TrimSpace(*password),
+			authFile:  paths.authFile,
 			tokenFile: paths.tokenFile,
 		}
 		handleManagerCommand(mgmtPort, args, authCfg)
+
+	case "migrate-encryption":
+		fs := flag.NewFlagSet("migrate-encryption", flag.ExitOnError)
+		dataDir := fs.String("data-dir", defaultDataDir(), "data directory root")
+		encryptionPassphrase := fs.String("encryption-passphrase", "", "passphrase for encryption-at-rest")
+		masterKeyFile := fs.String("master-key-file", "", "path to 32-byte master key (hex/base64/plain)")
+		fs.Parse(os.Args[2:]) //nolint
+		paths := newRuntimePaths(*dataDir)
+		if err := migrateEncryption(paths, *encryptionPassphrase, *masterKeyFile); err != nil {
+			log.Fatalf("Failed to migrate config files: %v", err)
+		}
+		fmt.Println("Config migration completed. Storage files migrate in-place on next write/checkpoint.")
 
 	case "--help":
 		printHelp()
@@ -926,10 +948,19 @@ func printStartupBanner() {
 }
 
 // buildRunSubcommandArgs builds argv for the child `run` process invoked by start.
-func buildRunSubcommandArgs(port, defaultPort, mgmtPort, defaultMgmtPort string, maxConnections, defaultLimit int32, paths runtimePaths, adminUser, adminPass string) []string {
+func buildRunSubcommandArgs(port, defaultPort, mgmtPort, defaultMgmtPort string, maxConnections, defaultLimit int32, paths runtimePaths, adminUser, adminPass string, encryptAtRest bool, encryptionPassphrase, masterKeyFile string) []string {
 	cmdArgs := []string{"run", "--data-dir", paths.rootDir}
 	if adminUser != "" {
 		cmdArgs = append(cmdArgs, "--admin-user", adminUser, "--admin-password", adminPass)
+	}
+	if encryptAtRest {
+		cmdArgs = append(cmdArgs, "--encrypt-at-rest")
+	}
+	if encryptionPassphrase != "" {
+		cmdArgs = append(cmdArgs, "--encryption-passphrase", encryptionPassphrase)
+	}
+	if masterKeyFile != "" {
+		cmdArgs = append(cmdArgs, "--master-key-file", masterKeyFile)
 	}
 	if port != defaultPort {
 		cmdArgs = append(cmdArgs, "--port", port)
@@ -943,12 +974,16 @@ func buildRunSubcommandArgs(port, defaultPort, mgmtPort, defaultMgmtPort string,
 	return cmdArgs
 }
 
-func startServer(port, mgmtPort string, maxConnections int32, paths runtimePaths, adminUser, adminPass string) {
+func startServer(port, mgmtPort string, maxConnections int32, paths runtimePaths, adminUser, adminPass string, encryptAtRest bool, encryptionPassphrase string, masterKeyFile string) {
 	// Check if server is already running
 	if running, pid := isServerRunning(paths.pidFile); running {
 		fmt.Printf("%sError:%s ShibuDB server is already running (PID: %d)\n", red, reset, pid)
 		fmt.Printf("Use 'shibudb stop' (or specify --data-dir) to stop the existing server first.\n")
 		os.Exit(1)
+	}
+
+	if err := initEncryption(paths, encryptAtRest, encryptionPassphrase, masterKeyFile); err != nil {
+		log.Fatalf("Failed to initialize encryption: %v", err)
 	}
 
 	_, err := auth.NewAuthManagerWithBootstrap(paths.authFile, adminUser, adminPass)
@@ -957,7 +992,7 @@ func startServer(port, mgmtPort string, maxConnections int32, paths runtimePaths
 	}
 	printStartupBanner()
 
-	cmdArgs := buildRunSubcommandArgs(port, server.DefaultPort, mgmtPort, server.DefaultManagementPort, maxConnections, resolveDefaultMaxConnections(), paths, adminUser, adminPass)
+	cmdArgs := buildRunSubcommandArgs(port, server.DefaultPort, mgmtPort, server.DefaultManagementPort, maxConnections, resolveDefaultMaxConnections(), paths, adminUser, adminPass, encryptAtRest, encryptionPassphrase, masterKeyFile)
 	cmd := exec.Command(os.Args[0], cmdArgs...)
 
 	logFile := openLogFile(paths.logFile)
@@ -1008,6 +1043,50 @@ func startServer(port, mgmtPort string, maxConnections int32, paths runtimePaths
 	}
 
 	fmt.Printf("%sShibuDB started on port %s (PID: %d, max connections: %d)%s\n", green, port, cmd.Process.Pid, displayLimit, reset)
+}
+
+func initEncryption(paths runtimePaths, enabled bool, passphrase string, masterKeyFile string) error {
+	cfg := atrest.Config{
+		Enabled:       enabled,
+		DataDir:       paths.libDir,
+		Passphrase:    passphrase,
+		MasterKeyFile: masterKeyFile,
+	}
+	manager, err := atrest.NewManager(cfg)
+	if err != nil {
+		return err
+	}
+	atrest.SetRuntimeManager(manager)
+	return nil
+}
+
+func migrateEncryption(paths runtimePaths, passphrase string, masterKeyFile string) error {
+	if err := initEncryption(paths, true, passphrase, masterKeyFile); err != nil {
+		return err
+	}
+	mgr := atrest.RuntimeManager()
+	if mgr == nil || !mgr.Enabled() {
+		return fmt.Errorf("encryption manager is not enabled")
+	}
+	return filepath.Walk(paths.libDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		if filepath.Ext(path) != ".json" {
+			return nil
+		}
+		if atrest.IsEncryptedFile(path) {
+			return nil
+		}
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return mgr.WriteFile(path, raw, 0600, "json-config")
+	})
 }
 
 func stopServer(paths runtimePaths) {


### PR DESCRIPTION
## Description

**Summary**
This PR adds optional encryption at rest for ShibuDb’s on-disk artifacts: config/metadata JSON, auth store, connection-limit persistence, key/value data and btree index material, WAL records, vector data records, and FAISS index files (encrypted as blobs; load may use a temporary decrypted file for ReadIndex).
Key material is resolved at process startup via passphrase (scrypt + per-data-dir salt manifest), SHIBUDB_MASTER_KEY / SHIBUDB_MASTER_PASSPHRASE, or --master-key-file, with --encrypt-at-rest enabling the feature. A migrate-encryption command re-wraps existing plaintext *.json under lib/ for operators upgrading in place.

**Issue**
Fixes: https://github.com/shibudb-org/shibudb-server/issues/2  — “Encode/encrypt data and config files so they are not human-readable on disk / reduce trivial tampering.”

**Motivation and context**
Today ShibuDb stores data, indexes, WAL, and configuration as ordinary files readable (and often editable) by anyone with OS access to the data directory, backups, or volumes. Application authentication does not protect against disk theft, backup leaks, or offline tampering of those files.

This change addresses that by using authenticated encryption (AES-GCM) with a versioned on-disk envelope, so ciphertext is not human-readable and undetected modification is much harder. It is complementary to—not a replacement for—TLS, OS permissions, and full-disk encryption.

Operational note: Key loss means data loss; operators should backup keys/secrets with the same care as the data directory.
Build note: Full go test ./... may still require a FAISS-capable environment for packages that depend on go-faiss; targeted unit tests cover the crypto and non-FAISS packages.

**Threat model**
Encryption protects data at rest on disk; it does not replace TLS or protect keys in process memory if the host is compromised.
Key management: Supports SHIBUDB_MASTER_KEY / SHIBUDB_MASTER_PASSPHRASE, --master-key-file, --encryption-passphrase, plus encryption.manifest.json (salt) when using passphrase KDF.
FAISS index: Encrypted on disk via envelope; load path may decrypt to a temporary file for ReadIndex (document for operators: secure temp directory, disk space).
Vector data file: Detects legacy fixed-size plaintext vs encrypted framed records to avoid mixing formats in one file on upgrade paths.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

[x]Test A — Unit tests (automated)
Ran focused tests for the packages touched by encryption-at-rest (crypto envelope, auth read path, btree index, WAL):

cd shibudb-server
go test ./internal/atrest ./internal/auth ./internal/index ./internal/wal
Result: all passed.

[x]Test B — Full repo tests
go test ./... was not used as the primary gate here because the vector stack depends on the FAISS C headers/libs (e.g. faiss/c_api/AutoTune_c.h). On environments without FAISS installed, packages that import go-faiss fail to compile; that is an environment/toolchain constraint, not a regression from these changes.


[x] Test C - Manual testing 

Without encryption
```
CREATE-SPACE my_data --engine key-value
Success: SPACE_CREATED
[]> USE my_data
Success: SPACE_CHANGED
[my_data]>
[my_data]> PUT user:1 "John Doe"
Success: OK
[my_data]>
[my_data]> GET user:1
Value: "John
[my_data]> exit
Goodbye!
```

```
 cd ~/.shibudb/lib/my_data/
➜  my_data ls
data.db   index.dat wal.db
➜  my_data
➜  my_data
➜  my_data cat data.db
user:1"John%
➜  my_data
➜  my_data
➜  my_data cat index.dat
user:1%
➜  my_data
➜  my_data
➜  my_data cat wal.db
Cuser:1"John%
```

With encryption:
 ```
./scripts/start-local-server.sh \
  --data-dir "$HOME/.shibudb-enc-demo" \
  --encrypt-at-rest \
  --encryption-passphrase 'your-long-passphrase'
Starting ShibuDB (go run) on client port 4444 (management default 5444).
Bootstrap admin: admin / admin (override by editing this script or passing flags after --).
Connect in another terminal: make connect-local-client
```

```
# github.com/shibudb.org/shibudb-server
ld: warning: duplicate -rpath '/Users/shivangi/oss/myclone/shibudb-server/resources/lib/mac/apple_silicon' ignored
ld: warning: ignoring duplicate libraries: '-lc++', '-lfaiss', '-lfaiss_c'
Connection limit saved to: /Users/shivangi/.shibudb-enc-demo/lib/connection_limit.json
Starting management server on port 5444...
Management server started on port 5444
ShibuDB server started on port 4444 (max connections: 1000)
Management server started on port 5444
Runtime limit updates: SIGUSR1 (increase by 100), SIGUSR2 (decrease by 100)
HTTP management: GET/PUT http://localhost:5444/limit (Authorization: Bearer <token> required)
New connection from [::1]:60383 (active: 1/1000)
Connection status: 1/1000 (0.1%)
2026/03/31 18:07:40 Query: CREATE_SPACE
2026/03/31 18:07:50 Query: USE_SPACE
2026/03/31 18:07:55 Query: PUT
2026/03/31 18:07:58 Query: GET
2026/03/31 18:07:58 Checking index position
2026/03/31 18:07:58 Found pos for index: 0
Found pos for index: 02026/03/31 18:07:58 Key size found 0
2026/03/31 18:07:58 Val size found 56
2026/03/31 18:07:58 Key found
2026/03/31 18:07:58 Value found SDBENC1
                                       �4z�bk���y�{�Q6{/�Tt#���b�M�k�2k�?��T�
Connection status: 1/1000 (0.1%)
Connection status: 1/1000 (0.1%)
Connection status: 1/1000 (0.1%)
Connection status: 1/1000 (0.1%)
Connection status: 1/1000 (0.1%)

```

```
login successful.
[]> CREATE-SPACE my_data --engine key-value
Success: SPACE_CREATED
[]>  USE my_data
Success: SPACE_CHANGED
[my_data]>  PUT user:1 "John Doe"
Success: OK
[my_data]> GET user:1
Value: "John
[my_data]>
```

 ```
my_data cd ~/.shibudb-enc-demo
➜  .shibudb-enc-demo ls
lib
➜  .shibudb-enc-demo cd lib
➜  lib ls
connection_limit.json  metadata.json          users.json
management_tokens.json my_data
➜  lib cd my_data
➜  my_data ls
data.db   index.dat wal.db
➜  my_data cat data.db
8SDBENC1
        �4z�bk���y�{�Q6{/�Tt#���b�M�k�2k�?��T�%
➜  my_data cat index.dat
+SDBENC1
        :�I?L��DK����Z��O�ϐ�bu�����%
➜  my_data cat wal.db
8CSDBENC1
         �zj���s��?�J
                      ޅ$��㊘d�+�5\7�w?G��Ң
                                          �%                                   ➜  my_data
```
## Checklist:

- [x] My code follows the style guidelines of this project
- [] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional Notes

Add any other context about the pull request here. 