### PR TITLE
feat(storage): added segmentation for vector and key-value engines

### DIFF
--- a/E2ETests/helper.go
+++ b/E2ETests/helper.go
@@ -23,6 +23,10 @@ func SendQuery(q models.Query, conn net.Conn, reader *bufio.Reader) error {
 
 func CreateSpaceWithIndex(tableSpace, engineType string, dimension int, indexType string, metric string, conn net.Conn, reader *bufio.Reader) bool {
 	query := models.Query{Type: "CREATE_SPACE", Space: tableSpace, EngineType: engineType, Dimension: dimension, IndexType: indexType, Metric: metric, EnableWAL: true}
+	return CreateSpaceWithSettings(query, conn, reader)
+}
+
+func CreateSpaceWithSettings(query models.Query, conn net.Conn, reader *bufio.Reader) bool {
 	data, _ := json.Marshal(query)
 	_, err := conn.Write(append(data, '\n'))
 	if err != nil {
@@ -31,6 +35,26 @@ func CreateSpaceWithIndex(tableSpace, engineType string, dimension int, indexTyp
 	resp, err := reader.ReadString('\n')
 	if err != nil || !strings.Contains(resp, "\"status\":\"OK\"") && !strings.Contains(resp, "SPACE_CREATED") {
 		fmt.Println("Table space creation failed. Server response:", strings.TrimSpace(resp))
+		return false
+	}
+	return true
+}
+
+func UpdateSpaceSettings(space string, rolloverBytes int64, maxSegmentsBeforeMerge int, conn net.Conn, reader *bufio.Reader) bool {
+	query := models.Query{
+		Type:                   models.TypeUpdateSpaceSettings,
+		Space:                  space,
+		SegmentRolloverBytes:   rolloverBytes,
+		MaxSegmentsBeforeMerge: maxSegmentsBeforeMerge,
+	}
+	data, _ := json.Marshal(query)
+	_, err := conn.Write(append(data, '\n'))
+	if err != nil {
+		return false
+	}
+	resp, err := reader.ReadString('\n')
+	if err != nil || !strings.Contains(resp, "\"status\":\"OK\"") && !strings.Contains(resp, "SPACE_SETTINGS_UPDATED") {
+		fmt.Println("Space settings update failed. Server response:", strings.TrimSpace(resp))
 		return false
 	}
 	return true

--- a/E2ETests/segmented_storage_e2e_test.go
+++ b/E2ETests/segmented_storage_e2e_test.go
@@ -1,0 +1,204 @@
+package E2ETests
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/shibudb.org/shibudb-server/internal/models"
+)
+
+func TestSegmentedKeyValueE2E(t *testing.T) {
+	conn, err := net.Dial("tcp", "localhost:4444")
+	if err != nil {
+		t.Fatalf("TCP connection error: %v", err)
+	}
+	defer conn.Close()
+	reader := bufio.NewReader(conn)
+
+	if !Login("admin", "admin", conn, reader) {
+		fmt.Println("Setup failed: Login failed")
+		os.Exit(1)
+	}
+
+	space := "kv_segmented_e2e"
+	CleanSpace(space, conn, reader)
+
+	if !CreateSpaceWithSettings(models.Query{
+		Type:                   models.TypeCreateSpace,
+		Space:                  space,
+		EngineType:             "key-value",
+		EnableWAL:              true,
+		SegmentRolloverBytes:   96,
+		MaxSegmentsBeforeMerge: 5,
+	}, conn, reader) {
+		t.Fatalf("failed to create segmented key-value space")
+	}
+
+	for _, item := range []struct {
+		key   string
+		value string
+	}{
+		{"alpha", strings.Repeat("a", 128)},
+		{"beta", strings.Repeat("b", 128)},
+		{"gamma", strings.Repeat("c", 128)},
+		{"delta", strings.Repeat("d", 128)},
+	} {
+		resp := sendQueryAndGetResponse(models.Query{
+			Type:  models.TypePut,
+			Space: space,
+			Key:   item.key,
+			Value: item.value,
+		}, conn, reader)
+		if !strings.Contains(resp, "OK") {
+			t.Fatalf("PUT %s failed: %s", item.key, resp)
+		}
+	}
+
+	time.Sleep(3 * time.Second)
+
+	for _, item := range []struct {
+		key   string
+		value string
+	}{
+		{"alpha", strings.Repeat("a", 128)},
+		{"beta", strings.Repeat("b", 128)},
+		{"gamma", strings.Repeat("c", 128)},
+		{"delta", strings.Repeat("d", 128)},
+	} {
+		resp := sendQueryAndGetResponse(models.Query{
+			Type:  models.TypeGet,
+			Space: space,
+			Key:   item.key,
+		}, conn, reader)
+		if !strings.Contains(resp, item.value) {
+			t.Fatalf("GET %s did not return expected value: %s", item.key, resp)
+		}
+	}
+
+	if !UpdateSpaceSettings(space, 80, 5, conn, reader) {
+		t.Fatalf("failed to update segmented key-value settings")
+	}
+
+	resp := sendQueryAndGetResponse(models.Query{
+		Type:  models.TypePut,
+		Space: space,
+		Key:   "epsilon",
+		Value: strings.Repeat("e", 128),
+	}, conn, reader)
+	if !strings.Contains(resp, "OK") {
+		t.Fatalf("PUT epsilon failed: %s", resp)
+	}
+
+	time.Sleep(3 * time.Second)
+
+	resp = sendQueryAndGetResponse(models.Query{
+		Type:  models.TypeGet,
+		Space: space,
+		Key:   "epsilon",
+	}, conn, reader)
+	if !strings.Contains(resp, strings.Repeat("e", 128)) {
+		t.Fatalf("GET epsilon did not return expected value after settings update: %s", resp)
+	}
+}
+
+func TestSegmentedVectorE2E(t *testing.T) {
+	conn, err := net.Dial("tcp", "localhost:4444")
+	if err != nil {
+		t.Fatalf("TCP connection error: %v", err)
+	}
+	defer conn.Close()
+	reader := bufio.NewReader(conn)
+
+	if !Login("admin", "admin", conn, reader) {
+		fmt.Println("Setup failed: Login failed")
+		os.Exit(1)
+	}
+
+	space := "vec_segmented_e2e"
+	CleanSpace(space, conn, reader)
+
+	if !CreateSpaceWithSettings(models.Query{
+		Type:                   models.TypeCreateSpace,
+		Space:                  space,
+		EngineType:             "vector",
+		Dimension:              4,
+		IndexType:              "Flat",
+		Metric:                 "L2",
+		EnableWAL:              true,
+		SegmentRolloverBytes:   48,
+		MaxSegmentsBeforeMerge: 5,
+	}, conn, reader) {
+		t.Fatalf("failed to create segmented vector space")
+	}
+
+	vectors := []struct {
+		id  string
+		vec string
+	}{
+		{"1001", "1,0,0,0"},
+		{"1002", "0,1,0,0"},
+		{"1003", "0,0,1,0"},
+		{"1004", "0,0,0,1"},
+	}
+	for _, item := range vectors {
+		resp := sendQueryAndGetResponse(models.Query{
+			Type:  models.TypeInsertVector,
+			Space: space,
+			Key:   item.id,
+			Value: item.vec,
+		}, conn, reader)
+		if !strings.Contains(resp, "VECTOR_INSERTED") && !strings.Contains(resp, `"status":"OK"`) {
+			t.Fatalf("INSERT_VECTOR %s failed: %s", item.id, resp)
+		}
+	}
+
+	time.Sleep(3 * time.Second)
+
+	for _, item := range vectors {
+		resp := sendQueryAndGetResponse(models.Query{
+			Type:      models.TypeSearchTopK,
+			Space:     space,
+			Value:     item.vec,
+			Dimension: 1,
+		}, conn, reader)
+		if !strings.Contains(resp, item.id) {
+			t.Fatalf("SEARCH_TOPK for %s did not return expected id: %s", item.id, resp)
+		}
+	}
+
+	if !UpdateSpaceSettings(space, 40, 5, conn, reader) {
+		t.Fatalf("failed to update segmented vector settings")
+	}
+
+	resp := sendQueryAndGetResponse(models.Query{
+		Type:  models.TypeInsertVector,
+		Space: space,
+		Key:   "1005",
+		Value: "1,1,0,0",
+	}, conn, reader)
+	if !strings.Contains(resp, "VECTOR_INSERTED") && !strings.Contains(resp, `"status":"OK"`) {
+		t.Fatalf("INSERT_VECTOR 1005 failed: %s", resp)
+	}
+
+	time.Sleep(3 * time.Second)
+
+	for _, item := range append(vectors, struct {
+		id  string
+		vec string
+	}{"1005", "1,1,0,0"}) {
+		resp := sendQueryAndGetResponse(models.Query{
+			Type:      models.TypeSearchTopK,
+			Space:     space,
+			Value:     item.vec,
+			Dimension: 1,
+		}, conn, reader)
+		if !strings.Contains(resp, item.id) {
+			t.Fatalf("SEARCH_TOPK after settings update for %s did not return expected id: %s", item.id, resp)
+		}
+	}
+}

--- a/cmd/server/management.go
+++ b/cmd/server/management.go
@@ -9,23 +9,27 @@ import (
 	"sync"
 
 	"github.com/shibudb.org/shibudb-server/internal/auth"
+	"github.com/shibudb.org/shibudb-server/internal/spaces"
+	"github.com/shibudb.org/shibudb-server/internal/storage"
 )
 
 // ManagementServer provides HTTP endpoints for runtime server management
 type ManagementServer struct {
-	connManager *ConnectionManager
-	tokenMgr    *auth.TokenManager
-	port        string
-	server      *http.Server
-	mu          sync.RWMutex
+	connManager  *ConnectionManager
+	spaceManager *spaces.SpaceManager
+	tokenMgr     *auth.TokenManager
+	port         string
+	server       *http.Server
+	mu           sync.RWMutex
 }
 
 // NewManagementServer creates a new management server
-func NewManagementServer(connManager *ConnectionManager, tokenMgr *auth.TokenManager, port string) *ManagementServer {
+func NewManagementServer(connManager *ConnectionManager, spaceManager *spaces.SpaceManager, tokenMgr *auth.TokenManager, port string) *ManagementServer {
 	ms := &ManagementServer{
-		connManager: connManager,
-		tokenMgr:    tokenMgr,
-		port:        port,
+		connManager:  connManager,
+		spaceManager: spaceManager,
+		tokenMgr:     tokenMgr,
+		port:         port,
 	}
 
 	mux := http.NewServeMux()
@@ -42,6 +46,7 @@ func NewManagementServer(connManager *ConnectionManager, tokenMgr *auth.TokenMan
 	mux.HandleFunc("/limit", ms.limitHandler)
 	mux.HandleFunc("/limit/increase", ms.increaseLimitHandler)
 	mux.HandleFunc("/limit/decrease", ms.decreaseLimitHandler)
+	mux.HandleFunc("/spaces/settings", ms.spaceSettingsHandler)
 	mux.Handle("/debug/pprof/", authorized(pprof.Index))
 	mux.Handle("/debug/pprof/cmdline", authorized(pprof.Cmdline))
 	mux.Handle("/debug/pprof/profile", authorized(pprof.Profile))
@@ -255,6 +260,61 @@ func (ms *ManagementServer) decreaseLimitHandler(w http.ResponseWriter, r *http.
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(response)
+}
+
+func (ms *ManagementServer) spaceSettingsHandler(w http.ResponseWriter, r *http.Request) {
+	if !ms.authorizeRequest(w, r) {
+		return
+	}
+	if r.Method != http.MethodPut {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+
+	var request struct {
+		Space                  string `json:"space"`
+		SegmentRolloverBytes   int64  `json:"segment_rollover_bytes"`
+		MaxSegmentsBeforeMerge int    `json:"max_segments_before_merge"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		http.Error(w, "Invalid JSON", http.StatusBadRequest)
+		return
+	}
+	if strings.TrimSpace(request.Space) == "" {
+		http.Error(w, "space is required", http.StatusBadRequest)
+		return
+	}
+	if request.SegmentRolloverBytes <= 0 && request.MaxSegmentsBeforeMerge <= 0 {
+		http.Error(w, "at least one space setting must be provided", http.StatusBadRequest)
+		return
+	}
+	if ms.spaceManager == nil {
+		http.Error(w, "space manager unavailable", http.StatusInternalServerError)
+		return
+	}
+
+	err := ms.spaceManager.UpdateSpaceSettings(request.Space, storage.SpaceSettings{
+		SegmentRolloverBytes:   request.SegmentRolloverBytes,
+		MaxSegmentsBeforeMerge: request.MaxSegmentsBeforeMerge,
+	})
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"status": "failed",
+			"error":  err.Error(),
+		})
+		return
+	}
+
+	meta, _ := ms.spaceManager.SpaceMeta(request.Space)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"status":                    "success",
+		"space":                     request.Space,
+		"segment_rollover_bytes":    meta.SegmentRolloverBytes,
+		"max_segments_before_merge": meta.MaxSegmentsBeforeMerge,
+		"message":                   fmt.Sprintf("Updated space settings for %s", request.Space),
+	})
 }
 
 func (ms *ManagementServer) authorizeRequest(w http.ResponseWriter, r *http.Request) bool {

--- a/cmd/server/management_auth_test.go
+++ b/cmd/server/management_auth_test.go
@@ -6,9 +6,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/shibudb.org/shibudb-server/internal/auth"
+	"github.com/shibudb.org/shibudb-server/internal/spaces"
 )
 
 func TestManagementServerRequiresBearerToken(t *testing.T) {
@@ -21,7 +23,9 @@ func TestManagementServerRequiresBearerToken(t *testing.T) {
 		t.Fatalf("NewTokenManager() error = %v", err)
 	}
 
-	ms := NewManagementServer(connMgr, tokenMgr, "0")
+	sm := spaces.NewSpaceManager(dataDir)
+	defer sm.CloseAll()
+	ms := NewManagementServer(connMgr, sm, tokenMgr, "0")
 
 	tests := []struct {
 		name         string
@@ -91,7 +95,9 @@ func TestManagementServerAcceptsValidBearerToken(t *testing.T) {
 		t.Fatalf("GenerateToken() error = %v", err)
 	}
 
-	ms := NewManagementServer(connMgr, tokenMgr, "0")
+	sm := spaces.NewSpaceManager(dataDir)
+	defer sm.CloseAll()
+	ms := NewManagementServer(connMgr, sm, tokenMgr, "0")
 
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	req.Header.Set("Authorization", "Bearer "+rawToken)
@@ -127,7 +133,9 @@ func TestManagementStatsExposeBusyAndIdleConnections(t *testing.T) {
 		t.Fatalf("GenerateToken() error = %v", err)
 	}
 
-	ms := NewManagementServer(connMgr, tokenMgr, "0")
+	sm := spaces.NewSpaceManager(dataDir)
+	defer sm.CloseAll()
+	ms := NewManagementServer(connMgr, sm, tokenMgr, "0")
 
 	req := httptest.NewRequest(http.MethodGet, "/stats", nil)
 	req.Header.Set("Authorization", "Bearer "+rawToken)
@@ -155,5 +163,47 @@ func TestManagementStatsExposeBusyAndIdleConnections(t *testing.T) {
 	}
 	if got := int(payload["available_slots"]); got != 99 {
 		t.Fatalf("available_slots = %d, want 99", got)
+	}
+}
+
+func TestManagementServerUpdatesSpaceSettings(t *testing.T) {
+	dataDir := t.TempDir()
+	connMgr := NewConnectionManager(100, dataDir)
+	defer connMgr.Shutdown()
+
+	tokenMgr, err := auth.NewTokenManager(filepath.Join(dataDir, "management_tokens.json"))
+	if err != nil {
+		t.Fatalf("NewTokenManager() error = %v", err)
+	}
+	_, rawToken, err := tokenMgr.GenerateToken("admin")
+	if err != nil {
+		t.Fatalf("GenerateToken() error = %v", err)
+	}
+
+	sm := spaces.NewSpaceManager(dataDir)
+	defer sm.CloseAll()
+	if _, err := sm.CreateSpace("managed_space", "key-value", 0, "", ""); err != nil {
+		t.Fatalf("CreateSpace() error = %v", err)
+	}
+
+	ms := NewManagementServer(connMgr, sm, tokenMgr, "0")
+
+	req := httptest.NewRequest(http.MethodPut, "/spaces/settings", strings.NewReader(`{"space":"managed_space","segment_rollover_bytes":12345}`))
+	req.Header.Set("Authorization", "Bearer "+rawToken)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	ms.server.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	meta, ok := sm.SpaceMeta("managed_space")
+	if !ok {
+		t.Fatal("SpaceMeta() missing managed_space")
+	}
+	if meta.SegmentRolloverBytes != 12345 {
+		t.Fatalf("SegmentRolloverBytes = %d, want 12345", meta.SegmentRolloverBytes)
 	}
 }

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -297,7 +297,7 @@ func StartServer(port string, authFilePath string, maxConnections int32, dataFol
 	// Start signal handler for runtime limit updates
 	go handleSignals(connManager)
 
-	managementServer := NewManagementServer(connManager, tokenManager, managementPort)
+	managementServer := NewManagementServer(connManager, spaceManager, tokenManager, managementPort)
 	go func() {
 		fmt.Printf("Starting management server on port %s...\n", managementPort)
 		if err := managementServer.Start(); err != nil {

--- a/internal/index/BTreeIndex.go
+++ b/internal/index/BTreeIndex.go
@@ -100,6 +100,19 @@ func (idx *BTreeIndex) Get(key string) (int64, bool) {
 	return item.(Item).Value, true
 }
 
+func (idx *BTreeIndex) SnapshotEntries() map[string]int64 {
+	idx.lock.RLock()
+	defer idx.lock.RUnlock()
+
+	entries := make(map[string]int64)
+	idx.btree.Ascend(func(i btree.Item) bool {
+		item := i.(Item)
+		entries[item.Key] = item.Value
+		return true
+	})
+	return entries
+}
+
 func (idx *BTreeIndex) Remove(key string) error {
 	idx.lock.Lock()
 	defer idx.lock.Unlock()

--- a/internal/models/query.go
+++ b/internal/models/query.go
@@ -5,6 +5,7 @@ const (
 	TypeGet                   = "GET"
 	TypeDelete                = "DELETE"
 	TypeCreateSpace           = "CREATE_SPACE"
+	TypeUpdateSpaceSettings   = "UPDATE_SPACE_SETTINGS"
 	TypeListSpaces            = "LIST_SPACES"
 	TypeDeleteSpace           = "DELETE_SPACE"
 	TypeUseSpace              = "USE_SPACE"
@@ -22,18 +23,20 @@ const (
 )
 
 type Query struct {
-	Type       string  `json:"type"`
-	Key        string  `json:"key,omitempty"`
-	Value      string  `json:"value,omitempty"`
-	Space      string  `json:"space,omitempty"`
-	User       string  `json:"user,omitempty"`
-	Data       string  `json:"data,omitempty"`
-	NewUser    *User   `json:"new_user,omitempty"`
-	DeleteUser *User   `json:"delete_user,omitempty"`
-	EngineType string  `json:"engine_type,omitempty"`
-	Dimension  int     `json:"dimension,omitempty"`
-	IndexType  string  `json:"index_type,omitempty"`
-	Metric     string  `json:"metric,omitempty"`
-	Radius     float32 `json:"radius,omitempty"`
-	EnableWAL  bool    `json:"enable_wal,omitempty"`
+	Type                   string  `json:"type"`
+	Key                    string  `json:"key,omitempty"`
+	Value                  string  `json:"value,omitempty"`
+	Space                  string  `json:"space,omitempty"`
+	User                   string  `json:"user,omitempty"`
+	Data                   string  `json:"data,omitempty"`
+	NewUser                *User   `json:"new_user,omitempty"`
+	DeleteUser             *User   `json:"delete_user,omitempty"`
+	EngineType             string  `json:"engine_type,omitempty"`
+	Dimension              int     `json:"dimension,omitempty"`
+	IndexType              string  `json:"index_type,omitempty"`
+	Metric                 string  `json:"metric,omitempty"`
+	Radius                 float32 `json:"radius,omitempty"`
+	EnableWAL              bool    `json:"enable_wal,omitempty"`
+	SegmentRolloverBytes   int64   `json:"segment_rollover_bytes,omitempty"`
+	MaxSegmentsBeforeMerge int     `json:"max_segments_before_merge,omitempty"`
 }

--- a/internal/queryengine/query_engine.go
+++ b/internal/queryengine/query_engine.go
@@ -189,11 +189,32 @@ func (qe *QueryEngine) Execute(query models.Query) (string, error) {
 			}
 		}
 
-		_, err = qe.spaceManager.CreateSpaceWithWAL(query.Space, query.EngineType, query.Dimension, indexType, metric, query.EnableWAL)
+		settings := storage.SpaceSettings{
+			SegmentRolloverBytes:   query.SegmentRolloverBytes,
+			MaxSegmentsBeforeMerge: query.MaxSegmentsBeforeMerge,
+		}
+		_, err = qe.spaceManager.CreateSpaceWithSettings(query.Space, query.EngineType, query.Dimension, indexType, metric, query.EnableWAL, settings)
 		if err != nil {
 			return "", err
 		}
 		return "SPACE_CREATED", nil
+
+	case models.TypeUpdateSpaceSettings:
+		if query.Space == "" {
+			return "", errors.New("space name required")
+		}
+		admin, err := qe.authManager.GetUser(query.User)
+		if err != nil || admin.Role != auth.RoleAdmin {
+			return "", errors.New("only admin can update spaces")
+		}
+		settings := storage.SpaceSettings{
+			SegmentRolloverBytes:   query.SegmentRolloverBytes,
+			MaxSegmentsBeforeMerge: query.MaxSegmentsBeforeMerge,
+		}
+		if err := qe.spaceManager.UpdateSpaceSettings(query.Space, settings); err != nil {
+			return "", err
+		}
+		return "SPACE_SETTINGS_UPDATED", nil
 
 	case models.TypeDeleteSpace:
 		if query.Data == "" {

--- a/internal/queryengine/query_engine_test.go
+++ b/internal/queryengine/query_engine_test.go
@@ -186,3 +186,45 @@ func TestQueryEngine_CreateSpaceSurvivesRestart(t *testing.T) {
 		t.Fatalf("ListSpaces response %q does not include restart_space", res)
 	}
 }
+
+func TestQueryEngine_UpdateSpaceSettings(t *testing.T) {
+	dir := t.TempDir()
+	sm := spaces.NewSpaceManager(dir)
+	defer sm.CloseAll()
+
+	qe := NewQueryEngine(sm, &mockAuth{})
+
+	if _, err := qe.Execute(models.Query{
+		Type:       models.TypeCreateSpace,
+		Space:      "settings_space",
+		EngineType: "key-value",
+		User:       "admin",
+	}); err != nil {
+		t.Fatalf("CreateSpace failed: %v", err)
+	}
+
+	res, err := qe.Execute(models.Query{
+		Type:                   models.TypeUpdateSpaceSettings,
+		Space:                  "settings_space",
+		User:                   "admin",
+		SegmentRolloverBytes:   2048,
+		MaxSegmentsBeforeMerge: 9,
+	})
+	if err != nil {
+		t.Fatalf("UpdateSpaceSettings failed: %v", err)
+	}
+	if res != "SPACE_SETTINGS_UPDATED" {
+		t.Fatalf("result = %q, want SPACE_SETTINGS_UPDATED", res)
+	}
+
+	meta, ok := sm.SpaceMeta("settings_space")
+	if !ok {
+		t.Fatal("SpaceMeta missing after update")
+	}
+	if meta.SegmentRolloverBytes != 2048 {
+		t.Fatalf("SegmentRolloverBytes = %d, want 2048", meta.SegmentRolloverBytes)
+	}
+	if meta.MaxSegmentsBeforeMerge != 9 {
+		t.Fatalf("MaxSegmentsBeforeMerge = %d, want 9", meta.MaxSegmentsBeforeMerge)
+	}
+}

--- a/internal/spaces/space_manager.go
+++ b/internal/spaces/space_manager.go
@@ -103,13 +103,15 @@ func isAllowedMetric(metric string) bool {
 }
 
 type spaceMeta struct {
-	LayoutVersion int    `json:"layout_version,omitempty"`
-	Name          string `json:"name"`
-	EngineType    string `json:"engine_type"`
-	Dimension     int    `json:"dimension,omitempty"`
-	IndexType     string `json:"index_type,omitempty"`
-	Metric        string `json:"metric,omitempty"`
-	EnableWAL     bool   `json:"enable_wal,omitempty"`
+	LayoutVersion          int    `json:"layout_version,omitempty"`
+	Name                   string `json:"name"`
+	EngineType             string `json:"engine_type"`
+	Dimension              int    `json:"dimension,omitempty"`
+	IndexType              string `json:"index_type,omitempty"`
+	Metric                 string `json:"metric,omitempty"`
+	EnableWAL              bool   `json:"enable_wal,omitempty"`
+	SegmentRolloverBytes   int64  `json:"segment_rollover_bytes,omitempty"`
+	MaxSegmentsBeforeMerge int    `json:"max_segments_before_merge,omitempty"`
 }
 
 type manifestRecord struct {
@@ -400,6 +402,21 @@ func normalizeSpaceMeta(meta spaceMeta) spaceMeta {
 		meta.IndexType = ""
 		meta.Metric = ""
 	}
+	if meta.EngineType == "vector" {
+		settings := storage.NormalizeVectorSpaceSettings(meta.IndexType, storage.SpaceSettings{
+			SegmentRolloverBytes:   meta.SegmentRolloverBytes,
+			MaxSegmentsBeforeMerge: meta.MaxSegmentsBeforeMerge,
+		})
+		meta.SegmentRolloverBytes = settings.SegmentRolloverBytes
+		meta.MaxSegmentsBeforeMerge = settings.MaxSegmentsBeforeMerge
+	} else {
+		settings := storage.NormalizeSpaceSettings(storage.SpaceSettings{
+			SegmentRolloverBytes:   meta.SegmentRolloverBytes,
+			MaxSegmentsBeforeMerge: meta.MaxSegmentsBeforeMerge,
+		})
+		meta.SegmentRolloverBytes = settings.SegmentRolloverBytes
+		meta.MaxSegmentsBeforeMerge = settings.MaxSegmentsBeforeMerge
+	}
 	return meta
 }
 
@@ -418,17 +435,21 @@ func (sm *SpaceManager) removeSpaceMeta(space string) error {
 func (sm *SpaceManager) openSpaceEngine(meta spaceMeta) (interface{}, error) {
 	meta = normalizeSpaceMeta(meta)
 	spacePath := filepath.Join(sm.baseDir, meta.Name)
+	settings := storage.SpaceSettings{
+		SegmentRolloverBytes:   meta.SegmentRolloverBytes,
+		MaxSegmentsBeforeMerge: meta.MaxSegmentsBeforeMerge,
+	}
 	if meta.EngineType == "key-value" {
 		dataFile := filepath.Join(spacePath, "data.db")
 		walFile := filepath.Join(spacePath, "wal.db")
 		indexFile := filepath.Join(spacePath, "index.dat")
-		return storage.OpenDBWithPathsAndWAL(dataFile, walFile, indexFile, meta.EnableWAL)
+		return storage.OpenDBWithPathsAndWALAndSettings(dataFile, walFile, indexFile, meta.EnableWAL, settings)
 	}
 	if meta.EngineType == "vector" {
 		dataFile := filepath.Join(spacePath, "vector_data.db")
 		indexFile := filepath.Join(spacePath, "vector_index.faiss")
 		walFile := filepath.Join(spacePath, "vector_wal.db")
-		return storage.NewVectorEngine(dataFile, indexFile, walFile, meta.Dimension, meta.IndexType, getFAISSMetric(meta.Metric), meta.EnableWAL)
+		return storage.NewVectorEngineWithSettings(dataFile, indexFile, walFile, meta.Dimension, meta.IndexType, getFAISSMetric(meta.Metric), meta.EnableWAL, settings)
 	}
 	return nil, fmt.Errorf("unknown engine type: %s", meta.EngineType)
 }
@@ -453,10 +474,14 @@ func (sm *SpaceManager) UseSpace(space string) (interface{}, error) {
 
 func (sm *SpaceManager) CreateSpace(space, engineType string, dimension int, indexType string, metric string) (interface{}, error) {
 	enableWAL := false
-	return sm.CreateSpaceWithWAL(space, engineType, dimension, indexType, metric, enableWAL)
+	return sm.CreateSpaceWithSettings(space, engineType, dimension, indexType, metric, enableWAL, storage.SpaceSettings{})
 }
 
 func (sm *SpaceManager) CreateSpaceWithWAL(space, engineType string, dimension int, indexType string, metric string, enableWAL bool) (interface{}, error) {
+	return sm.CreateSpaceWithSettings(space, engineType, dimension, indexType, metric, enableWAL, storage.SpaceSettings{})
+}
+
+func (sm *SpaceManager) CreateSpaceWithSettings(space, engineType string, dimension int, indexType string, metric string, enableWAL bool, settings storage.SpaceSettings) (interface{}, error) {
 	sm.lock.Lock()
 	defer sm.lock.Unlock()
 
@@ -468,13 +493,15 @@ func (sm *SpaceManager) CreateSpaceWithWAL(space, engineType string, dimension i
 	}
 
 	meta := normalizeSpaceMeta(spaceMeta{
-		Name:          space,
-		EngineType:    engineType,
-		Dimension:     dimension,
-		IndexType:     indexType,
-		Metric:        metric,
-		EnableWAL:     enableWAL,
-		LayoutVersion: currentSpaceLayoutVersion,
+		Name:                   space,
+		EngineType:             engineType,
+		Dimension:              dimension,
+		IndexType:              indexType,
+		Metric:                 metric,
+		EnableWAL:              enableWAL,
+		SegmentRolloverBytes:   settings.SegmentRolloverBytes,
+		MaxSegmentsBeforeMerge: settings.MaxSegmentsBeforeMerge,
+		LayoutVersion:          currentSpaceLayoutVersion,
 	})
 
 	if engineType == "vector" {
@@ -525,6 +552,56 @@ func (sm *SpaceManager) CreateSpaceWithWAL(space, engineType string, dimension i
 	sm.spaces[space] = engine
 	sm.spaceMetas[space] = meta
 	return engine, nil
+}
+
+func (sm *SpaceManager) UpdateSpaceSettings(space string, settings storage.SpaceSettings) error {
+	sm.lock.Lock()
+	defer sm.lock.Unlock()
+
+	meta, exists := sm.spaceMetas[space]
+	if !exists {
+		return errors.New("space does not exist")
+	}
+
+	var applied storage.SpaceSettings
+	if meta.EngineType == "vector" && !storage.VectorSegmentsEnabled(meta.IndexType) {
+		if settings.SegmentRolloverBytes > 0 || settings.MaxSegmentsBeforeMerge > 0 {
+			return fmt.Errorf("segment settings do not apply to vector index type %q (only Flat and HNSW use segmented storage)", meta.IndexType)
+		}
+		meta.SegmentRolloverBytes = 0
+		meta.MaxSegmentsBeforeMerge = 0
+		applied = storage.NormalizeVectorSpaceSettings(meta.IndexType, storage.SpaceSettings{})
+	} else {
+		if settings.SegmentRolloverBytes > 0 {
+			meta.SegmentRolloverBytes = settings.SegmentRolloverBytes
+		}
+		if settings.MaxSegmentsBeforeMerge > 0 {
+			meta.MaxSegmentsBeforeMerge = settings.MaxSegmentsBeforeMerge
+		}
+		applied = storage.NormalizeSpaceSettings(storage.SpaceSettings{
+			SegmentRolloverBytes:   meta.SegmentRolloverBytes,
+			MaxSegmentsBeforeMerge: meta.MaxSegmentsBeforeMerge,
+		})
+		meta.SegmentRolloverBytes = applied.SegmentRolloverBytes
+		meta.MaxSegmentsBeforeMerge = applied.MaxSegmentsBeforeMerge
+	}
+
+	if engine, ok := sm.spaces[space]; ok {
+		applier, ok := engine.(storage.SpaceSettingsApplier)
+		if !ok {
+			return errors.New("space engine does not support live settings updates")
+		}
+		if err := applier.UpdateSpaceSettings(applied); err != nil {
+			return err
+		}
+	}
+
+	if err := sm.writeSpaceMeta(meta); err != nil {
+		return err
+	}
+
+	sm.spaceMetas[space] = meta
+	return nil
 }
 
 func getFAISSMetric(metric string) int {

--- a/internal/spaces/space_manager_test.go
+++ b/internal/spaces/space_manager_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/shibudb.org/shibudb-server/internal/storage"
 )
 
 func TestIsAllowedIndexType(t *testing.T) {
@@ -213,6 +215,12 @@ func TestSpaceManager_KeyValueMetadataOmitsVectorFieldsAndDefaultsWALOff(t *test
 	if meta.Metric != "" {
 		t.Fatalf("Metric = %q, want empty for key-value", meta.Metric)
 	}
+	if meta.SegmentRolloverBytes != storage.DefaultSegmentRolloverBytes {
+		t.Fatalf("SegmentRolloverBytes = %d, want %d", meta.SegmentRolloverBytes, storage.DefaultSegmentRolloverBytes)
+	}
+	if meta.MaxSegmentsBeforeMerge != storage.DefaultMaxSegmentsBeforeMerge {
+		t.Fatalf("MaxSegmentsBeforeMerge = %d, want %d", meta.MaxSegmentsBeforeMerge, storage.DefaultMaxSegmentsBeforeMerge)
+	}
 
 	data, err := os.ReadFile(filepath.Join(dir, "kv_default", spaceMetaFileName))
 	if err != nil {
@@ -223,6 +231,84 @@ func TestSpaceManager_KeyValueMetadataOmitsVectorFieldsAndDefaultsWALOff(t *test
 		if strings.Contains(content, forbidden) {
 			t.Fatalf("key-value metadata unexpectedly contains %s: %s", forbidden, content)
 		}
+	}
+	for _, expected := range []string{`"segment_rollover_bytes"`, `"max_segments_before_merge"`} {
+		if !strings.Contains(content, expected) {
+			t.Fatalf("key-value metadata missing %s: %s", expected, content)
+		}
+	}
+}
+
+func TestSpaceManager_UpdateSpaceSettingsPersistsAndAppliesDefaults(t *testing.T) {
+	dir := t.TempDir()
+	sm := NewSpaceManager(dir)
+	defer sm.CloseAll()
+
+	if _, err := sm.CreateSpace("settings_space", "key-value", 0, "", ""); err != nil {
+		t.Fatalf("CreateSpace failed: %v", err)
+	}
+
+	if err := sm.UpdateSpaceSettings("settings_space", storage.SpaceSettings{
+		SegmentRolloverBytes:   1024,
+		MaxSegmentsBeforeMerge: 7,
+	}); err != nil {
+		t.Fatalf("UpdateSpaceSettings failed: %v", err)
+	}
+
+	meta, ok := sm.SpaceMeta("settings_space")
+	if !ok {
+		t.Fatal("SpaceMeta did not return updated space")
+	}
+	if meta.SegmentRolloverBytes != 1024 {
+		t.Fatalf("SegmentRolloverBytes = %d, want 1024", meta.SegmentRolloverBytes)
+	}
+	if meta.MaxSegmentsBeforeMerge != 7 {
+		t.Fatalf("MaxSegmentsBeforeMerge = %d, want 7", meta.MaxSegmentsBeforeMerge)
+	}
+
+	sm.CloseAll()
+	reloaded := NewSpaceManager(dir)
+	defer reloaded.CloseAll()
+
+	meta, ok = reloaded.SpaceMeta("settings_space")
+	if !ok {
+		t.Fatal("SpaceMeta missing after reload")
+	}
+	if meta.SegmentRolloverBytes != 1024 {
+		t.Fatalf("reloaded SegmentRolloverBytes = %d, want 1024", meta.SegmentRolloverBytes)
+	}
+	if meta.MaxSegmentsBeforeMerge != 7 {
+		t.Fatalf("reloaded MaxSegmentsBeforeMerge = %d, want 7", meta.MaxSegmentsBeforeMerge)
+	}
+}
+
+func TestSpaceManager_UpdateSpaceSettingsPreservesUnspecifiedValues(t *testing.T) {
+	dir := t.TempDir()
+	sm := NewSpaceManager(dir)
+	defer sm.CloseAll()
+
+	if _, err := sm.CreateSpaceWithSettings("settings_space", "key-value", 0, "", "", false, storage.SpaceSettings{
+		SegmentRolloverBytes:   4096,
+		MaxSegmentsBeforeMerge: 11,
+	}); err != nil {
+		t.Fatalf("CreateSpaceWithSettings failed: %v", err)
+	}
+
+	if err := sm.UpdateSpaceSettings("settings_space", storage.SpaceSettings{
+		SegmentRolloverBytes: 2048,
+	}); err != nil {
+		t.Fatalf("UpdateSpaceSettings failed: %v", err)
+	}
+
+	meta, ok := sm.SpaceMeta("settings_space")
+	if !ok {
+		t.Fatal("SpaceMeta missing")
+	}
+	if meta.SegmentRolloverBytes != 2048 {
+		t.Fatalf("SegmentRolloverBytes = %d, want 2048", meta.SegmentRolloverBytes)
+	}
+	if meta.MaxSegmentsBeforeMerge != 11 {
+		t.Fatalf("MaxSegmentsBeforeMerge = %d, want 11", meta.MaxSegmentsBeforeMerge)
 	}
 }
 
@@ -409,5 +495,65 @@ func TestSpaceManager_DeleteSpacePersistsAcrossRestart(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(dir, "alpha")); !os.IsNotExist(err) {
 		t.Fatalf("deleted space directory still exists, err=%v", err)
+	}
+}
+
+func TestSpaceManager_VectorTrainingIndexClearsSegmentSettings(t *testing.T) {
+	dir := t.TempDir()
+	sm := NewSpaceManager(dir)
+	defer sm.CloseAll()
+
+	if _, err := sm.CreateSpaceWithSettings("ivf_seg", "vector", 8, "IVF32,Flat", "L2", true, storage.SpaceSettings{
+		SegmentRolloverBytes:   99,
+		MaxSegmentsBeforeMerge: 3,
+	}); err != nil {
+		t.Fatalf("CreateSpaceWithSettings: %v", err)
+	}
+	meta, ok := sm.SpaceMeta("ivf_seg")
+	if !ok {
+		t.Fatal("SpaceMeta missing")
+	}
+	if meta.SegmentRolloverBytes != 0 || meta.MaxSegmentsBeforeMerge != 0 {
+		t.Fatalf("IVF space should persist zero segment settings, got rollover=%d merge=%d",
+			meta.SegmentRolloverBytes, meta.MaxSegmentsBeforeMerge)
+	}
+}
+
+func TestSpaceManager_UpdateSpaceSettingsRejectsSegmentForTrainingVector(t *testing.T) {
+	dir := t.TempDir()
+	sm := NewSpaceManager(dir)
+	defer sm.CloseAll()
+
+	if _, err := sm.CreateSpaceWithSettings("ivf_upd", "vector", 8, "IVF32,Flat", "L2", true, storage.SpaceSettings{}); err != nil {
+		t.Fatalf("CreateSpaceWithSettings: %v", err)
+	}
+	if err := sm.UpdateSpaceSettings("ivf_upd", storage.SpaceSettings{
+		SegmentRolloverBytes: 1024,
+	}); err == nil {
+		t.Fatal("expected error when updating segment settings for IVF space")
+	}
+	if err := sm.UpdateSpaceSettings("ivf_upd", storage.SpaceSettings{}); err != nil {
+		t.Fatalf("no-op update: %v", err)
+	}
+}
+
+func TestSpaceManager_VectorFlatKeepsSegmentSettings(t *testing.T) {
+	dir := t.TempDir()
+	sm := NewSpaceManager(dir)
+	defer sm.CloseAll()
+
+	if _, err := sm.CreateSpaceWithSettings("flat_seg", "vector", 4, "Flat", "L2", true, storage.SpaceSettings{
+		SegmentRolloverBytes:   2048,
+		MaxSegmentsBeforeMerge: 9,
+	}); err != nil {
+		t.Fatalf("CreateSpaceWithSettings: %v", err)
+	}
+	meta, ok := sm.SpaceMeta("flat_seg")
+	if !ok {
+		t.Fatal("SpaceMeta missing")
+	}
+	if meta.SegmentRolloverBytes != 2048 || meta.MaxSegmentsBeforeMerge != 9 {
+		t.Fatalf("Flat space should keep segment settings, got rollover=%d merge=%d",
+			meta.SegmentRolloverBytes, meta.MaxSegmentsBeforeMerge)
 	}
 }

--- a/internal/storage/engine.go
+++ b/internal/storage/engine.go
@@ -1,5 +1,45 @@
 package storage
 
+const (
+	DefaultSegmentRolloverBytes   int64 = 50 * 1024 * 1024
+	DefaultMaxSegmentsBeforeMerge       = 20
+)
+
+type SpaceSettings struct {
+	SegmentRolloverBytes   int64 `json:"segment_rollover_bytes,omitempty"`
+	MaxSegmentsBeforeMerge int   `json:"max_segments_before_merge,omitempty"`
+}
+
+func NormalizeSpaceSettings(settings SpaceSettings) SpaceSettings {
+	if settings.SegmentRolloverBytes <= 0 {
+		settings.SegmentRolloverBytes = DefaultSegmentRolloverBytes
+	}
+	if settings.MaxSegmentsBeforeMerge <= 0 {
+		settings.MaxSegmentsBeforeMerge = DefaultMaxSegmentsBeforeMerge
+	}
+	return settings
+}
+
+// VectorSegmentsEnabled is true for index types that use segmented vector storage
+// (Flat, HNSW). Training-based indexes (IVF, PQ, …) use a single file and ignore
+// segment rollover / merge settings.
+func VectorSegmentsEnabled(indexType string) bool {
+	return requiredTrainCountForIndex(indexType) == 0
+}
+
+// NormalizeVectorSpaceSettings applies segment defaults for Flat/HNSW, and clears
+// segment fields for training-based vector index types.
+func NormalizeVectorSpaceSettings(indexType string, settings SpaceSettings) SpaceSettings {
+	if !VectorSegmentsEnabled(indexType) {
+		return SpaceSettings{}
+	}
+	return NormalizeSpaceSettings(settings)
+}
+
+type SpaceSettingsApplier interface {
+	UpdateSpaceSettings(settings SpaceSettings) error
+}
+
 type KeyValueEngine interface {
 	Close() error
 	Put(key, value string) error

--- a/internal/storage/key_value_storage.go
+++ b/internal/storage/key_value_storage.go
@@ -4,41 +4,54 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"os"
-	"strconv"
+	"path/filepath"
 	"sync"
+	"time"
 
-	"github.com/shibudb.org/shibudb-server/internal/index"
+	kvindex "github.com/shibudb.org/shibudb-server/internal/index"
 	"github.com/shibudb.org/shibudb-server/internal/maintenance"
 	"github.com/shibudb.org/shibudb-server/internal/wal"
 )
 
+type kvSegment struct {
+	meta     SegmentMeta
+	dataFile *os.File
+	index    map[string]int64
+}
+
 type ShibuDB struct {
-	file      *os.File
 	lock      sync.RWMutex
-	index     *index.BTreeIndex
 	wal       *wal.WAL
+	settings  SpaceSettings
 	batchLock sync.Mutex
 	batch     map[string]string
 	closeOnce sync.Once
 
 	maintenanceMu     sync.RWMutex
 	maintenanceClosed bool
+
+	layout           SegmentLayout
+	primaryDataPath  string
+	primaryIndexPath string
+	manifest         *SegmentManifest
+	segments         []*kvSegment
+
+	indexBuildQueue chan int64
+	mergeQueue      chan struct{}
+	backgroundStop  chan struct{}
+	backgroundWG    sync.WaitGroup
 }
 
 func OpenDBWithPathsAndWAL(dataPath, walPath, indexPath string, enableWAL bool) (*ShibuDB, error) {
-	file, err := os.OpenFile(dataPath, os.O_RDWR|os.O_CREATE, 0666)
-	if err != nil {
-		return nil, err
-	}
+	return OpenDBWithPathsAndWALAndSettings(dataPath, walPath, indexPath, enableWAL, SpaceSettings{})
+}
 
-	dbIndex, err := index.NewBTreeIndex(indexPath)
-	if err != nil {
-		return nil, err
-	}
-
+func OpenDBWithPathsAndWALAndSettings(dataPath, walPath, indexPath string, enableWAL bool, settings SpaceSettings) (*ShibuDB, error) {
 	var dbWAL *wal.WAL
+	var err error
 	if enableWAL {
 		dbWAL, err = wal.OpenWAL(walPath)
 		if err != nil {
@@ -47,13 +60,34 @@ func OpenDBWithPathsAndWAL(dataPath, walPath, indexPath string, enableWAL bool) 
 	}
 
 	db := &ShibuDB{
-		file:  file,
-		index: dbIndex,
-		wal:   dbWAL,
-		batch: make(map[string]string),
+		wal:              dbWAL,
+		settings:         NormalizeSpaceSettings(settings),
+		batch:            make(map[string]string),
+		layout:           NewSegmentLayout(filepath.Dir(dataPath), "data", ".db", ".idx"),
+		primaryDataPath:  dataPath,
+		primaryIndexPath: indexPath,
+		indexBuildQueue:  make(chan int64, 32),
+		mergeQueue:       make(chan struct{}, 1),
+		backgroundStop:   make(chan struct{}),
 	}
 
-	db.index.BatchLoadFromMmap()
+	manifest, err := db.loadOrCreateManifest()
+	if err != nil {
+		if db.wal != nil {
+			_ = db.wal.Close()
+		}
+		return nil, err
+	}
+	db.manifest = manifest
+
+	if err := db.loadSegments(); err != nil {
+		if db.wal != nil {
+			_ = db.wal.Close()
+		}
+		return nil, err
+	}
+
+	db.startBackgroundWorkers()
 	if enableWAL {
 		db.replayWAL()
 	}
@@ -66,33 +100,99 @@ func OpenDB(filename string, walFilename string) (*ShibuDB, error) {
 }
 
 func OpenDBWithWAL(filename string, walFilename string, enableWAL bool) (*ShibuDB, error) {
-	file, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE, 0666)
-	if err != nil {
+	return OpenDBWithWALAndSettings(filename, walFilename, enableWAL, SpaceSettings{})
+}
+
+func OpenDBWithWALAndSettings(filename string, walFilename string, enableWAL bool, settings SpaceSettings) (*ShibuDB, error) {
+	return OpenDBWithPathsAndWALAndSettings(filename, walFilename, filepath.Join(filepath.Dir(filename), "index.dat"), enableWAL, settings)
+}
+
+func (db *ShibuDB) loadOrCreateManifest() (*SegmentManifest, error) {
+	path := db.layout.ManifestPath()
+	if _, err := os.Stat(path); err == nil {
+		return LoadOrCreateSegmentManifest(db.layout)
+	} else if !os.IsNotExist(err) {
 		return nil, err
-	}
-	dbIndex, err := index.NewBTreeIndex("index.dat")
-	if err != nil {
-		return nil, err
-	}
-	var dbWAL *wal.WAL
-	if enableWAL {
-		dbWAL, err = wal.OpenWAL(walFilename)
-		if err != nil {
-			return nil, err
-		}
-	}
-	db := &ShibuDB{
-		file:  file,
-		index: dbIndex,
-		wal:   dbWAL,
-		batch: make(map[string]string),
-	}
-	db.index.BatchLoadFromMmap()
-	if enableWAL {
-		db.replayWAL()
 	}
 
-	return db, nil
+	now := time.Now().UnixNano()
+	manifest := &SegmentManifest{
+		Version:         currentSegmentManifestVersion,
+		NextSegmentID:   2,
+		ActiveSegmentID: 1,
+		Segments: []SegmentMeta{{
+			ID:              1,
+			State:           SegmentStateHot,
+			DataFile:        filepath.Base(db.primaryDataPath),
+			IndexFile:       filepath.Base(db.primaryIndexPath),
+			CreatedAtUnixNs: now,
+		}},
+	}
+	if info, err := os.Stat(db.primaryDataPath); err == nil {
+		manifest.Segments[0].SizeBytes = info.Size()
+	}
+	if err := WriteSegmentManifest(db.layout, manifest); err != nil {
+		return nil, err
+	}
+	return manifest, nil
+}
+
+func (db *ShibuDB) loadSegments() error {
+	db.lock.Lock()
+	defer db.lock.Unlock()
+
+	db.segments = nil
+	if len(db.manifest.Segments) == 0 {
+		return errors.New("segment manifest has no segments")
+	}
+
+	db.manifest.ActiveSegmentID = db.manifest.Segments[len(db.manifest.Segments)-1].ID
+	manifestChanged := false
+
+	for idx, meta := range db.manifest.Segments {
+		desc := db.layout.Descriptor(meta)
+		dataFile, err := os.OpenFile(desc.DataPath, os.O_RDWR|os.O_CREATE, 0666)
+		if err != nil {
+			return err
+		}
+
+		var entries map[string]int64
+		if idx == len(db.manifest.Segments)-1 {
+			entries, err = scanKeyValueDataFile(desc.DataPath)
+			meta.State = SegmentStateHot
+		} else {
+			entries, err = loadOrBuildKeyValueSegmentIndex(desc)
+			meta.State = SegmentStateCold
+		}
+		if err != nil {
+			_ = dataFile.Close()
+			return err
+		}
+
+		if info, err := dataFile.Stat(); err == nil {
+			meta.SizeBytes = info.Size()
+		}
+		db.manifest.Segments[idx] = meta
+		db.segments = append(db.segments, &kvSegment{
+			meta:     meta,
+			dataFile: dataFile,
+			index:    entries,
+		})
+		manifestChanged = true
+	}
+
+	if manifestChanged {
+		if err := WriteSegmentManifest(db.layout, db.manifest); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (db *ShibuDB) startBackgroundWorkers() {
+	db.backgroundWG.Add(2)
+	go db.indexBuildWorker()
+	go db.mergeWorker()
 }
 
 func (db *ShibuDB) replayWAL() {
@@ -105,12 +205,23 @@ func (db *ShibuDB) replayWAL() {
 		return
 	}
 	for _, entry := range entries {
-		if entry[1] != "" {
-			db.PutBatch(entry[0], entry[1])
+		if len(entry) != 2 {
+			continue
+		}
+		if entry[1] == "" {
+			if err := db.Delete(entry[0]); err != nil && !errors.Is(err, errKeyDeleted) && !errors.Is(err, errKeyNotFound) {
+				log.Printf("WAL replay delete failed for %q: %v", entry[0], err)
+			}
+			continue
+		}
+		if err := db.PutBatch(entry[0], entry[1]); err != nil {
+			log.Printf("WAL replay put failed for %q: %v", entry[0], err)
 		}
 	}
-	db.FlushBatch()
-	db.wal.Clear()
+	if err := db.FlushBatch(); err != nil {
+		log.Printf("WAL replay flush failed: %v", err)
+	}
+	_ = db.wal.Clear()
 }
 
 func (db *ShibuDB) PutBatch(key, value string) error {
@@ -137,69 +248,48 @@ func (db *ShibuDB) FlushBatch() error {
 	db.lock.Lock()
 	defer db.lock.Unlock()
 
-	// Write to WAL if enabled
+	active := db.activeSegmentLocked()
+	if active == nil {
+		return errors.New("no active segment")
+	}
+
 	if db.wal != nil {
 		for key, value := range batchCopy {
-			err := db.wal.WriteEntry(key, value)
-			if err != nil {
+			if err := db.wal.WriteEntry(key, value); err != nil {
 				return err
 			}
 		}
 	}
 
 	for key, value := range batchCopy {
-		keyBytes := []byte(key)
-		valBytes := []byte(value)
-
-		keySize := uint32(len(keyBytes))
-		valSize := uint32(len(valBytes))
-
-		buf := make([]byte, 8+len(keyBytes)+len(valBytes))
-		binary.LittleEndian.PutUint32(buf[0:4], keySize)
-		binary.LittleEndian.PutUint32(buf[4:8], valSize)
-		copy(buf[8:], keyBytes)
-		copy(buf[8+len(keyBytes):], valBytes)
-
-		// Use Seek once to get atomic write offset
-		pos, err := db.file.Seek(0, 2)
+		pos, err := appendKeyValueRecord(active.dataFile, key, value)
 		if err != nil {
 			return err
 		}
-
-		written, err := db.file.WriteAt(buf, pos)
-		if err != nil {
-			return err
-		}
-
-		if written != len(buf) {
-			return fmt.Errorf("short write: wrote %d of %d bytes", written, len(buf))
-		}
-
-		// Only add to index after a confirmed successful write
-		err = db.index.Add(key, pos)
-		if err != nil {
-			return err
-		}
+		active.index[key] = pos
 	}
 
-	// Sync to flush data to disk
-	if err := db.file.Sync(); err != nil {
+	if err := active.dataFile.Sync(); err != nil {
 		return err
 	}
+	if info, err := active.dataFile.Stat(); err == nil {
+		active.meta.SizeBytes = info.Size()
+		db.updateSegmentMetaLocked(active.meta)
+	}
 
-	// Mark WAL as committed if enabled
 	if db.wal != nil {
-		db.wal.MarkCommitted()
+		if err := db.wal.MarkCommitted(); err != nil {
+			return err
+		}
 		if db.wal.ShouldCheckpoint() {
-			db.wal.Clear()
+			_ = db.wal.Clear()
 		}
 	}
 
-	return nil
+	return db.rotateHotSegmentLocked()
 }
 
 func (db *ShibuDB) Get(key string) (string, error) {
-	// Check batch first for read-your-own-writes
 	db.batchLock.Lock()
 	if val, exists := db.batch[key]; exists {
 		db.batchLock.Unlock()
@@ -210,102 +300,97 @@ func (db *ShibuDB) Get(key string) (string, error) {
 	db.lock.RLock()
 	defer db.lock.RUnlock()
 
-	log.Println("Checking index position")
-	pos, exists := db.index.Get(key)
-	if !exists {
-		return "", errors.New("key not found")
-	}
-	log.Println("Found pos for index: " + strconv.FormatInt(pos, 10))
-	fmt.Printf("Found pos for index: " + strconv.FormatInt(pos, 10))
-
-	header := make([]byte, 8)
-	_, err := db.file.ReadAt(header, pos)
-	if err != nil {
-		return "", err
-	}
-
-	keySize := binary.LittleEndian.Uint32(header[0:4])
-	valSize := binary.LittleEndian.Uint32(header[4:8])
-
-	log.Println("Key size found", keySize)
-	log.Println("Val size found", valSize)
-
-	keyBytes := make([]byte, keySize)
-	_, err = db.file.ReadAt(keyBytes, pos+8)
-	if err != nil {
-		log.Println("Error reading key bytes")
-		return "", err
-	}
-
-	valBytes := make([]byte, valSize)
-	_, err = db.file.ReadAt(valBytes, pos+8+int64(keySize))
-	if err != nil {
-		log.Println("Error reading value bytes")
-		return "", err
-	}
-
-	log.Println("Key found", string(keyBytes))
-	log.Println("Value found", string(valBytes))
-
-	if string(keyBytes) == key {
-		value := string(valBytes)
-		if value == "__deleted__" {
-			return "", errors.New("key is deleted")
+	for idx := len(db.segments) - 1; idx >= 0; idx-- {
+		segment := db.segments[idx]
+		pos, exists := segment.index[key]
+		if !exists {
+			continue
+		}
+		foundKey, value, deleted, err := readKeyValueRecordAt(segment.dataFile, pos)
+		if err != nil {
+			return "", err
+		}
+		if foundKey != key {
+			return "", fmt.Errorf("key mismatch at position %d: found %q expected %q", pos, foundKey, key)
+		}
+		if deleted {
+			return "", errKeyDeleted
 		}
 		return value, nil
 	}
-	return "", errors.New("key mismatch at position: " + strconv.FormatInt(pos, 10) + ". Found: " + string(keyBytes) + ". Expected: " + key)
+	return "", errKeyNotFound
 }
 
 func (db *ShibuDB) Delete(key string) error {
 	db.lock.Lock()
 	defer db.lock.Unlock()
 
-	_, exists := db.index.Get(key)
+	exists, err := db.keyExistsLocked(key)
+	if err != nil {
+		return err
+	}
 	if !exists {
-		return errors.New("key not found")
+		return errKeyNotFound
 	}
 
-	db.index.Remove(key)
+	active := db.activeSegmentLocked()
+	if active == nil {
+		return errors.New("no active segment")
+	}
+
 	if db.wal != nil {
-		err := db.wal.WriteDelete(key)
-		if err != nil {
+		if err := db.wal.WriteDelete(key); err != nil {
 			return err
 		}
 	}
 
-	keyBytes := []byte(key)
-	keySize := uint32(len(keyBytes))
-	valSize := uint32(0)
-
-	buf := make([]byte, 8+len(keyBytes))
-	binary.LittleEndian.PutUint32(buf[0:4], keySize)
-	binary.LittleEndian.PutUint32(buf[4:8], valSize)
-	copy(buf[8:], keyBytes)
-
-	pos, err := db.file.Seek(0, 2)
+	pos, err := appendDeleteRecord(active.dataFile, key)
 	if err != nil {
 		return err
 	}
-	_, err = db.file.WriteAt(buf, pos)
-	return err
+	active.index[key] = pos
+
+	if err := active.dataFile.Sync(); err != nil {
+		return err
+	}
+	if info, err := active.dataFile.Stat(); err == nil {
+		active.meta.SizeBytes = info.Size()
+		db.updateSegmentMetaLocked(active.meta)
+	}
+
+	if db.wal != nil {
+		if err := db.wal.MarkCommitted(); err != nil {
+			return err
+		}
+		if db.wal.ShouldCheckpoint() {
+			_ = db.wal.Clear()
+		}
+	}
+
+	return db.rotateHotSegmentLocked()
 }
 
 func (db *ShibuDB) Close() error {
 	db.closeOnce.Do(func() {
-		log.Println("Closed.............")
-
 		db.maintenanceMu.Lock()
 		db.maintenanceClosed = true
 		maintenance.UnregisterKVFlush(db)
 		db.maintenanceMu.Unlock()
 
-		db.FlushBatch()
-		if db.wal != nil {
-			db.wal.Clear()
-			db.wal.Close()
+		_ = db.FlushBatch()
+		close(db.backgroundStop)
+		db.backgroundWG.Wait()
+
+		db.lock.Lock()
+		for _, segment := range db.segments {
+			_ = segment.dataFile.Close()
 		}
-		db.file.Close()
+		db.lock.Unlock()
+
+		if db.wal != nil {
+			_ = db.wal.Clear()
+			_ = db.wal.Close()
+		}
 	})
 	return nil
 }
@@ -314,7 +399,14 @@ func (db *ShibuDB) Put(key, value string) error {
 	return db.PutBatch(key, value)
 }
 
-// MaintenanceFlush participates in the shared KV flush loop.
+func (db *ShibuDB) UpdateSpaceSettings(settings SpaceSettings) error {
+	db.lock.Lock()
+	defer db.lock.Unlock()
+	db.settings = NormalizeSpaceSettings(settings)
+	db.scheduleMergeCheckLocked()
+	return nil
+}
+
 func (db *ShibuDB) MaintenanceFlush() {
 	db.maintenanceMu.RLock()
 	defer db.maintenanceMu.RUnlock()
@@ -324,4 +416,516 @@ func (db *ShibuDB) MaintenanceFlush() {
 	if err := db.FlushBatch(); err != nil {
 		log.Printf("FlushBatch failed: %v", err)
 	}
+}
+
+func (db *ShibuDB) indexBuildWorker() {
+	defer db.backgroundWG.Done()
+	for {
+		select {
+		case <-db.backgroundStop:
+			return
+		case id := <-db.indexBuildQueue:
+			db.buildIndexForSegment(id)
+		}
+	}
+}
+
+func (db *ShibuDB) mergeWorker() {
+	defer db.backgroundWG.Done()
+	for {
+		select {
+		case <-db.backgroundStop:
+			return
+		case <-db.mergeQueue:
+			for db.tryMergeOldestColdSegments() {
+			}
+		}
+	}
+}
+
+func (db *ShibuDB) buildIndexForSegment(id int64) {
+	db.lock.Lock()
+	segment := db.segmentByIDLocked(id)
+	if segment == nil || id == db.manifest.ActiveSegmentID {
+		db.lock.Unlock()
+		return
+	}
+	segment.meta.State = SegmentStateIndexing
+	db.updateSegmentMetaLocked(segment.meta)
+	dataPath := db.layout.Descriptor(segment.meta).DataPath
+	indexPath := db.layout.Descriptor(segment.meta).IndexPath
+	_ = WriteSegmentManifest(db.layout, db.manifest)
+	db.lock.Unlock()
+
+	if _, err := RebuildKeyValueIndex(dataPath, indexPath); err != nil {
+		log.Printf("build key-value segment index failed for segment %d: %v", id, err)
+		db.lock.Lock()
+		if segment := db.segmentByIDLocked(id); segment != nil {
+			segment.meta.State = SegmentStateSealed
+			db.updateSegmentMetaLocked(segment.meta)
+			_ = WriteSegmentManifest(db.layout, db.manifest)
+		}
+		db.lock.Unlock()
+		return
+	}
+
+	db.lock.Lock()
+	if segment := db.segmentByIDLocked(id); segment != nil {
+		segment.meta.State = SegmentStateCold
+		if info, err := os.Stat(dataPath); err == nil {
+			segment.meta.SizeBytes = info.Size()
+		}
+		db.updateSegmentMetaLocked(segment.meta)
+		_ = WriteSegmentManifest(db.layout, db.manifest)
+		db.scheduleMergeCheckLocked()
+	}
+	db.lock.Unlock()
+}
+
+func (db *ShibuDB) tryMergeOldestColdSegments() bool {
+	db.lock.Lock()
+	if len(db.segments) <= db.settings.MaxSegmentsBeforeMerge {
+		db.lock.Unlock()
+		return false
+	}
+
+	var first, second *kvSegment
+	for _, segment := range db.segments {
+		if segment.meta.ID == db.manifest.ActiveSegmentID {
+			continue
+		}
+		if segment.meta.State != SegmentStateCold {
+			continue
+		}
+		if first == nil {
+			first = segment
+			continue
+		}
+		second = segment
+		break
+	}
+	if first == nil || second == nil {
+		db.lock.Unlock()
+		return false
+	}
+
+	first.meta.State = SegmentStateMerging
+	second.meta.State = SegmentStateMerging
+	db.updateSegmentMetaLocked(first.meta)
+	db.updateSegmentMetaLocked(second.meta)
+
+	newID := second.meta.ID
+	firstDesc := db.layout.Descriptor(first.meta)
+	secondDesc := db.layout.Descriptor(second.meta)
+	_ = WriteSegmentManifest(db.layout, db.manifest)
+	db.lock.Unlock()
+
+	mergedMeta, mergedIndex, mergedFile, err := db.mergeSegments(newID, firstDesc, secondDesc)
+	if err != nil {
+		log.Printf("merge key-value segments %d and %d failed: %v", first.meta.ID, second.meta.ID, err)
+		db.lock.Lock()
+		if segment := db.segmentByIDLocked(first.meta.ID); segment != nil {
+			segment.meta.State = SegmentStateCold
+			db.updateSegmentMetaLocked(segment.meta)
+		}
+		if segment := db.segmentByIDLocked(second.meta.ID); segment != nil {
+			segment.meta.State = SegmentStateCold
+			db.updateSegmentMetaLocked(segment.meta)
+		}
+		_ = WriteSegmentManifest(db.layout, db.manifest)
+		db.lock.Unlock()
+		return false
+	}
+
+	db.lock.Lock()
+	defer db.lock.Unlock()
+
+	firstIdx := db.segmentIndexByIDLocked(first.meta.ID)
+	secondIdx := db.segmentIndexByIDLocked(second.meta.ID)
+	if firstIdx < 0 || secondIdx < 0 || secondIdx <= firstIdx {
+		_ = mergedFile.Close()
+		return false
+	}
+
+	_ = db.segments[firstIdx].dataFile.Close()
+	_ = db.segments[secondIdx].dataFile.Close()
+	_ = os.Remove(firstDesc.DataPath)
+	_ = os.Remove(firstDesc.IndexPath)
+
+	mergedSegment := &kvSegment{
+		meta:     mergedMeta,
+		dataFile: mergedFile,
+		index:    mergedIndex,
+	}
+	db.segments = append(append([]*kvSegment{}, mergedSegment), db.segments[secondIdx+1:]...)
+	db.manifest.Segments = append(append([]SegmentMeta{}, mergedMeta), db.manifest.Segments[secondIdx+1:]...)
+	_ = WriteSegmentManifest(db.layout, db.manifest)
+	return len(db.segments) > db.settings.MaxSegmentsBeforeMerge
+}
+
+func (db *ShibuDB) mergeSegments(newID int64, firstDesc, secondDesc SegmentDescriptor) (SegmentMeta, map[string]int64, *os.File, error) {
+	latestRecords, err := collectLatestKeyValueRecords(firstDesc.DataPath, secondDesc.DataPath)
+	if err != nil {
+		return SegmentMeta{}, nil, nil, err
+	}
+
+	mergedDataPath := db.layout.DataPath(newID)
+	mergedIndexPath := db.layout.IndexPath(newID)
+	if err := writeMergedKeyValueDataFile(mergedDataPath, latestRecords); err != nil {
+		return SegmentMeta{}, nil, nil, err
+	}
+	if _, err := RebuildKeyValueIndex(mergedDataPath, mergedIndexPath); err != nil {
+		return SegmentMeta{}, nil, nil, err
+	}
+
+	entries, err := loadKeyValueIndexEntries(mergedIndexPath)
+	if err != nil {
+		return SegmentMeta{}, nil, nil, err
+	}
+	dataFile, err := os.OpenFile(mergedDataPath, os.O_RDWR|os.O_CREATE, 0666)
+	if err != nil {
+		return SegmentMeta{}, nil, nil, err
+	}
+
+	meta := SegmentMeta{
+		ID:              newID,
+		State:           SegmentStateCold,
+		DataFile:        filepath.Base(mergedDataPath),
+		IndexFile:       filepath.Base(mergedIndexPath),
+		CreatedAtUnixNs: time.Now().UnixNano(),
+	}
+	if info, err := dataFile.Stat(); err == nil {
+		meta.SizeBytes = info.Size()
+	}
+	return meta, entries, dataFile, nil
+}
+
+func (db *ShibuDB) rotateHotSegmentLocked() error {
+	active := db.activeSegmentLocked()
+	if active == nil {
+		return errors.New("no active segment")
+	}
+	if active.meta.SizeBytes < db.settings.SegmentRolloverBytes {
+		return nil
+	}
+
+	active.meta.State = SegmentStateSealed
+	active.meta.SealedAtUnixNs = time.Now().UnixNano()
+	db.updateSegmentMetaLocked(active.meta)
+
+	newID := db.manifest.NextSegmentID
+	db.manifest.NextSegmentID++
+	newMeta := SegmentMeta{
+		ID:              newID,
+		State:           SegmentStateHot,
+		DataFile:        db.layout.DataFileName(newID),
+		IndexFile:       db.layout.IndexFileName(newID),
+		CreatedAtUnixNs: time.Now().UnixNano(),
+	}
+	newDataFile, err := os.OpenFile(db.layout.DataPath(newID), os.O_RDWR|os.O_CREATE, 0666)
+	if err != nil {
+		return err
+	}
+
+	db.manifest.ActiveSegmentID = newID
+	db.manifest.Segments = append(db.manifest.Segments, newMeta)
+	db.segments = append(db.segments, &kvSegment{
+		meta:     newMeta,
+		dataFile: newDataFile,
+		index:    make(map[string]int64),
+	})
+	if err := WriteSegmentManifest(db.layout, db.manifest); err != nil {
+		return err
+	}
+
+	db.enqueueIndexBuildLocked(active.meta.ID)
+	db.scheduleMergeCheckLocked()
+	return nil
+}
+
+func (db *ShibuDB) activeSegmentLocked() *kvSegment {
+	for _, segment := range db.segments {
+		if segment.meta.ID == db.manifest.ActiveSegmentID {
+			return segment
+		}
+	}
+	return nil
+}
+
+func (db *ShibuDB) keyExistsLocked(key string) (bool, error) {
+	for idx := len(db.segments) - 1; idx >= 0; idx-- {
+		segment := db.segments[idx]
+		pos, exists := segment.index[key]
+		if !exists {
+			continue
+		}
+		_, _, deleted, err := readKeyValueRecordAt(segment.dataFile, pos)
+		if err != nil {
+			return false, err
+		}
+		return !deleted, nil
+	}
+	return false, nil
+}
+
+func (db *ShibuDB) updateSegmentMetaLocked(meta SegmentMeta) {
+	for idx := range db.segments {
+		if db.segments[idx].meta.ID == meta.ID {
+			db.segments[idx].meta = meta
+			break
+		}
+	}
+	for idx := range db.manifest.Segments {
+		if db.manifest.Segments[idx].ID == meta.ID {
+			db.manifest.Segments[idx] = meta
+			break
+		}
+	}
+}
+
+func (db *ShibuDB) segmentByIDLocked(id int64) *kvSegment {
+	for _, segment := range db.segments {
+		if segment.meta.ID == id {
+			return segment
+		}
+	}
+	return nil
+}
+
+func (db *ShibuDB) segmentIndexByIDLocked(id int64) int {
+	for idx, segment := range db.segments {
+		if segment.meta.ID == id {
+			return idx
+		}
+	}
+	return -1
+}
+
+func (db *ShibuDB) enqueueIndexBuildLocked(id int64) {
+	select {
+	case db.indexBuildQueue <- id:
+	default:
+		go func() {
+			select {
+			case db.indexBuildQueue <- id:
+			case <-db.backgroundStop:
+			}
+		}()
+	}
+}
+
+func (db *ShibuDB) scheduleMergeCheckLocked() {
+	select {
+	case db.mergeQueue <- struct{}{}:
+	default:
+	}
+}
+
+var (
+	errKeyNotFound = errors.New("key not found")
+	errKeyDeleted  = errors.New("key is deleted")
+)
+
+func appendKeyValueRecord(file *os.File, key, value string) (int64, error) {
+	keyBytes := []byte(key)
+	valBytes := []byte(value)
+	buf := make([]byte, 8+len(keyBytes)+len(valBytes))
+	binary.LittleEndian.PutUint32(buf[0:4], uint32(len(keyBytes)))
+	binary.LittleEndian.PutUint32(buf[4:8], uint32(len(valBytes)))
+	copy(buf[8:], keyBytes)
+	copy(buf[8+len(keyBytes):], valBytes)
+
+	pos, err := file.Seek(0, io.SeekEnd)
+	if err != nil {
+		return 0, err
+	}
+	if _, err := file.Write(buf); err != nil {
+		return 0, err
+	}
+	return pos, nil
+}
+
+func appendDeleteRecord(file *os.File, key string) (int64, error) {
+	keyBytes := []byte(key)
+	buf := make([]byte, 8+len(keyBytes))
+	binary.LittleEndian.PutUint32(buf[0:4], uint32(len(keyBytes)))
+	binary.LittleEndian.PutUint32(buf[4:8], 0)
+	copy(buf[8:], keyBytes)
+
+	pos, err := file.Seek(0, io.SeekEnd)
+	if err != nil {
+		return 0, err
+	}
+	if _, err := file.Write(buf); err != nil {
+		return 0, err
+	}
+	return pos, nil
+}
+
+func readKeyValueRecordAt(file *os.File, pos int64) (string, string, bool, error) {
+	header := make([]byte, 8)
+	if _, err := file.ReadAt(header, pos); err != nil {
+		return "", "", false, err
+	}
+	keySize := binary.LittleEndian.Uint32(header[0:4])
+	valSize := binary.LittleEndian.Uint32(header[4:8])
+
+	keyBytes := make([]byte, keySize)
+	if _, err := file.ReadAt(keyBytes, pos+8); err != nil {
+		return "", "", false, err
+	}
+	if valSize == 0 {
+		return string(keyBytes), "", true, nil
+	}
+	valBytes := make([]byte, valSize)
+	if _, err := file.ReadAt(valBytes, pos+8+int64(keySize)); err != nil {
+		return "", "", false, err
+	}
+	return string(keyBytes), string(valBytes), false, nil
+}
+
+func scanKeyValueDataFile(dataPath string) (map[string]int64, error) {
+	file, err := os.OpenFile(dataPath, os.O_RDWR|os.O_CREATE, 0666)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	offsets := make(map[string]int64)
+	var offset int64
+	for {
+		header := make([]byte, 8)
+		n, err := io.ReadFull(file, header)
+		if err == io.EOF || (err == io.ErrUnexpectedEOF && n == 0) {
+			break
+		}
+		if err == io.ErrUnexpectedEOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		keySize := binary.LittleEndian.Uint32(header[0:4])
+		valSize := binary.LittleEndian.Uint32(header[4:8])
+		keyBytes := make([]byte, keySize)
+		if _, err := io.ReadFull(file, keyBytes); err != nil {
+			if err == io.EOF || err == io.ErrUnexpectedEOF {
+				break
+			}
+			return nil, err
+		}
+		if _, err := io.CopyN(io.Discard, file, int64(valSize)); err != nil {
+			if err == io.EOF || err == io.ErrUnexpectedEOF {
+				break
+			}
+			return nil, err
+		}
+
+		offsets[string(keyBytes)] = offset
+		offset += int64(8) + int64(keySize) + int64(valSize)
+	}
+	return offsets, nil
+}
+
+func loadOrBuildKeyValueSegmentIndex(desc SegmentDescriptor) (map[string]int64, error) {
+	if _, err := os.Stat(desc.IndexPath); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+		if _, rebuildErr := RebuildKeyValueIndex(desc.DataPath, desc.IndexPath); rebuildErr != nil {
+			return nil, rebuildErr
+		}
+		return loadKeyValueIndexEntries(desc.IndexPath)
+	}
+
+	entries, err := loadKeyValueIndexEntries(desc.IndexPath)
+	if err == nil {
+		return entries, nil
+	}
+	if _, rebuildErr := RebuildKeyValueIndex(desc.DataPath, desc.IndexPath); rebuildErr != nil {
+		return nil, rebuildErr
+	}
+	return loadKeyValueIndexEntries(desc.IndexPath)
+}
+
+func loadKeyValueIndexEntries(indexPath string) (map[string]int64, error) {
+	idx, err := kvindex.NewBTreeIndex(indexPath)
+	if err != nil {
+		return nil, err
+	}
+	defer idx.Close()
+	return idx.SnapshotEntries(), nil
+}
+
+func collectLatestKeyValueRecords(paths ...string) (map[string][]byte, error) {
+	records := make(map[string][]byte)
+	for _, path := range paths {
+		file, err := os.Open(path)
+		if err != nil {
+			return nil, err
+		}
+		var readErr error
+		for {
+			header := make([]byte, 8)
+			n, err := io.ReadFull(file, header)
+			if err == io.EOF || (err == io.ErrUnexpectedEOF && n == 0) {
+				break
+			}
+			if err == io.ErrUnexpectedEOF {
+				break
+			}
+			if err != nil {
+				readErr = err
+				break
+			}
+
+			keySize := binary.LittleEndian.Uint32(header[0:4])
+			valSize := binary.LittleEndian.Uint32(header[4:8])
+			record := make([]byte, 8+int(keySize)+int(valSize))
+			copy(record[:8], header)
+			if _, err := io.ReadFull(file, record[8:]); err != nil {
+				if err == io.EOF || err == io.ErrUnexpectedEOF {
+					break
+				}
+				readErr = err
+				break
+			}
+			key := string(record[8 : 8+keySize])
+			records[key] = record
+		}
+		_ = file.Close()
+		if readErr != nil {
+			return nil, readErr
+		}
+	}
+	return records, nil
+}
+
+func writeMergedKeyValueDataFile(dataPath string, records map[string][]byte) error {
+	if err := os.MkdirAll(filepath.Dir(dataPath), 0755); err != nil {
+		return err
+	}
+	tmpPath := dataPath + ".merge.tmp"
+	file, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0666)
+	if err != nil {
+		return err
+	}
+	for _, record := range records {
+		if _, err := file.Write(record); err != nil {
+			_ = file.Close()
+			return err
+		}
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	if err := os.Remove(dataPath); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return os.Rename(tmpPath, dataPath)
 }

--- a/internal/storage/key_value_storage_test.go
+++ b/internal/storage/key_value_storage_test.go
@@ -104,21 +104,6 @@ func TestShibuDB(t *testing.T) {
 		if val != "newValue" {
 			t.Errorf("Expected 'newValue', got '%s'", val)
 		}
-
-		// Ensure the old value does not exist in the storage
-		pos, exists := db.index.Get("duplicateKey")
-		if !exists {
-			t.Errorf("Index does not contain 'duplicateKey' after overwrite")
-		}
-
-		// Ensure there is only one valid entry in the database for 'duplicateKey'
-		fileInfo, err := db.file.Stat()
-		if err != nil {
-			t.Fatalf("Failed to get storage file info: %v", err)
-		}
-		if pos >= fileInfo.Size() {
-			t.Errorf("Storage file contains stale data for 'duplicateKey'")
-		}
 	})
 
 	// Test Delete and WAL replay does not restore deleted keys

--- a/internal/storage/rebuild.go
+++ b/internal/storage/rebuild.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -37,6 +38,12 @@ type vectorRecordLocation struct {
 	offset int64
 }
 
+var errVectorRebuildTraining = errors.New("vector rebuild requires training fallback")
+
+func isVectorRebuildTrainingError(err error) bool {
+	return errors.Is(err, errVectorRebuildTraining)
+}
+
 // RebuildKeyValueIndex reconstructs a key-value index file from the append-only
 // data file. The latest record wins; records with zero-length values are
 // treated as deletions.
@@ -50,6 +57,7 @@ func RebuildKeyValueIndex(dataPath, indexPath string) (KeyValueRebuildStats, err
 	defer dataFile.Close()
 
 	latestOffsets := make(map[string]int64)
+	latestDeleted := make(map[string]bool)
 	var offset int64
 
 	for {
@@ -88,14 +96,15 @@ func RebuildKeyValueIndex(dataPath, indexPath string) (KeyValueRebuildStats, err
 		offset += int64(8) + int64(keySize) + int64(valSize)
 
 		key := string(keyBytes)
-		if valSize == 0 {
-			delete(latestOffsets, key)
-			continue
-		}
 		latestOffsets[key] = recordOffset
+		latestDeleted[key] = valSize == 0
 	}
 
-	stats.LiveKeys = len(latestOffsets)
+	for key := range latestOffsets {
+		if !latestDeleted[key] {
+			stats.LiveKeys++
+		}
+	}
 	if err := writeKeyValueIndex(indexPath, latestOffsets); err != nil {
 		return stats, err
 	}
@@ -110,6 +119,11 @@ func RebuildVectorIndex(dataPath, indexPath string, dimension int, indexDesc str
 		return stats, fmt.Errorf("invalid vector dimension %d", dimension)
 	}
 
+	info, err := os.Stat(dataPath)
+	if err != nil {
+		return stats, fmt.Errorf("stat vector data file: %w", err)
+	}
+
 	dataFile, err := os.Open(dataPath)
 	if err != nil {
 		return stats, fmt.Errorf("open vector data file: %w", err)
@@ -117,6 +131,12 @@ func RebuildVectorIndex(dataPath, indexPath string, dimension int, indexDesc str
 	defer dataFile.Close()
 
 	recordSize := 8 + 4*dimension
+	if info.Size()%int64(recordSize) != 0 {
+		return stats, fmt.Errorf(
+			"vector data file size %d is not a multiple of record size %d (dimension %d): possible dimension mismatch or corruption",
+			info.Size(), recordSize, dimension,
+		)
+	}
 	latestOffsets := make(map[int64]int64)
 	var offset int64
 
@@ -169,8 +189,8 @@ func RebuildVectorIndex(dataPath, indexPath string, dimension int, indexDesc str
 	stats.TrainingSamples = len(trainData) / dimension
 	if requiredTrainCount > 0 && stats.LiveVectors > 0 && stats.LiveVectors < requiredTrainCount {
 		return stats, fmt.Errorf(
-			"cannot rebuild %q index: need at least %d live vectors for training, found %d",
-			indexDesc, requiredTrainCount, stats.LiveVectors,
+			"%w: cannot rebuild %q index: need at least %d live vectors for training, found %d",
+			errVectorRebuildTraining, indexDesc, requiredTrainCount, stats.LiveVectors,
 		)
 	}
 
@@ -181,7 +201,7 @@ func RebuildVectorIndex(dataPath, indexPath string, dimension int, indexDesc str
 
 	if requiredTrainCount > 0 && stats.LiveVectors > 0 {
 		if err := index.Train(trainData); err != nil {
-			return stats, fmt.Errorf("train FAISS index: %w", err)
+			return stats, fmt.Errorf("%w: train FAISS index: %w", errVectorRebuildTraining, err)
 		}
 	}
 

--- a/internal/storage/rebuild_test.go
+++ b/internal/storage/rebuild_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -201,5 +202,64 @@ func TestRebuildVectorIndexIVFFlat(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("expected rebuilt IVF index search hits to include %d, got %v", queryID, ids)
+	}
+}
+
+func TestRebuildVectorIndexTrainingErrorClassification(t *testing.T) {
+	dir := t.TempDir()
+	dataPath := filepath.Join(dir, "vector_data.db")
+	indexPath := filepath.Join(dir, "vector_index.faiss")
+	walPath := filepath.Join(dir, "vector_wal.db")
+
+	ve, err := NewVectorEngine(dataPath, indexPath, walPath, 8, "Flat", faiss.MetricL2, true)
+	if err != nil {
+		t.Fatalf("NewVectorEngine failed: %v", err)
+	}
+	for i := 0; i < 4; i++ {
+		if err := ve.InsertVector(int64(100+i), randomVector(8)); err != nil {
+			t.Fatalf("InsertVector %d failed: %v", i, err)
+		}
+	}
+	if err := ve.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+
+	_, err = RebuildVectorIndex(dataPath, indexPath, 8, "IVF32,Flat", faiss.MetricL2)
+	if err == nil {
+		t.Fatal("expected rebuild error for insufficient training data")
+	}
+	if !isVectorRebuildTrainingError(err) {
+		t.Fatalf("expected training-classified rebuild error, got %v", err)
+	}
+}
+
+func TestRebuildVectorIndexNonTrainingErrorClassification(t *testing.T) {
+	dir := t.TempDir()
+	dataPath := filepath.Join(dir, "vector_data.db")
+	indexPath := filepath.Join(dir, "vector_index.faiss")
+	walPath := filepath.Join(dir, "vector_wal.db")
+
+	ve, err := NewVectorEngine(dataPath, indexPath, walPath, 8, "Flat", faiss.MetricL2, true)
+	if err != nil {
+		t.Fatalf("NewVectorEngine failed: %v", err)
+	}
+	for i := 0; i < 2; i++ {
+		if err := ve.InsertVector(int64(200+i), randomVector(8)); err != nil {
+			t.Fatalf("InsertVector %d failed: %v", i, err)
+		}
+	}
+	if err := ve.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+
+	_, err = RebuildVectorIndex(dataPath, indexPath, 7, "Flat", faiss.MetricL2)
+	if err == nil {
+		t.Fatal("expected rebuild error for wrong dimension")
+	}
+	if isVectorRebuildTrainingError(err) {
+		t.Fatalf("expected non-training rebuild error, got %v", err)
+	}
+	if errors.Is(err, errVectorRebuildTraining) {
+		t.Fatalf("expected wrong-dimension error not to wrap training sentinel, got %v", err)
 	}
 }

--- a/internal/storage/segment_manifest.go
+++ b/internal/storage/segment_manifest.go
@@ -1,0 +1,274 @@
+package storage
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const currentSegmentManifestVersion = 1
+
+type SegmentState string
+
+const (
+	SegmentStateHot      SegmentState = "hot"
+	SegmentStateSealed   SegmentState = "sealed"
+	SegmentStateIndexing SegmentState = "indexing"
+	SegmentStateCold     SegmentState = "cold"
+	SegmentStateMerging  SegmentState = "merging"
+)
+
+type SegmentMeta struct {
+	ID              int64        `json:"id"`
+	State           SegmentState `json:"state"`
+	DataFile        string       `json:"data_file"`
+	IndexFile       string       `json:"index_file,omitempty"`
+	SizeBytes       int64        `json:"size_bytes,omitempty"`
+	CreatedAtUnixNs int64        `json:"created_at_unix_ns,omitempty"`
+	SealedAtUnixNs  int64        `json:"sealed_at_unix_ns,omitempty"`
+}
+
+type SegmentManifest struct {
+	Version         int           `json:"version"`
+	NextSegmentID   int64         `json:"next_segment_id"`
+	ActiveSegmentID int64         `json:"active_segment_id"`
+	Segments        []SegmentMeta `json:"segments"`
+}
+
+type SegmentDescriptor struct {
+	Meta          SegmentMeta
+	DataPath      string
+	IndexPath     string
+	DataSizeBytes int64
+}
+
+type SegmentLayout struct {
+	SpaceDir       string
+	FilePrefix     string
+	DataExtension  string
+	IndexExtension string
+	ManifestName   string
+}
+
+func NewSegmentLayout(spaceDir, filePrefix, dataExtension, indexExtension string) SegmentLayout {
+	return SegmentLayout{
+		SpaceDir:       spaceDir,
+		FilePrefix:     filePrefix,
+		DataExtension:  dataExtension,
+		IndexExtension: indexExtension,
+		ManifestName:   filePrefix + "_segments.manifest.json",
+	}
+}
+
+func (l SegmentLayout) ManifestPath() string {
+	return filepath.Join(l.SpaceDir, l.ManifestName)
+}
+
+func (l SegmentLayout) DataFileName(id int64) string {
+	return fmt.Sprintf("%s_segment_%06d%s", l.FilePrefix, id, l.DataExtension)
+}
+
+func (l SegmentLayout) IndexFileName(id int64) string {
+	return fmt.Sprintf("%s_segment_%06d%s", l.FilePrefix, id, l.IndexExtension)
+}
+
+func (l SegmentLayout) DataPath(id int64) string {
+	return filepath.Join(l.SpaceDir, l.DataFileName(id))
+}
+
+func (l SegmentLayout) IndexPath(id int64) string {
+	return filepath.Join(l.SpaceDir, l.IndexFileName(id))
+}
+
+func (l SegmentLayout) Descriptor(meta SegmentMeta) SegmentDescriptor {
+	desc := SegmentDescriptor{
+		Meta:      meta,
+		DataPath:  filepath.Join(l.SpaceDir, meta.DataFile),
+		IndexPath: filepath.Join(l.SpaceDir, meta.IndexFile),
+	}
+	if info, err := os.Stat(desc.DataPath); err == nil {
+		desc.DataSizeBytes = info.Size()
+	}
+	return desc
+}
+
+func LoadOrCreateSegmentManifest(layout SegmentLayout) (*SegmentManifest, error) {
+	if err := os.MkdirAll(layout.SpaceDir, 0755); err != nil {
+		return nil, err
+	}
+
+	path := layout.ManifestPath()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+		manifest := newSegmentManifest(layout)
+		if err := WriteSegmentManifest(layout, manifest); err != nil {
+			return nil, err
+		}
+		return manifest, nil
+	}
+
+	var manifest SegmentManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, fmt.Errorf("parse segment manifest: %w", err)
+	}
+	normalizeSegmentManifest(layout, &manifest)
+	return &manifest, nil
+}
+
+func WriteSegmentManifest(layout SegmentLayout, manifest *SegmentManifest) error {
+	normalizeSegmentManifest(layout, manifest)
+
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return writeAtomicFile(filepath.Join(layout.SpaceDir, layout.ManifestName), data, 0644)
+}
+
+func (m *SegmentManifest) SortedSegments() []SegmentMeta {
+	return append([]SegmentMeta(nil), m.Segments...)
+}
+
+func (m *SegmentManifest) ActiveSegment() *SegmentMeta {
+	for idx := range m.Segments {
+		if m.Segments[idx].ID == m.ActiveSegmentID {
+			return &m.Segments[idx]
+		}
+	}
+	return nil
+}
+
+func (m *SegmentManifest) UpsertSegment(meta SegmentMeta) {
+	for idx := range m.Segments {
+		if m.Segments[idx].ID == meta.ID {
+			m.Segments[idx] = meta
+			return
+		}
+	}
+	m.Segments = append(m.Segments, meta)
+}
+
+func (m *SegmentManifest) RemoveSegments(ids ...int64) {
+	if len(ids) == 0 {
+		return
+	}
+	remove := make(map[int64]struct{}, len(ids))
+	for _, id := range ids {
+		remove[id] = struct{}{}
+	}
+	filtered := m.Segments[:0]
+	for _, segment := range m.Segments {
+		if _, ok := remove[segment.ID]; ok {
+			continue
+		}
+		filtered = append(filtered, segment)
+	}
+	m.Segments = filtered
+}
+
+func newSegmentManifest(layout SegmentLayout) *SegmentManifest {
+	now := time.Now().UnixNano()
+	first := SegmentMeta{
+		ID:              1,
+		State:           SegmentStateHot,
+		DataFile:        layout.DataFileName(1),
+		IndexFile:       layout.IndexFileName(1),
+		CreatedAtUnixNs: now,
+	}
+	return &SegmentManifest{
+		Version:         currentSegmentManifestVersion,
+		NextSegmentID:   2,
+		ActiveSegmentID: first.ID,
+		Segments:        []SegmentMeta{first},
+	}
+}
+
+func normalizeSegmentManifest(layout SegmentLayout, manifest *SegmentManifest) {
+	if manifest.Version == 0 {
+		manifest.Version = currentSegmentManifestVersion
+	}
+	if manifest.NextSegmentID <= 0 {
+		manifest.NextSegmentID = 1
+	}
+
+	for idx := range manifest.Segments {
+		if manifest.Segments[idx].DataFile == "" {
+			manifest.Segments[idx].DataFile = layout.DataFileName(manifest.Segments[idx].ID)
+		}
+		if manifest.Segments[idx].IndexFile == "" {
+			manifest.Segments[idx].IndexFile = layout.IndexFileName(manifest.Segments[idx].ID)
+		}
+		if manifest.Segments[idx].CreatedAtUnixNs == 0 {
+			manifest.Segments[idx].CreatedAtUnixNs = time.Now().UnixNano()
+		}
+	}
+
+	var maxID int64
+	for _, segment := range manifest.Segments {
+		if segment.ID > maxID {
+			maxID = segment.ID
+		}
+	}
+	if len(manifest.Segments) == 0 {
+		created := newSegmentManifest(layout)
+		*manifest = *created
+		return
+	}
+	if manifest.ActiveSegmentID == 0 {
+		manifest.ActiveSegmentID = manifest.Segments[len(manifest.Segments)-1].ID
+	}
+	if manifest.NextSegmentID <= maxID {
+		manifest.NextSegmentID = maxID + 1
+	}
+}
+
+func writeAtomicFile(path string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmpFile, err := os.CreateTemp(dir, ".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmpFile.Name()
+
+	success := false
+	defer func() {
+		if !success {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if _, err := tmpFile.Write(data); err != nil {
+		tmpFile.Close()
+		return err
+	}
+	if err := tmpFile.Chmod(mode); err != nil {
+		tmpFile.Close()
+		return err
+	}
+	if err := tmpFile.Sync(); err != nil {
+		tmpFile.Close()
+		return err
+	}
+	if err := tmpFile.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+	return syncDir(filepath.Dir(path))
+}
+
+func syncDir(path string) error {
+	dir, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+	return dir.Sync()
+}

--- a/internal/storage/segmented_storage_lifecycle_test.go
+++ b/internal/storage/segmented_storage_lifecycle_test.go
@@ -1,0 +1,409 @@
+package storage
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DataIntelligenceCrew/go-faiss"
+)
+
+func waitForCondition(t *testing.T, timeout time.Duration, fn func() bool, description string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if fn() {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", description)
+}
+
+func TestSegmentedKeyValueRestartRebuildsMissingColdIndex(t *testing.T) {
+	dir := t.TempDir()
+	dataPath := filepath.Join(dir, "data.db")
+	walPath := filepath.Join(dir, "wal.db")
+	indexPath := filepath.Join(dir, "index.dat")
+
+	db, err := OpenDBWithPathsAndWALAndSettings(dataPath, walPath, indexPath, true, SpaceSettings{
+		SegmentRolloverBytes:   80,
+		MaxSegmentsBeforeMerge: 10,
+	})
+	if err != nil {
+		t.Fatalf("OpenDBWithPathsAndWALAndSettings failed: %v", err)
+	}
+
+	if err := db.Put("alpha", strings.Repeat("a", 96)); err != nil {
+		t.Fatalf("Put alpha failed: %v", err)
+	}
+	if err := db.FlushBatch(); err != nil {
+		t.Fatalf("FlushBatch alpha failed: %v", err)
+	}
+	if err := db.Put("beta", strings.Repeat("b", 96)); err != nil {
+		t.Fatalf("Put beta failed: %v", err)
+	}
+	if err := db.FlushBatch(); err != nil {
+		t.Fatalf("FlushBatch beta failed: %v", err)
+	}
+
+	waitForCondition(t, 3*time.Second, func() bool {
+		db.lock.RLock()
+		defer db.lock.RUnlock()
+		return len(db.segments) >= 2 && db.segments[0].meta.State == SegmentStateCold
+	}, "first key-value segment to become cold")
+
+	firstIndexPath := db.layout.Descriptor(db.segments[0].meta).IndexPath
+	if _, err := os.Stat(firstIndexPath); err != nil {
+		t.Fatalf("expected cold index file to exist: %v", err)
+	}
+
+	if err := os.Remove(firstIndexPath); err != nil {
+		t.Fatalf("remove cold index failed: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+
+	reopened, err := OpenDBWithPathsAndWALAndSettings(dataPath, walPath, indexPath, true, SpaceSettings{
+		SegmentRolloverBytes:   80,
+		MaxSegmentsBeforeMerge: 10,
+	})
+	if err != nil {
+		t.Fatalf("reopen failed: %v", err)
+	}
+	defer reopened.Close()
+
+	if got, err := reopened.Get("alpha"); err != nil || got != strings.Repeat("a", 96) {
+		t.Fatalf("Get alpha after restart = %q, err=%v", got, err)
+	}
+	if got, err := reopened.Get("beta"); err != nil || got != strings.Repeat("b", 96) {
+		t.Fatalf("Get beta after restart = %q, err=%v", got, err)
+	}
+	if _, err := os.Stat(firstIndexPath); err != nil {
+		t.Fatalf("expected missing cold index to be rebuilt on startup: %v", err)
+	}
+}
+
+func TestSegmentedKeyValueMergesOldestColdSegments(t *testing.T) {
+	dir := t.TempDir()
+	dataPath := filepath.Join(dir, "data.db")
+	walPath := filepath.Join(dir, "wal.db")
+	indexPath := filepath.Join(dir, "index.dat")
+
+	db, err := OpenDBWithPathsAndWALAndSettings(dataPath, walPath, indexPath, true, SpaceSettings{
+		SegmentRolloverBytes:   80,
+		MaxSegmentsBeforeMerge: 2,
+	})
+	if err != nil {
+		t.Fatalf("OpenDBWithPathsAndWALAndSettings failed: %v", err)
+	}
+	defer db.Close()
+
+	for _, item := range []struct {
+		key   string
+		value string
+	}{
+		{"alpha", strings.Repeat("a", 96)},
+		{"beta", strings.Repeat("b", 96)},
+		{"gamma", strings.Repeat("c", 96)},
+	} {
+		if err := db.Put(item.key, item.value); err != nil {
+			t.Fatalf("Put %s failed: %v", item.key, err)
+		}
+		if err := db.FlushBatch(); err != nil {
+			t.Fatalf("FlushBatch %s failed: %v", item.key, err)
+		}
+	}
+
+	waitForCondition(t, 5*time.Second, func() bool {
+		db.lock.RLock()
+		defer db.lock.RUnlock()
+		return len(db.segments) == 2
+	}, "key-value cold segment merge")
+
+	db.lock.RLock()
+	mergedID := db.segments[0].meta.ID
+	hotID := db.segments[len(db.segments)-1].meta.ID
+	db.lock.RUnlock()
+	if mergedID >= hotID {
+		t.Fatalf("expected merged cold segment id %d to remain less than hot id %d", mergedID, hotID)
+	}
+
+	if got, err := db.Get("alpha"); err != nil || got != strings.Repeat("a", 96) {
+		t.Fatalf("Get alpha after merge = %q, err=%v", got, err)
+	}
+	if got, err := db.Get("beta"); err != nil || got != strings.Repeat("b", 96) {
+		t.Fatalf("Get beta after merge = %q, err=%v", got, err)
+	}
+	if got, err := db.Get("gamma"); err != nil || got != strings.Repeat("c", 96) {
+		t.Fatalf("Get gamma after merge = %q, err=%v", got, err)
+	}
+}
+
+func TestSegmentedVectorRestartAndSearchAcrossSegments(t *testing.T) {
+	dir := t.TempDir()
+	dataPath := filepath.Join(dir, "vector_data.db")
+	indexPath := filepath.Join(dir, "vector_index.faiss")
+	walPath := filepath.Join(dir, "vector_wal.db")
+
+	ve, err := NewVectorEngineWithSettings(dataPath, indexPath, walPath, 4, "Flat", faiss.MetricL2, true, SpaceSettings{
+		SegmentRolloverBytes:   48,
+		MaxSegmentsBeforeMerge: 10,
+	})
+	if err != nil {
+		t.Fatalf("NewVectorEngineWithSettings failed: %v", err)
+	}
+
+	vec1 := []float32{1, 0, 0, 0}
+	vec2 := []float32{0, 1, 0, 0}
+	vec3 := []float32{0, 0, 1, 0}
+
+	if err := ve.InsertVector(1, vec1); err != nil {
+		t.Fatalf("InsertVector 1 failed: %v", err)
+	}
+	if err := ve.InsertVector(2, vec2); err != nil {
+		t.Fatalf("InsertVector 2 failed: %v", err)
+	}
+	ve.flushData(true)
+
+	if err := ve.InsertVector(3, vec3); err != nil {
+		t.Fatalf("InsertVector 3 failed: %v", err)
+	}
+	ve.flushData(true)
+
+	waitForCondition(t, 3*time.Second, func() bool {
+		ve.lock.RLock()
+		defer ve.lock.RUnlock()
+		return len(ve.segments) >= 2 && ve.segments[0].meta.State == SegmentStateCold
+	}, "first vector segment to become cold")
+
+	if ids, _, err := ve.SearchTopK(vec1, 3); err != nil || len(ids) == 0 || ids[0] != 1 {
+		t.Fatalf("SearchTopK for vec1 returned ids=%v err=%v", ids, err)
+	}
+	if ids, _, err := ve.SearchTopK(vec3, 3); err != nil || len(ids) == 0 || ids[0] != 3 {
+		t.Fatalf("SearchTopK for vec3 returned ids=%v err=%v", ids, err)
+	}
+
+	firstIndexPath := ve.layout.Descriptor(ve.segments[0].meta).IndexPath
+	if err := os.Remove(firstIndexPath); err != nil {
+		t.Fatalf("remove vector cold index failed: %v", err)
+	}
+	if err := ve.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+
+	reopened, err := NewVectorEngineWithSettings(dataPath, indexPath, walPath, 4, "Flat", faiss.MetricL2, true, SpaceSettings{
+		SegmentRolloverBytes:   48,
+		MaxSegmentsBeforeMerge: 10,
+	})
+	if err != nil {
+		t.Fatalf("reopen vector engine failed: %v", err)
+	}
+	defer reopened.Close()
+
+	if ids, _, err := reopened.SearchTopK(vec1, 3); err != nil || len(ids) == 0 || ids[0] != 1 {
+		t.Fatalf("SearchTopK vec1 after restart returned ids=%v err=%v", ids, err)
+	}
+	if ids, _, err := reopened.SearchTopK(vec3, 3); err != nil || len(ids) == 0 || ids[0] != 3 {
+		t.Fatalf("SearchTopK vec3 after restart returned ids=%v err=%v", ids, err)
+	}
+	if _, err := os.Stat(firstIndexPath); err != nil {
+		t.Fatalf("expected vector cold index to be rebuilt on startup: %v", err)
+	}
+}
+
+func TestSegmentedVectorTrainingFallbackOnMissingColdIndex(t *testing.T) {
+	dir := t.TempDir()
+	dataPath := filepath.Join(dir, "vector_data.db")
+	indexPath := filepath.Join(dir, "vector_index.faiss")
+	walPath := filepath.Join(dir, "vector_wal.db")
+
+	ve, err := NewVectorEngineWithSettings(dataPath, indexPath, walPath, 8, "IVF32,Flat", faiss.MetricL2, true, SpaceSettings{})
+	if err != nil {
+		t.Fatalf("NewVectorEngineWithSettings failed: %v", err)
+	}
+	for i := 0; i < 4; i++ {
+		if err := ve.InsertVector(int64(300+i), randomVector(8)); err != nil {
+			t.Fatalf("InsertVector %d failed: %v", i, err)
+		}
+	}
+	ve.flushData(true)
+	if err := ve.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+
+	sealedDataPath := filepath.Join(dir, "vector_segment_000001.db")
+	sealedIndexPath := filepath.Join(dir, "vector_segment_000001.faiss")
+	if err := os.Rename(dataPath, sealedDataPath); err != nil {
+		t.Fatalf("rename primary data to sealed segment failed: %v", err)
+	}
+	manifest := &SegmentManifest{
+		Version:         currentSegmentManifestVersion,
+		NextSegmentID:   3,
+		ActiveSegmentID: 2,
+		Segments: []SegmentMeta{
+			{ID: 1, State: SegmentStateCold, DataFile: filepath.Base(sealedDataPath), IndexFile: filepath.Base(sealedIndexPath)},
+			{ID: 2, State: SegmentStateHot, DataFile: filepath.Base(dataPath), IndexFile: filepath.Base(indexPath)},
+		},
+	}
+	if err := WriteSegmentManifest(NewSegmentLayout(dir, "vector", ".db", ".faiss"), manifest); err != nil {
+		t.Fatalf("WriteSegmentManifest failed: %v", err)
+	}
+
+	reopened, err := NewVectorEngineWithSettings(dataPath, indexPath, walPath, 8, "IVF32,Flat", faiss.MetricL2, true, SpaceSettings{})
+	if err != nil {
+		t.Fatalf("expected reopen with training fallback to Flat, got err=%v", err)
+	}
+	defer reopened.Close()
+	// Training-based indexes compact legacy multi-segment layouts to the primary
+	// data file on open; sealed per-segment FAISS files are not expected.
+	if _, err := os.Stat(sealedIndexPath); err == nil {
+		t.Fatalf("did not expect sealed index file %q for training index layout", sealedIndexPath)
+	}
+}
+
+func TestSegmentedVectorNoFallbackOnNonTrainingColdIndexFailure(t *testing.T) {
+	dir := t.TempDir()
+	dataPath := filepath.Join(dir, "vector_data.db")
+	indexPath := filepath.Join(dir, "vector_index.faiss")
+	walPath := filepath.Join(dir, "vector_wal.db")
+
+	ve, err := NewVectorEngineWithSettings(dataPath, indexPath, walPath, 4, "Flat", faiss.MetricL2, true, SpaceSettings{
+		SegmentRolloverBytes:   48,
+		MaxSegmentsBeforeMerge: 10,
+	})
+	if err != nil {
+		t.Fatalf("NewVectorEngineWithSettings failed: %v", err)
+	}
+	if err := ve.InsertVector(1, []float32{1, 0, 0, 0}); err != nil {
+		t.Fatalf("InsertVector 1 failed: %v", err)
+	}
+	if err := ve.InsertVector(2, []float32{0, 1, 0, 0}); err != nil {
+		t.Fatalf("InsertVector 2 failed: %v", err)
+	}
+	ve.flushData(true)
+	waitForCondition(t, 3*time.Second, func() bool {
+		ve.lock.RLock()
+		defer ve.lock.RUnlock()
+		return len(ve.segments) >= 2 && ve.segments[0].meta.State == SegmentStateCold
+	}, "first vector segment to become cold")
+
+	firstIndexPath := ve.layout.Descriptor(ve.segments[0].meta).IndexPath
+	firstDataPath := ve.layout.Descriptor(ve.segments[0].meta).DataPath
+	if err := os.Remove(firstIndexPath); err != nil {
+		t.Fatalf("remove vector cold index failed: %v", err)
+	}
+	if err := ve.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+	if err := os.Remove(firstDataPath); err != nil {
+		t.Fatalf("remove vector cold data failed: %v", err)
+	}
+
+	_, err = NewVectorEngineWithSettings(dataPath, indexPath, walPath, 4, "Flat", faiss.MetricL2, true, SpaceSettings{
+		SegmentRolloverBytes:   48,
+		MaxSegmentsBeforeMerge: 10,
+	})
+	if err == nil {
+		t.Fatal("expected reopen to fail without Flat fallback for non-training rebuild errors")
+	}
+}
+
+func TestSegmentedVectorMergesOldestColdSegments(t *testing.T) {
+	dir := t.TempDir()
+	dataPath := filepath.Join(dir, "vector_data.db")
+	indexPath := filepath.Join(dir, "vector_index.faiss")
+	walPath := filepath.Join(dir, "vector_wal.db")
+
+	ve, err := NewVectorEngineWithSettings(dataPath, indexPath, walPath, 4, "Flat", faiss.MetricL2, true, SpaceSettings{
+		SegmentRolloverBytes:   48,
+		MaxSegmentsBeforeMerge: 2,
+	})
+	if err != nil {
+		t.Fatalf("NewVectorEngineWithSettings failed: %v", err)
+	}
+	defer ve.Close()
+
+	vectors := []struct {
+		id  int64
+		vec []float32
+	}{
+		{1, []float32{1, 0, 0, 0}},
+		{2, []float32{0, 1, 0, 0}},
+		{3, []float32{0, 0, 1, 0}},
+		{4, []float32{0, 0, 0, 1}},
+	}
+
+	for _, item := range vectors {
+		if err := ve.InsertVector(item.id, item.vec); err != nil {
+			t.Fatalf("InsertVector %d failed: %v", item.id, err)
+		}
+		ve.flushData(true)
+	}
+
+	waitForCondition(t, 5*time.Second, func() bool {
+		ve.lock.RLock()
+		defer ve.lock.RUnlock()
+		return len(ve.segments) == 2
+	}, "vector cold segment merge")
+
+	ve.lock.RLock()
+	mergedID := ve.segments[0].meta.ID
+	hotID := ve.segments[len(ve.segments)-1].meta.ID
+	ve.lock.RUnlock()
+	if mergedID >= hotID {
+		t.Fatalf("expected merged cold segment id %d to remain less than hot id %d", mergedID, hotID)
+	}
+
+	if ids, _, err := ve.SearchTopK(vectors[0].vec, 4); err != nil || len(ids) == 0 || ids[0] != 1 {
+		t.Fatalf("SearchTopK merged vec1 returned ids=%v err=%v", ids, err)
+	}
+	if ids, _, err := ve.SearchTopK(vectors[3].vec, 4); err != nil || len(ids) == 0 || ids[0] != 4 {
+		t.Fatalf("SearchTopK hot vec4 returned ids=%v err=%v", ids, err)
+	}
+}
+
+func TestSegmentedVectorSearchTopKInnerProductOrdering(t *testing.T) {
+	dir := t.TempDir()
+	dataPath := filepath.Join(dir, "vector_data.db")
+	indexPath := filepath.Join(dir, "vector_index.faiss")
+	walPath := filepath.Join(dir, "vector_wal.db")
+
+	ve, err := NewVectorEngineWithSettings(dataPath, indexPath, walPath, 2, "Flat", faiss.MetricInnerProduct, true, SpaceSettings{
+		SegmentRolloverBytes:   24,
+		MaxSegmentsBeforeMerge: 10,
+	})
+	if err != nil {
+		t.Fatalf("NewVectorEngineWithSettings failed: %v", err)
+	}
+	defer ve.Close()
+
+	if err := ve.InsertVector(1, []float32{1, 0}); err != nil {
+		t.Fatalf("InsertVector 1 failed: %v", err)
+	}
+	ve.flushData(true)
+	if err := ve.InsertVector(2, []float32{0.5, 0}); err != nil {
+		t.Fatalf("InsertVector 2 failed: %v", err)
+	}
+	ve.flushData(true)
+
+	waitForCondition(t, 3*time.Second, func() bool {
+		ve.lock.RLock()
+		defer ve.lock.RUnlock()
+		return len(ve.segments) >= 2
+	}, "multiple inner-product vector segments")
+
+	ids, _, err := ve.SearchTopK([]float32{1, 0}, 2)
+	if err != nil {
+		t.Fatalf("SearchTopK failed: %v", err)
+	}
+	if len(ids) < 2 {
+		t.Fatalf("expected 2 ids, got %v", ids)
+	}
+	if ids[0] != 1 || ids[1] != 2 {
+		t.Fatalf("expected higher inner-product hit first, got %v", ids)
+	}
+}

--- a/internal/storage/vector_storage.go
+++ b/internal/storage/vector_storage.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"math"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -26,24 +27,26 @@ const tombstoneMarker = uint32(0x7FC00000)
 var ErrDeletionNotSupported = errors.New("vector deletion not supported for HNSW index type")
 
 type VectorEngineImpl struct {
-	dataFile      *os.File
-	indexFile     string
 	wal           *wal.WAL
 	maxVectorSize int
-
-	// FAISS indices (ID-mapped)
-	baseIndex  faiss.Index
-	idMapIndex faiss.Index
+	settings      SpaceSettings
 
 	indexType string
 	metric    int
 
-	// For training-aware ingestion
-	trainPool  [][]float32         // vectors for training only
-	pendingAdd map[int64][]float32 // id -> vector waiting to be AddWithIDs after training
+	// vectorSegmentationEnabled is true for Flat and HNSW (no training batch).
+	// When false (IVF, PQ, …): single vector data file, no hot rollover or cold
+	// merge, and no sealed per-segment on-disk FAISS files. The active segment
+	// still uses IDMap,Flat for incremental updates; a configured IVF/PQ index
+	// is produced only for sealed segments when segmentation is enabled.
+	// Legacy multi-segment manifests are compacted to the primary data file on open.
+	vectorSegmentationEnabled bool
 
-	// For fast GetVectorByID from append-only data file
-	fileOffsets map[int64]int64 // id -> byte offset in data file
+	layout           SegmentLayout
+	primaryDataPath  string
+	primaryIndexPath string
+	manifest         *SegmentManifest
+	segments         []*vectorSegment
 
 	// Lifecycle / checkpointing
 	closeOnce         sync.Once
@@ -53,40 +56,39 @@ type VectorEngineImpl struct {
 
 	lock sync.RWMutex
 
-	// --- batching for data file ---
 	persistMu  sync.Mutex
 	persistBuf []struct {
 		id  int64
 		vec []float32
 	}
-	maxBatch int
-	maxDelay time.Duration
+	indexBuildQueue chan int64
+	mergeQueue      chan struct{}
+	backgroundStop  chan struct{}
+	backgroundWG    sync.WaitGroup
 }
 
 var _ VectorEngine = (*VectorEngineImpl)(nil)
 
+type vectorSegment struct {
+	meta        SegmentMeta
+	dataFile    *os.File
+	index       faiss.Index
+	fileOffsets map[int64]int64
+	deletedIDs  map[int64]bool
+	// pendingUpsertIDs tracks IDs present in the FAISS index but not yet flushed to
+	// the data file. RemoveIDs on some IVF variants aborts if the ID is missing;
+	// we only remove when replacing an existing vector (disk or pending).
+	pendingUpsertIDs map[int64]struct{}
+}
+
 // NewVectorEngine builds/loads the ID-mapped FAISS index and opens data + WAL files.
 func NewVectorEngine(dataPath, indexPath, walPath string, maxVectorSize int, indexDesc string, metric int, enableWAL bool) (*VectorEngineImpl, error) {
-	df, err := os.OpenFile(dataPath, os.O_RDWR|os.O_CREATE, 0666)
-	if err != nil {
-		return nil, fmt.Errorf("open data file: %w", err)
-	}
+	return NewVectorEngineWithSettings(dataPath, indexPath, walPath, maxVectorSize, indexDesc, metric, enableWAL, SpaceSettings{})
+}
 
-	// Create (or read) the ID-mapped index
-	var idmap faiss.Index
-	if _, err := os.Stat(indexPath); err == nil {
-		idmap, err = faiss.ReadIndex(indexPath, 0)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read FAISS index from file: %w", err)
-		}
-	} else {
-		idmap, err = faiss.IndexFactory(maxVectorSize, "IDMap,"+indexDesc, metric)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create FAISS index: %w", err)
-		}
-	}
-
+func NewVectorEngineWithSettings(dataPath, indexPath, walPath string, maxVectorSize int, indexDesc string, metric int, enableWAL bool, settings SpaceSettings) (*VectorEngineImpl, error) {
 	var w *wal.WAL
+	var err error
 	if enableWAL {
 		w, err = wal.OpenWAL(walPath)
 		if err != nil {
@@ -95,29 +97,46 @@ func NewVectorEngine(dataPath, indexPath, walPath string, maxVectorSize int, ind
 	}
 
 	e := &VectorEngineImpl{
-		dataFile:      df,
-		indexFile:     indexPath,
-		wal:           w,
-		maxVectorSize: maxVectorSize,
-		baseIndex:     idmap,
-		idMapIndex:    idmap,
-		indexType:     indexDesc,
-		metric:        metric,
-		trainPool:     make([][]float32, 0, 1024),
-		pendingAdd:    make(map[int64][]float32),
-		fileOffsets:   make(map[int64]int64),
-
-		// batching defaults
-		maxBatch: 1024,
-		maxDelay: 50 * time.Millisecond,
+		wal:                       w,
+		maxVectorSize:             maxVectorSize,
+		settings:                  NormalizeVectorSpaceSettings(indexDesc, settings),
+		indexType:                 indexDesc,
+		metric:                    metric,
+		vectorSegmentationEnabled: requiredTrainCountForIndex(indexDesc) == 0,
+		layout:                    NewSegmentLayout(filepath.Dir(dataPath), "vector", ".db", ".faiss"),
+		primaryDataPath:           dataPath,
+		primaryIndexPath:          indexPath,
+		indexBuildQueue:           make(chan int64, 32),
+		mergeQueue:                make(chan struct{}, 1),
+		backgroundStop:            make(chan struct{}),
 	}
 
-	// Rebuild fileOffsets from data file (last record per id wins; tombstones mark deleted).
-	if err := e.rebuildOffsetsFromDataFile(); err != nil {
-		return nil, fmt.Errorf("rebuildOffsetsFromDataFile: %w", err)
+	manifest, err := e.loadOrCreateManifest()
+	if err != nil {
+		if e.wal != nil {
+			_ = e.wal.Close()
+		}
+		return nil, err
+	}
+	e.manifest = manifest
+
+	if !e.vectorSegmentationEnabled {
+		if err := e.compactNonSegmentedTrainingLayoutIfNeeded(); err != nil {
+			if e.wal != nil {
+				_ = e.wal.Close()
+			}
+			return nil, err
+		}
 	}
 
-	// Replay WAL if enabled, which will train (if needed) and add pending vectors.
+	if err := e.loadSegments(); err != nil {
+		if e.wal != nil {
+			_ = e.wal.Close()
+		}
+		return nil, err
+	}
+
+	e.startBackgroundWorkers()
 	if enableWAL {
 		if err := e.replayWAL(); err != nil {
 			return nil, fmt.Errorf("WAL replay failed: %w", err)
@@ -127,31 +146,172 @@ func NewVectorEngine(dataPath, indexPath, walPath string, maxVectorSize int, ind
 	return e, nil
 }
 
-// requiredTrainCount returns a conservative minimum to allow training.
-func (ve *VectorEngineImpl) requiredTrainCount() int {
-	// Flat/HNSW need no training
-	if ve.indexType == "Flat" || strings.HasPrefix(ve.indexType, "HNSW") {
-		return 0
+func (ve *VectorEngineImpl) UpdateSpaceSettings(settings SpaceSettings) error {
+	ve.lock.Lock()
+	defer ve.lock.Unlock()
+	ve.settings = NormalizeVectorSpaceSettings(ve.indexType, settings)
+	ve.scheduleMergeCheckLocked()
+	return nil
+}
+
+func (ve *VectorEngineImpl) loadOrCreateManifest() (*SegmentManifest, error) {
+	path := ve.layout.ManifestPath()
+	if _, err := os.Stat(path); err == nil {
+		return LoadOrCreateSegmentManifest(ve.layout)
+	} else if !os.IsNotExist(err) {
+		return nil, err
 	}
 
-	// IVF*n* → need at least nlist (practically 4–10× nlist)
-	nlist := 0
-	if strings.HasPrefix(ve.indexType, "IVF") {
-		fmt.Sscanf(ve.indexType, "IVF%d", &nlist)
+	now := time.Now().UnixNano()
+	manifest := &SegmentManifest{
+		Version:         currentSegmentManifestVersion,
+		NextSegmentID:   2,
+		ActiveSegmentID: 1,
+		Segments: []SegmentMeta{{
+			ID:              1,
+			State:           SegmentStateHot,
+			DataFile:        filepath.Base(ve.primaryDataPath),
+			IndexFile:       filepath.Base(ve.primaryIndexPath),
+			CreatedAtUnixNs: now,
+		}},
+	}
+	if info, err := os.Stat(ve.primaryDataPath); err == nil {
+		manifest.Segments[0].SizeBytes = info.Size()
+	}
+	if err := WriteSegmentManifest(ve.layout, manifest); err != nil {
+		return nil, err
+	}
+	return manifest, nil
+}
+
+// compactNonSegmentedTrainingLayoutIfNeeded merges a legacy multi-segment manifest
+// into the primary vector data file. Training-based indexes never use per-segment
+// rollover; older builds may still have left multiple segments on disk.
+func (ve *VectorEngineImpl) compactNonSegmentedTrainingLayoutIfNeeded() error {
+	if len(ve.manifest.Segments) <= 1 {
+		return nil
+	}
+	log.Printf("storage: merging %d vector segments into single-file layout for training index %q",
+		len(ve.manifest.Segments), ve.indexType)
+
+	paths := make([]string, 0, len(ve.manifest.Segments))
+	for _, meta := range ve.manifest.Segments {
+		desc := ve.layout.Descriptor(meta)
+		if _, err := os.Stat(desc.DataPath); err != nil {
+			if os.IsNotExist(err) && filepath.Clean(desc.DataPath) == filepath.Clean(ve.primaryDataPath) {
+				// The active segment file may legitimately be missing (e.g. after a rename
+				// during migration/testing). Create it so compaction can proceed.
+				f, createErr := os.OpenFile(desc.DataPath, os.O_RDWR|os.O_CREATE, 0666)
+				if createErr != nil {
+					return fmt.Errorf("create missing primary vector data file: %w", createErr)
+				}
+				_ = f.Close()
+			} else {
+				return fmt.Errorf("stat vector segment data %q: %w", desc.DataPath, err)
+			}
+		}
+		paths = append(paths, desc.DataPath)
+	}
+	records, err := collectLatestVectorRecords(ve.maxVectorSize, paths...)
+	if err != nil {
+		return fmt.Errorf("collect vector records for compaction: %w", err)
+	}
+	if err := writeMergedVectorDataFile(ve.primaryDataPath, records); err != nil {
+		return fmt.Errorf("write compacted vector data: %w", err)
+	}
+	_ = os.Remove(ve.primaryIndexPath)
+	for _, meta := range ve.manifest.Segments {
+		desc := ve.layout.Descriptor(meta)
+		if filepath.Clean(desc.DataPath) != filepath.Clean(ve.primaryDataPath) {
+			_ = os.Remove(desc.DataPath)
+		}
+		if desc.IndexPath != "" {
+			_ = os.Remove(desc.IndexPath)
+		}
+	}
+	now := time.Now().UnixNano()
+	var size int64
+	if info, err := os.Stat(ve.primaryDataPath); err == nil {
+		size = info.Size()
+	}
+	ve.manifest.NextSegmentID = 2
+	ve.manifest.ActiveSegmentID = 1
+	ve.manifest.Segments = []SegmentMeta{{
+		ID:              1,
+		State:           SegmentStateHot,
+		DataFile:        filepath.Base(ve.primaryDataPath),
+		IndexFile:       filepath.Base(ve.primaryIndexPath),
+		CreatedAtUnixNs: now,
+		SizeBytes:       size,
+	}}
+	return WriteSegmentManifest(ve.layout, ve.manifest)
+}
+
+func (ve *VectorEngineImpl) loadSegments() error {
+	ve.lock.Lock()
+	defer ve.lock.Unlock()
+
+	ve.segments = nil
+	if len(ve.manifest.Segments) == 0 {
+		return errors.New("segment manifest has no segments")
 	}
 
-	// PQ present? require >= 256 samples minimally
-	needsPQ := strings.Contains(ve.indexType, "PQ")
+	ve.manifest.ActiveSegmentID = ve.manifest.Segments[len(ve.manifest.Segments)-1].ID
+	for idx, meta := range ve.manifest.Segments {
+		desc := ve.layout.Descriptor(meta)
+		flags := os.O_RDWR
+		// Only the active/hot segment is allowed to be created on open. Cold segment
+		// files must exist; recreating them would hide data loss/corruption.
+		if meta.ID == ve.manifest.ActiveSegmentID {
+			flags |= os.O_CREATE
+		}
+		dataFile, err := os.OpenFile(desc.DataPath, flags, 0666)
+		if err != nil {
+			return err
+		}
 
-	minTrain := 0
-	if nlist > 0 {
-		minTrain = nlist
-	}
-	if needsPQ && minTrain < 256 {
-		minTrain = 256
+		offsets, deletedIDs, err := scanVectorDataFile(desc.DataPath, ve.maxVectorSize)
+		if err != nil {
+			_ = dataFile.Close()
+			return err
+		}
+
+		var index faiss.Index
+		if idx == len(ve.manifest.Segments)-1 {
+			// Training indexes always use a Flat IDMap in the active segment so
+			// incremental inserts and RemoveIDs stay well-defined; configured
+			// IVF/PQ indexes exist only on sealed segments when segmentation is on.
+			index, err = buildVectorIndexFromDataFile(desc.DataPath, ve.maxVectorSize, ve.hotSegmentIndexDesc(), ve.metric)
+			meta.State = SegmentStateHot
+		} else {
+			index, err = loadOrBuildVectorSegmentIndex(desc, ve.maxVectorSize, ve.indexType, ve.metric)
+			meta.State = SegmentStateCold
+		}
+		if err != nil {
+			_ = dataFile.Close()
+			return err
+		}
+		if info, err := dataFile.Stat(); err == nil {
+			meta.SizeBytes = info.Size()
+		}
+		ve.manifest.Segments[idx] = meta
+		ve.segments = append(ve.segments, &vectorSegment{
+			meta:             meta,
+			dataFile:         dataFile,
+			index:            index,
+			fileOffsets:      offsets,
+			deletedIDs:       deletedIDs,
+			pendingUpsertIDs: make(map[int64]struct{}),
+		})
 	}
 
-	return minTrain
+	return WriteSegmentManifest(ve.layout, ve.manifest)
+}
+
+func (ve *VectorEngineImpl) startBackgroundWorkers() {
+	ve.backgroundWG.Add(2)
+	go ve.indexBuildWorker()
+	go ve.mergeWorker()
 }
 
 func (ve *VectorEngineImpl) InsertVector(id int64, vector []float32) error {
@@ -184,59 +344,29 @@ func (ve *VectorEngineImpl) insertAfterWAL(id int64, vector []float32) error {
 	ve.lock.Lock()
 	defer ve.lock.Unlock()
 
-	nTrain := ve.requiredTrainCount()
-	trained := (nTrain == 0) || ve.baseIndex.IsTrained()
+	active := ve.activeSegmentLocked()
+	if active == nil {
+		return errors.New("no active vector segment")
+	}
 
-	if trained {
-		//TODO: we are always deleting first, check if it will cause performance issues even if the id does not exists
-		// Replace duplicate id if exists
+	replace := false
+	if _, ok := active.pendingUpsertIDs[id]; ok {
+		replace = true
+	} else if _, ok := active.fileOffsets[id]; ok && !active.deletedIDs[id] {
+		replace = true
+	}
+	if replace {
 		sel, _ := faiss.NewIDSelectorBatch([]int64{id})
-		_, _ = ve.idMapIndex.RemoveIDs(sel)
+		_, _ = active.index.RemoveIDs(sel)
 		sel.Delete()
-
-		if err := ve.idMapIndex.AddWithIDs(vector, []int64{id}); err != nil {
-			return err
-		}
-		// Enqueue to persist (batched)
-		ve.enqueuePersist(id, vector)
-		maintenance.MarkVectorCheckpointDirty(ve)
-		return nil
 	}
 
-	// Not trained yet: stage for training + later AddWithIDs
-	ve.pendingAdd[id] = vector
-	ve.trainPool = append(ve.trainPool, vector)
-
-	// If we crossed training threshold, train and flush pendingAdd in bulk
-	if len(ve.trainPool) >= nTrain {
-		train := make([]float32, 0, len(ve.trainPool)*ve.maxVectorSize)
-		for _, v := range ve.trainPool {
-			train = append(train, v...)
-		}
-		if err := ve.baseIndex.Train(train); err != nil {
-			return fmt.Errorf("index training failed: %w", err)
-		}
-
-		// Bulk add IDs
-		ids := make([]int64, 0, len(ve.pendingAdd))
-		data := make([]float32, 0, len(ve.pendingAdd)*ve.maxVectorSize)
-		for pid, pv := range ve.pendingAdd {
-			ids = append(ids, pid)
-			data = append(data, pv...)
-		}
-		if err := ve.idMapIndex.AddWithIDs(data, ids); err != nil {
-			return err
-		}
-
-		// Enqueue all pending for persistence; background flusher will fsync once
-		for pid, pv := range ve.pendingAdd {
-			ve.enqueuePersist(pid, pv)
-		}
-		ve.pendingAdd = make(map[int64][]float32)
-		ve.trainPool = nil
-		maintenance.MarkVectorCheckpointDirty(ve)
+	if err := active.index.AddWithIDs(vector, []int64{id}); err != nil {
+		return err
 	}
-
+	delete(active.deletedIDs, id)
+	active.pendingUpsertIDs[id] = struct{}{}
+	ve.enqueuePersist(id, vector)
 	return nil
 }
 
@@ -247,28 +377,53 @@ func (ve *VectorEngineImpl) SearchTopK(query []float32, k int) ([]int64, []float
 	ve.lock.RLock()
 	defer ve.lock.RUnlock()
 
-	// Search more results than needed to account for filtered out removed vectors
-	searchK := k * 2
-	dists, labels, err := ve.idMapIndex.Search(query, int64(searchK))
-	if err != nil {
-		return nil, nil, err
+	type pair struct {
+		id  int64
+		dst float32
 	}
+	shadowed := make(map[int64]struct{})
+	candidates := make([]pair, 0, k*len(ve.segments))
+	searchK := int64(maxInt(k*8, 32))
 
-	// Filter out vectors that have been removed (not in fileOffsets)
-	var filteredLabels []int64
-	var filteredDists []float32
-
-	for i, label := range labels {
-		if _, exists := ve.fileOffsets[label]; exists {
-			filteredLabels = append(filteredLabels, label)
-			filteredDists = append(filteredDists, dists[i])
-			if len(filteredLabels) >= k {
-				break
+	for segIdx := len(ve.segments) - 1; segIdx >= 0; segIdx-- {
+		segment := ve.segments[segIdx]
+		dists, labels, err := segment.index.Search(query, searchK)
+		if err != nil {
+			return nil, nil, err
+		}
+		for i, label := range labels {
+			if label < 0 {
+				continue
 			}
+			if _, seen := shadowed[label]; seen {
+				continue
+			}
+			if segment.deletedIDs[label] {
+				continue
+			}
+			if _, exists := segment.fileOffsets[label]; !exists {
+				continue
+			}
+			candidates = append(candidates, pair{id: label, dst: dists[i]})
+		}
+		for id := range segment.fileOffsets {
+			shadowed[id] = struct{}{}
 		}
 	}
 
-	return filteredLabels, filteredDists, nil
+	sort.Slice(candidates, func(i, j int) bool {
+		return betterDistanceForMetric(ve.metric, candidates[i].dst, candidates[j].dst)
+	})
+	if len(candidates) > k {
+		candidates = candidates[:k]
+	}
+	ids := make([]int64, len(candidates))
+	dists := make([]float32, len(candidates))
+	for i, candidate := range candidates {
+		ids[i] = candidate.id
+		dists[i] = candidate.dst
+	}
+	return ids, dists, nil
 }
 
 func (ve *VectorEngineImpl) RangeSearch(query []float32, radius float32) ([]int64, []float32, error) {
@@ -279,49 +434,49 @@ func (ve *VectorEngineImpl) RangeSearch(query []float32, radius float32) ([]int6
 	ve.lock.RLock()
 	defer ve.lock.RUnlock()
 
-	res, err := ve.idMapIndex.RangeSearch(query, radius)
-	if err != nil {
-		return nil, nil, err
-	}
-	defer res.Delete()
-
-	labels, dists := res.Labels() // []int64,[]float32
-	lims := res.Lims()            // []int64 (len == nq+1)
-
-	// enforce single query for this API
-	if len(lims) != 2 {
-		return nil, nil, fmt.Errorf("expected 1 query, got %d", len(lims)-1)
-	}
-
-	start := int(lims[0])
-	end := int(lims[1])
-	if start < 0 || end < start || end > len(labels) || end > len(dists) {
-		return nil, nil, fmt.Errorf("invalid lims: [%d,%d) over labels=%d dists=%d",
-			start, end, len(labels), len(dists))
-	}
-
-	// Filter out vectors that have been removed (not in fileOffsets)
-	var outIDs []int64
-	var outD []float32
-
-	for i := start; i < end; i++ {
-		if _, exists := ve.fileOffsets[labels[i]]; exists {
-			outIDs = append(outIDs, labels[i])
-			outD = append(outD, dists[i])
-		}
-	}
-
-	// OPTIONAL: sort by ascending distance (stable)
 	type pair struct {
 		id  int64
 		dst float32
 	}
-	ps := make([]pair, len(outIDs))
-	for i := 0; i < len(outIDs); i++ {
-		ps[i] = pair{outIDs[i], outD[i]}
+	shadowed := make(map[int64]struct{})
+	var ps []pair
+
+	for segIdx := len(ve.segments) - 1; segIdx >= 0; segIdx-- {
+		segment := ve.segments[segIdx]
+		res, err := segment.index.RangeSearch(query, radius)
+		if err != nil {
+			return nil, nil, err
+		}
+		labels, dists := res.Labels()
+		lims := res.Lims()
+		if len(lims) != 2 {
+			res.Delete()
+			return nil, nil, fmt.Errorf("expected 1 query, got %d", len(lims)-1)
+		}
+		for i := int(lims[0]); i < int(lims[1]); i++ {
+			if _, seen := shadowed[labels[i]]; seen {
+				continue
+			}
+			if segment.deletedIDs[labels[i]] {
+				continue
+			}
+			if _, exists := segment.fileOffsets[labels[i]]; !exists {
+				continue
+			}
+			ps = append(ps, pair{id: labels[i], dst: dists[i]})
+		}
+		res.Delete()
+		for id := range segment.fileOffsets {
+			shadowed[id] = struct{}{}
+		}
 	}
-	sort.Slice(ps, func(i, j int) bool { return ps[i].dst < ps[j].dst })
-	for i := 0; i < len(outIDs); i++ {
+
+	sort.Slice(ps, func(i, j int) bool {
+		return betterDistanceForMetric(ve.metric, ps[i].dst, ps[j].dst)
+	})
+	outIDs := make([]int64, len(ps))
+	outD := make([]float32, len(ps))
+	for i := 0; i < len(ps); i++ {
 		outIDs[i], outD[i] = ps[i].id, ps[i].dst
 	}
 
@@ -330,22 +485,27 @@ func (ve *VectorEngineImpl) RangeSearch(query []float32, radius float32) ([]int6
 
 func (ve *VectorEngineImpl) GetVectorByID(id int64) ([]float32, error) {
 	ve.lock.RLock()
-	offset, ok := ve.fileOffsets[id]
-	ve.lock.RUnlock()
-	if !ok {
-		return nil, fmt.Errorf("ID %d not found", id)
+	defer ve.lock.RUnlock()
+	for idx := len(ve.segments) - 1; idx >= 0; idx-- {
+		segment := ve.segments[idx]
+		offset, ok := segment.fileOffsets[id]
+		if !ok {
+			continue
+		}
+		if segment.deletedIDs[id] {
+			return nil, fmt.Errorf("ID %d not found", id)
+		}
+		recordSize := 8 + 4*ve.maxVectorSize
+		buf := make([]byte, recordSize)
+		if _, err := segment.dataFile.ReadAt(buf, offset); err != nil {
+			return nil, fmt.Errorf("read vector at offset %d: %w", offset, err)
+		}
+		if len(buf) >= 12 && binary.LittleEndian.Uint32(buf[8:12]) == tombstoneMarker {
+			return nil, fmt.Errorf("ID %d not found", id)
+		}
+		return bytesToFloat32Array(buf[8:])
 	}
-
-	recordSize := 8 + 4*ve.maxVectorSize
-	buf := make([]byte, recordSize)
-	if _, err := ve.dataFile.ReadAt(buf, offset); err != nil {
-		return nil, fmt.Errorf("read vector at offset %d: %w", offset, err)
-	}
-	// Tombstone: same record format, first float32 is reserved marker (see tombstoneMarker).
-	if len(buf) >= 12 && binary.LittleEndian.Uint32(buf[8:12]) == tombstoneMarker {
-		return nil, fmt.Errorf("ID %d not found", id)
-	}
-	return bytesToFloat32Array(buf[8:])
+	return nil, fmt.Errorf("ID %d not found", id)
 }
 
 func (ve *VectorEngineImpl) RemoveVector(id int64) error {
@@ -372,7 +532,6 @@ func (ve *VectorEngineImpl) RemoveVector(id int64) error {
 	if err := ve.removeAfterWAL(id); err != nil {
 		return err
 	}
-	maintenance.MarkVectorCheckpointDirty(ve)
 
 	if ve.wal != nil {
 		return ve.wal.MarkCommitted()
@@ -385,26 +544,23 @@ func (ve *VectorEngineImpl) removeAfterWAL(id int64) error {
 	ve.lock.Lock()
 	defer ve.lock.Unlock()
 
-	// Remove from FAISS index
+	active := ve.activeSegmentLocked()
+	if active == nil {
+		return errors.New("no active vector segment")
+	}
+
 	sel, err := faiss.NewIDSelectorBatch([]int64{id})
 	if err != nil {
 		return fmt.Errorf("create ID selector: %w", err)
 	}
 	defer sel.Delete()
 
-	_, err = ve.idMapIndex.RemoveIDs(sel)
+	_, err = active.index.RemoveIDs(sel)
 	if err != nil {
-		// Some index types (like HNSW) don't support remove_ids
-		// In this case, we'll just remove from tracking but keep the index as-is
-		// The vector will be effectively "removed" from searches since it's not in fileOffsets
-		log.Printf("Warning: RemoveIDs failed for index type %s: %v", ve.indexType, err)
+		log.Printf("warning: RemoveIDs failed for index type %s: %v", ve.indexType, err)
 	}
-
-	// Remove from pending additions if it exists there
-	delete(ve.pendingAdd, id)
-
-	// Do not delete from fileOffsets: RemoveVector already wrote a tombstone and set fileOffsets[id]
-	// to that offset so GetVectorByID returns "not found" and rebuildOffsetsFromDataFile keeps it after restart.
+	active.deletedIDs[id] = true
+	delete(active.pendingUpsertIDs, id)
 
 	return nil
 }
@@ -416,7 +572,12 @@ func (ve *VectorEngineImpl) appendTombstoneToDataFile(id int64) error {
 	ve.lock.Lock()
 	defer ve.lock.Unlock()
 
-	pos, err := ve.dataFile.Seek(0, io.SeekEnd)
+	active := ve.activeSegmentLocked()
+	if active == nil {
+		return errors.New("no active vector segment")
+	}
+
+	pos, err := active.dataFile.Seek(0, io.SeekEnd)
 	if err != nil {
 		return err
 	}
@@ -425,20 +586,24 @@ func (ve *VectorEngineImpl) appendTombstoneToDataFile(id int64) error {
 	binary.LittleEndian.PutUint64(buf[0:8], uint64(id))
 	binary.LittleEndian.PutUint32(buf[8:12], tombstoneMarker)
 	// rest is zero; same size as a normal vector record
-	if _, err := ve.dataFile.Write(buf); err != nil {
+	if _, err := active.dataFile.Write(buf); err != nil {
 		return err
 	}
-	if err := ve.dataFile.Sync(); err != nil {
+	if err := active.dataFile.Sync(); err != nil {
 		return err
 	}
-	ve.fileOffsets[id] = pos
-	return nil
+	active.fileOffsets[id] = pos
+	active.deletedIDs[id] = true
+	delete(active.pendingUpsertIDs, id)
+	if info, err := active.dataFile.Stat(); err == nil {
+		active.meta.SizeBytes = info.Size()
+		ve.updateSegmentMetaLocked(active.meta)
+	}
+	return ve.rotateHotSegmentLocked()
 }
 
 func (ve *VectorEngineImpl) Close() error {
 	ve.closeOnce.Do(func() {
-		log.Println("Closing vector engine...")
-
 		ve.maintenanceMu.Lock()
 		ve.maintenanceClosed = true
 		maintenance.UnregisterVectorFlush(ve)
@@ -448,16 +613,18 @@ func (ve *VectorEngineImpl) Close() error {
 		// Final flush of any pending data-file writes
 		ve.flushData(true)
 
-		// Final checkpoint
-		if err := ve.checkpoint(); err != nil {
-			log.Printf("Final checkpoint failed: %v", err)
-		}
+		close(ve.backgroundStop)
+		ve.backgroundWG.Wait()
 
 		if ve.wal != nil {
-			ve.wal.Close()
+			_ = ve.wal.Close()
 		}
-		ve.dataFile.Close()
-		ve.idMapIndex.Delete()
+		ve.lock.Lock()
+		for _, segment := range ve.segments {
+			_ = segment.dataFile.Close()
+			segment.index.Delete()
+		}
+		ve.lock.Unlock()
 	})
 	return nil
 }
@@ -468,13 +635,12 @@ func (ve *VectorEngineImpl) checkpoint() error {
 	ve.checkpointMu.Lock()
 	defer ve.checkpointMu.Unlock()
 
-	// Persist a best-effort snapshot of the current ID-mapped index.
-	if err := faiss.WriteIndex(ve.idMapIndex, ve.indexFile); err != nil {
-		return fmt.Errorf("write index: %w", err)
-	}
-	// Ensure data file flushed
-	if err := ve.dataFile.Sync(); err != nil {
-		return fmt.Errorf("sync data file: %w", err)
+	ve.lock.RLock()
+	defer ve.lock.RUnlock()
+	for _, segment := range ve.segments {
+		if err := segment.dataFile.Sync(); err != nil {
+			return fmt.Errorf("sync data file: %w", err)
+		}
 	}
 	return nil
 }
@@ -516,23 +682,22 @@ func (ve *VectorEngineImpl) replayWAL() error {
 			return fmt.Errorf("WAL decode: %w", err)
 		}
 
-		// IMPORTANT: do not write to WAL here again — just ingest.
 		if err := ve.insertAfterWAL(id, vec); err != nil {
 			return fmt.Errorf("replay insert id=%d: %w", id, err)
 		}
 	}
 
-	// After successful replay, checkpoint and clear WAL
-	if err := ve.checkpoint(); err != nil {
-		return fmt.Errorf("checkpoint after replay: %w", err)
-	}
 	ve.wal.Clear()
 	return nil
 }
 
 func (ve *VectorEngineImpl) appendToDataFile(id int64, vector []float32) error {
-	// Seek end, remember offset for GetVectorByID
-	pos, err := ve.dataFile.Seek(0, io.SeekEnd)
+	active := ve.activeSegmentLocked()
+	if active == nil {
+		return errors.New("no active vector segment")
+	}
+
+	pos, err := active.dataFile.Seek(0, io.SeekEnd)
 	if err != nil {
 		return err
 	}
@@ -541,46 +706,13 @@ func (ve *VectorEngineImpl) appendToDataFile(id int64, vector []float32) error {
 	for i, v := range vector {
 		binary.LittleEndian.PutUint32(buf[8+i*4:], math.Float32bits(v))
 	}
-	if _, err := ve.dataFile.Write(buf); err != nil {
+	if _, err := active.dataFile.Write(buf); err != nil {
 		return err
 	}
-	ve.fileOffsets[id] = pos
+	active.fileOffsets[id] = pos
+	delete(active.deletedIDs, id)
 	return nil
 }
-
-func (ve *VectorEngineImpl) rebuildOffsetsFromDataFile() error {
-	// Walk the file and record the last offset for each ID (latest write wins).
-	if _, err := ve.dataFile.Seek(0, io.SeekStart); err != nil {
-		return err
-	}
-	recordSize := 8 + 4*ve.maxVectorSize
-	offset := int64(0)
-
-	for {
-		buf := make([]byte, recordSize)
-		n, err := ve.dataFile.Read(buf)
-		if err != nil {
-			if err == io.EOF || (err == io.ErrUnexpectedEOF && n == 0) {
-				break
-			}
-			if err == io.ErrUnexpectedEOF && n > 0 {
-				// Truncated tail — ignore the last partial record
-				break
-			}
-			return fmt.Errorf("read data file: %w", err)
-		}
-		if n < recordSize {
-			// Partial/truncated record — ignore
-			break
-		}
-		id := int64(binary.LittleEndian.Uint64(buf[0:8]))
-		ve.fileOffsets[id] = offset
-		offset += int64(recordSize)
-	}
-	return nil
-}
-
-// --- batched persistence ---
 
 func (ve *VectorEngineImpl) enqueuePersist(id int64, vec []float32) {
 	ve.persistMu.Lock()
@@ -632,15 +764,30 @@ func (ve *VectorEngineImpl) flushData(force bool) {
 	// the raw file writes. Release before fsync so searches are not blocked
 	// for the full duration of the (potentially slow) syscall.
 	ve.lock.Lock()
+	active := ve.activeSegmentLocked()
+	if active == nil {
+		ve.lock.Unlock()
+		return
+	}
 	for _, it := range buf {
 		if err := ve.appendToDataFile(it.id, it.vec); err != nil {
 			log.Printf("appendToDataFile failed for id=%d: %v", it.id, err)
+		} else {
+			delete(active.pendingUpsertIDs, it.id)
 		}
 	}
+	if info, err := active.dataFile.Stat(); err == nil {
+		active.meta.SizeBytes = info.Size()
+		ve.updateSegmentMetaLocked(active.meta)
+	}
+	rotateErr := ve.rotateHotSegmentLocked()
 	ve.lock.Unlock()
 
-	if err := ve.dataFile.Sync(); err != nil {
+	if err := active.dataFile.Sync(); err != nil {
 		log.Printf("data file sync failed: %v", err)
+	}
+	if rotateErr != nil {
+		log.Printf("hot segment rotation failed: %v", rotateErr)
 	}
 }
 
@@ -661,4 +808,517 @@ func bytesToFloat32Array(buf []byte) ([]float32, error) {
 		vec[i] = math.Float32frombits(binary.LittleEndian.Uint32(buf[i*4:]))
 	}
 	return vec, nil
+}
+
+func (ve *VectorEngineImpl) activeSegmentLocked() *vectorSegment {
+	for _, segment := range ve.segments {
+		if segment.meta.ID == ve.manifest.ActiveSegmentID {
+			return segment
+		}
+	}
+	return nil
+}
+
+func (ve *VectorEngineImpl) updateSegmentMetaLocked(meta SegmentMeta) {
+	for idx := range ve.segments {
+		if ve.segments[idx].meta.ID == meta.ID {
+			ve.segments[idx].meta = meta
+			break
+		}
+	}
+	for idx := range ve.manifest.Segments {
+		if ve.manifest.Segments[idx].ID == meta.ID {
+			ve.manifest.Segments[idx] = meta
+			break
+		}
+	}
+}
+
+func (ve *VectorEngineImpl) rotateHotSegmentLocked() error {
+	if !ve.vectorSegmentationEnabled {
+		return nil
+	}
+	active := ve.activeSegmentLocked()
+	if active == nil || active.meta.SizeBytes < ve.settings.SegmentRolloverBytes {
+		return nil
+	}
+
+	active.meta.State = SegmentStateSealed
+	active.meta.SealedAtUnixNs = time.Now().UnixNano()
+	ve.updateSegmentMetaLocked(active.meta)
+
+	newID := ve.manifest.NextSegmentID
+	ve.manifest.NextSegmentID++
+	newMeta := SegmentMeta{
+		ID:              newID,
+		State:           SegmentStateHot,
+		DataFile:        ve.layout.DataFileName(newID),
+		IndexFile:       ve.layout.IndexFileName(newID),
+		CreatedAtUnixNs: time.Now().UnixNano(),
+	}
+	index, err := faiss.IndexFactory(ve.maxVectorSize, "IDMap,"+ve.hotSegmentIndexDesc(), ve.metric)
+	if err != nil {
+		return err
+	}
+	dataFile, err := os.OpenFile(ve.layout.DataPath(newID), os.O_RDWR|os.O_CREATE, 0666)
+	if err != nil {
+		index.Delete()
+		return err
+	}
+
+	ve.manifest.ActiveSegmentID = newID
+	ve.manifest.Segments = append(ve.manifest.Segments, newMeta)
+	ve.segments = append(ve.segments, &vectorSegment{
+		meta:             newMeta,
+		dataFile:         dataFile,
+		index:            index,
+		fileOffsets:      make(map[int64]int64),
+		deletedIDs:       make(map[int64]bool),
+		pendingUpsertIDs: make(map[int64]struct{}),
+	})
+	if err := WriteSegmentManifest(ve.layout, ve.manifest); err != nil {
+		return err
+	}
+
+	ve.enqueueIndexBuildLocked(active.meta.ID)
+	ve.scheduleMergeCheckLocked()
+	return nil
+}
+
+func (ve *VectorEngineImpl) indexBuildWorker() {
+	defer ve.backgroundWG.Done()
+	for {
+		select {
+		case <-ve.backgroundStop:
+			return
+		case id := <-ve.indexBuildQueue:
+			ve.buildIndexForSegment(id)
+		}
+	}
+}
+
+func (ve *VectorEngineImpl) mergeWorker() {
+	defer ve.backgroundWG.Done()
+	for {
+		select {
+		case <-ve.backgroundStop:
+			return
+		case <-ve.mergeQueue:
+			for ve.tryMergeOldestColdSegments() {
+			}
+		}
+	}
+}
+
+func (ve *VectorEngineImpl) buildIndexForSegment(id int64) {
+	ve.lock.Lock()
+	segment := ve.segmentByIDLocked(id)
+	if segment == nil || id == ve.manifest.ActiveSegmentID {
+		ve.lock.Unlock()
+		return
+	}
+	segment.meta.State = SegmentStateIndexing
+	ve.updateSegmentMetaLocked(segment.meta)
+	desc := ve.layout.Descriptor(segment.meta)
+	_ = WriteSegmentManifest(ve.layout, ve.manifest)
+	ve.lock.Unlock()
+
+	if err := buildSealedVectorIndex(desc.DataPath, desc.IndexPath, ve.maxVectorSize, ve.indexType, ve.metric); err != nil {
+		log.Printf("build vector segment index failed for segment %d: %v", id, err)
+		ve.lock.Lock()
+		if segment := ve.segmentByIDLocked(id); segment != nil {
+			segment.meta.State = SegmentStateSealed
+			ve.updateSegmentMetaLocked(segment.meta)
+			_ = WriteSegmentManifest(ve.layout, ve.manifest)
+		}
+		ve.lock.Unlock()
+		return
+	}
+
+	ve.lock.Lock()
+	if segment := ve.segmentByIDLocked(id); segment != nil {
+		segment.meta.State = SegmentStateCold
+		if info, err := os.Stat(desc.DataPath); err == nil {
+			segment.meta.SizeBytes = info.Size()
+		}
+		ve.updateSegmentMetaLocked(segment.meta)
+		_ = WriteSegmentManifest(ve.layout, ve.manifest)
+		ve.scheduleMergeCheckLocked()
+	}
+	ve.lock.Unlock()
+}
+
+func (ve *VectorEngineImpl) tryMergeOldestColdSegments() bool {
+	ve.lock.Lock()
+	if !ve.vectorSegmentationEnabled {
+		ve.lock.Unlock()
+		return false
+	}
+	if len(ve.segments) <= ve.settings.MaxSegmentsBeforeMerge {
+		ve.lock.Unlock()
+		return false
+	}
+
+	var first, second *vectorSegment
+	for _, segment := range ve.segments {
+		if segment.meta.ID == ve.manifest.ActiveSegmentID {
+			continue
+		}
+		if segment.meta.State != SegmentStateCold {
+			continue
+		}
+		if first == nil {
+			first = segment
+			continue
+		}
+		second = segment
+		break
+	}
+	if first == nil || second == nil {
+		ve.lock.Unlock()
+		return false
+	}
+
+	first.meta.State = SegmentStateMerging
+	second.meta.State = SegmentStateMerging
+	ve.updateSegmentMetaLocked(first.meta)
+	ve.updateSegmentMetaLocked(second.meta)
+	newID := second.meta.ID
+	firstDesc := ve.layout.Descriptor(first.meta)
+	secondDesc := ve.layout.Descriptor(second.meta)
+	_ = WriteSegmentManifest(ve.layout, ve.manifest)
+	ve.lock.Unlock()
+
+	meta, mergedIndex, dataFile, offsets, deletedIDs, err := ve.mergeSegments(newID, firstDesc, secondDesc)
+	if err != nil {
+		log.Printf("merge vector segments %d and %d failed: %v", first.meta.ID, second.meta.ID, err)
+		ve.lock.Lock()
+		if segment := ve.segmentByIDLocked(first.meta.ID); segment != nil {
+			segment.meta.State = SegmentStateCold
+			ve.updateSegmentMetaLocked(segment.meta)
+		}
+		if segment := ve.segmentByIDLocked(second.meta.ID); segment != nil {
+			segment.meta.State = SegmentStateCold
+			ve.updateSegmentMetaLocked(segment.meta)
+		}
+		_ = WriteSegmentManifest(ve.layout, ve.manifest)
+		ve.lock.Unlock()
+		return false
+	}
+
+	ve.lock.Lock()
+	defer ve.lock.Unlock()
+	firstIdx := ve.segmentIndexByIDLocked(first.meta.ID)
+	secondIdx := ve.segmentIndexByIDLocked(second.meta.ID)
+	if firstIdx < 0 || secondIdx <= firstIdx {
+		_ = dataFile.Close()
+		mergedIndex.Delete()
+		return false
+	}
+
+	ve.segments[firstIdx].index.Delete()
+	ve.segments[secondIdx].index.Delete()
+	_ = ve.segments[firstIdx].dataFile.Close()
+	_ = ve.segments[secondIdx].dataFile.Close()
+	_ = os.Remove(firstDesc.DataPath)
+	_ = os.Remove(firstDesc.IndexPath)
+
+	mergedSegment := &vectorSegment{
+		meta:             meta,
+		dataFile:         dataFile,
+		index:            mergedIndex,
+		fileOffsets:      offsets,
+		deletedIDs:       deletedIDs,
+		pendingUpsertIDs: make(map[int64]struct{}),
+	}
+	ve.segments = append(append([]*vectorSegment{}, mergedSegment), ve.segments[secondIdx+1:]...)
+	ve.manifest.Segments = append(append([]SegmentMeta{}, meta), ve.manifest.Segments[secondIdx+1:]...)
+	_ = WriteSegmentManifest(ve.layout, ve.manifest)
+	return len(ve.segments) > ve.settings.MaxSegmentsBeforeMerge
+}
+
+func (ve *VectorEngineImpl) mergeSegments(newID int64, firstDesc, secondDesc SegmentDescriptor) (SegmentMeta, faiss.Index, *os.File, map[int64]int64, map[int64]bool, error) {
+	records, err := collectLatestVectorRecords(ve.maxVectorSize, firstDesc.DataPath, secondDesc.DataPath)
+	if err != nil {
+		return SegmentMeta{}, nil, nil, nil, nil, err
+	}
+
+	dataPath := ve.layout.DataPath(newID)
+	indexPath := ve.layout.IndexPath(newID)
+	if err := writeMergedVectorDataFile(dataPath, records); err != nil {
+		return SegmentMeta{}, nil, nil, nil, nil, err
+	}
+	if err := buildSealedVectorIndex(dataPath, indexPath, ve.maxVectorSize, ve.indexType, ve.metric); err != nil {
+		return SegmentMeta{}, nil, nil, nil, nil, err
+	}
+	index, err := faiss.ReadIndex(indexPath, 0)
+	if err != nil {
+		return SegmentMeta{}, nil, nil, nil, nil, err
+	}
+	dataFile, err := os.OpenFile(dataPath, os.O_RDWR|os.O_CREATE, 0666)
+	if err != nil {
+		index.Delete()
+		return SegmentMeta{}, nil, nil, nil, nil, err
+	}
+	offsets, deletedIDs, err := scanVectorDataFile(dataPath, ve.maxVectorSize)
+	if err != nil {
+		index.Delete()
+		_ = dataFile.Close()
+		return SegmentMeta{}, nil, nil, nil, nil, err
+	}
+
+	meta := SegmentMeta{
+		ID:              newID,
+		State:           SegmentStateCold,
+		DataFile:        filepath.Base(dataPath),
+		IndexFile:       filepath.Base(indexPath),
+		CreatedAtUnixNs: time.Now().UnixNano(),
+	}
+	if info, err := dataFile.Stat(); err == nil {
+		meta.SizeBytes = info.Size()
+	}
+	return meta, index, dataFile, offsets, deletedIDs, nil
+}
+
+func (ve *VectorEngineImpl) enqueueIndexBuildLocked(id int64) {
+	select {
+	case ve.indexBuildQueue <- id:
+	default:
+		go func() {
+			select {
+			case ve.indexBuildQueue <- id:
+			case <-ve.backgroundStop:
+			}
+		}()
+	}
+}
+
+func (ve *VectorEngineImpl) scheduleMergeCheckLocked() {
+	select {
+	case ve.mergeQueue <- struct{}{}:
+	default:
+	}
+}
+
+func (ve *VectorEngineImpl) segmentByIDLocked(id int64) *vectorSegment {
+	for _, segment := range ve.segments {
+		if segment.meta.ID == id {
+			return segment
+		}
+	}
+	return nil
+}
+
+func (ve *VectorEngineImpl) segmentIndexByIDLocked(id int64) int {
+	for idx, segment := range ve.segments {
+		if segment.meta.ID == id {
+			return idx
+		}
+	}
+	return -1
+}
+
+func loadOrBuildVectorSegmentIndex(desc SegmentDescriptor, dimension int, indexDesc string, metric int) (faiss.Index, error) {
+	index, err := faiss.ReadIndex(desc.IndexPath, 0)
+	if err == nil {
+		return index, nil
+	}
+	if err := buildSealedVectorIndex(desc.DataPath, desc.IndexPath, dimension, indexDesc, metric); err != nil {
+		return nil, err
+	}
+	return faiss.ReadIndex(desc.IndexPath, 0)
+}
+
+func buildSealedVectorIndex(dataPath, indexPath string, dimension int, indexDesc string, metric int) error {
+	if _, err := RebuildVectorIndex(dataPath, indexPath, dimension, indexDesc, metric); err == nil {
+		return nil
+	} else if !isVectorRebuildTrainingError(err) {
+		return err
+	}
+	return func() error {
+		_, err := RebuildVectorIndex(dataPath, indexPath, dimension, "Flat", metric)
+		return err
+	}()
+}
+
+func buildVectorIndexFromDataFile(dataPath string, dimension int, indexDesc string, metric int) (faiss.Index, error) {
+	offsets, deletedIDs, err := scanVectorDataFile(dataPath, dimension)
+	if err != nil {
+		return nil, err
+	}
+	index, err := faiss.IndexFactory(dimension, "IDMap,"+indexDesc, metric)
+	if err != nil {
+		return nil, err
+	}
+	if len(offsets) == 0 {
+		if requiredTrainCountForIndex(indexDesc) > 0 {
+			index.Delete()
+			return faiss.IndexFactory(dimension, "IDMap,Flat", metric)
+		}
+		return index, nil
+	}
+
+	dataFile, err := os.Open(dataPath)
+	if err != nil {
+		index.Delete()
+		return nil, err
+	}
+	defer dataFile.Close()
+
+	requiredTrainCount := requiredTrainCountForIndex(indexDesc)
+	ids := make([]int64, 0, len(offsets))
+	data := make([]float32, 0, len(offsets)*dimension)
+	for id, offset := range offsets {
+		if deletedIDs[id] {
+			continue
+		}
+		_, vec, deleted, err := readVectorRecordAt(dataFile, offset, dimension)
+		if err != nil {
+			index.Delete()
+			return nil, err
+		}
+		if deleted {
+			continue
+		}
+		ids = append(ids, id)
+		data = append(data, vec...)
+	}
+	if len(ids) == 0 {
+		if requiredTrainCountForIndex(indexDesc) > 0 {
+			index.Delete()
+			return faiss.IndexFactory(dimension, "IDMap,Flat", metric)
+		}
+		return index, nil
+	}
+	if requiredTrainCount > 0 && len(ids) > 0 {
+		if len(ids) < requiredTrainCount {
+			index.Delete()
+			return buildVectorIndexFromDataFile(dataPath, dimension, "Flat", metric)
+		}
+		trainCount := trainingSampleCount(requiredTrainCount, len(ids))
+		if trainCount > len(ids) {
+			trainCount = len(ids)
+		}
+		trainData := data[:trainCount*dimension]
+		if err := index.Train(trainData); err != nil {
+			index.Delete()
+			return nil, err
+		}
+	}
+	if len(ids) > 0 {
+		if err := index.AddWithIDs(data, ids); err != nil {
+			index.Delete()
+			return nil, err
+		}
+	}
+	return index, nil
+}
+
+func scanVectorDataFile(dataPath string, dimension int) (map[int64]int64, map[int64]bool, error) {
+	file, err := os.OpenFile(dataPath, os.O_RDWR|os.O_CREATE, 0666)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer file.Close()
+
+	recordSize := 8 + 4*dimension
+	offsets := make(map[int64]int64)
+	deletedIDs := make(map[int64]bool)
+	var offset int64
+	for {
+		buf := make([]byte, recordSize)
+		n, err := file.Read(buf)
+		if err == io.EOF || (err == io.ErrUnexpectedEOF && n == 0) {
+			break
+		}
+		if err == io.ErrUnexpectedEOF || n < recordSize {
+			break
+		}
+		if err != nil {
+			return nil, nil, err
+		}
+		id := int64(binary.LittleEndian.Uint64(buf[0:8]))
+		offsets[id] = offset
+		deletedIDs[id] = len(buf) >= 12 && binary.LittleEndian.Uint32(buf[8:12]) == tombstoneMarker
+		offset += int64(recordSize)
+	}
+	return offsets, deletedIDs, nil
+}
+
+func collectLatestVectorRecords(dimension int, paths ...string) (map[int64][]byte, error) {
+	recordSize := 8 + 4*dimension
+	records := make(map[int64][]byte)
+	for _, path := range paths {
+		file, err := os.Open(path)
+		if err != nil {
+			return nil, err
+		}
+		for {
+			buf := make([]byte, recordSize)
+			n, err := file.Read(buf)
+			if err == io.EOF || (err == io.ErrUnexpectedEOF && n == 0) {
+				break
+			}
+			if err == io.ErrUnexpectedEOF || n < recordSize {
+				break
+			}
+			if err != nil {
+				_ = file.Close()
+				return nil, err
+			}
+			id := int64(binary.LittleEndian.Uint64(buf[0:8]))
+			records[id] = append([]byte(nil), buf...)
+		}
+		_ = file.Close()
+	}
+	return records, nil
+}
+
+func writeMergedVectorDataFile(dataPath string, records map[int64][]byte) error {
+	if err := os.MkdirAll(filepath.Dir(dataPath), 0755); err != nil {
+		return err
+	}
+	tmpPath := dataPath + ".merge.tmp"
+	file, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0666)
+	if err != nil {
+		return err
+	}
+	for _, record := range records {
+		if _, err := file.Write(record); err != nil {
+			_ = file.Close()
+			return err
+		}
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	if err := os.Remove(dataPath); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return os.Rename(tmpPath, dataPath)
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func (ve *VectorEngineImpl) hotSegmentIndexDesc() string {
+	if requiredTrainCountForIndex(ve.indexType) > 0 {
+		return "Flat"
+	}
+	return ve.indexType
+}
+
+func betterDistanceForMetric(metric int, left, right float32) bool {
+	if metric == faiss.MetricInnerProduct {
+		return left > right
+	}
+	return left < right
 }

--- a/internal/storage/vector_storage_ivf_flat_test.go
+++ b/internal/storage/vector_storage_ivf_flat_test.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"math/rand"
 	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
@@ -296,4 +297,45 @@ func TestVectorEngineImpl_InsertAndSearch_IVF32Flat(t *testing.T) {
 			t.Errorf("Stored vector should not match first inserted vector")
 		}
 	})
+}
+
+// Training-based indexes (IVF, PQ, …) must not use hot-segment rollover: a single
+// data file and in-memory index rebuilt on open.
+func TestVectorEngineTrainingIndex_NoSegmentRollover(t *testing.T) {
+	dataPath := filepath.Join("testdata", "vector_data_ivf_noseg.db")
+	indexPath := filepath.Join("testdata", "vector_index_ivf_noseg.faiss")
+	walPath := filepath.Join("testdata", "vector_wal_ivf_noseg.db")
+	os.MkdirAll("testdata", 0755)
+	for _, p := range []string{dataPath, indexPath, walPath} {
+		os.Remove(p)
+	}
+	t.Cleanup(func() {
+		for _, p := range []string{dataPath, indexPath, walPath} {
+			os.Remove(p)
+		}
+	})
+
+	ve, err := NewVectorEngineWithSettings(dataPath, indexPath, walPath, 4, "IVF32,Flat", faiss.MetricL2, true, SpaceSettings{
+		SegmentRolloverBytes:   256,
+		MaxSegmentsBeforeMerge: 2,
+	})
+	if err != nil {
+		t.Fatalf("NewVectorEngineWithSettings: %v", err)
+	}
+	defer ve.Close()
+
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 200; i++ {
+		if err := ve.InsertVector(int64(i), randomVector(4)); err != nil {
+			t.Fatalf("InsertVector %d: %v", i, err)
+		}
+	}
+	ve.MaintenanceFlush()
+
+	if len(ve.manifest.Segments) != 1 {
+		t.Fatalf("expected single vector segment for IVF, got %d segments", len(ve.manifest.Segments))
+	}
+	if ve.vectorSegmentationEnabled {
+		t.Fatal("IVF index must disable vector segmentation (vectorSegmentationEnabled=false)")
+	}
 }

--- a/main.go
+++ b/main.go
@@ -382,6 +382,7 @@ Runtime Management:
 Manager Commands:
   status                    Show current connection limit and active connections
   stats                     Show detailed connection statistics
+  update-space-settings     [--segment-rollover-bytes N] [--max-segments-before-merge N] <space>
   limit <new_limit>         Set connection limit to specific value
   increase [amount]         Increase connection limit by amount (default: 100)
   decrease [amount]         Decrease connection limit by amount (default: 100)
@@ -404,6 +405,7 @@ Examples:
                                       # Connect to default port %s
   shibudb connect --port 9090 --username admin --password admin
   shibudb manager --username admin --password admin status   # Management API on default port %s
+  shibudb manager --username admin --password admin update-space-settings --segment-rollover-bytes 52428800 my_space
   shibudb start --port 9090 --management-port 19090
   shibudb manager --port 19090 --username admin --password admin limit 2000
                                       # Custom client and management ports
@@ -630,7 +632,7 @@ func connectToServer(port, providedUser, providedPass string) {
 			query = models.Query{Type: models.TypeGetUser, Data: parts[1]}
 		case "create-space":
 			if len(parts) < 2 {
-				fmt.Println("Usage: create-space <name> [--engine key-value|vector] [--dimension N] [--index-type TYPE] [--metric METRIC] [--enable-wal] [--disable-wal]")
+				fmt.Println("Usage: create-space <name> [--engine key-value|vector] [--dimension N] [--index-type TYPE] [--metric METRIC] [--enable-wal] [--disable-wal] [--segment-rollover-bytes N] [--max-segments-before-merge N]")
 				continue
 			}
 			engineType := "key-value"
@@ -639,6 +641,8 @@ func connectToServer(port, providedUser, providedPass string) {
 			metric := "L2"
 			enableWAL := false // Will be set based on engine type
 			walExplicitlySet := false
+			segmentRolloverBytes := int64(0)
+			maxSegmentsBeforeMerge := 0
 			for i := 2; i < len(parts); i++ {
 				if parts[i] == "--engine" && i+1 < len(parts) {
 					engineType = parts[i+1]
@@ -662,6 +666,18 @@ func connectToServer(port, providedUser, providedPass string) {
 				} else if parts[i] == "--disable-wal" {
 					enableWAL = false
 					walExplicitlySet = true
+				} else if parts[i] == "--segment-rollover-bytes" && i+1 < len(parts) {
+					value, err := strconv.ParseInt(parts[i+1], 10, 64)
+					if err == nil {
+						segmentRolloverBytes = value
+					}
+					i++
+				} else if parts[i] == "--max-segments-before-merge" && i+1 < len(parts) {
+					value, err := strconv.Atoi(parts[i+1])
+					if err == nil {
+						maxSegmentsBeforeMerge = value
+					}
+					i++
 				}
 			}
 
@@ -674,7 +690,47 @@ func connectToServer(port, providedUser, providedPass string) {
 				fmt.Println("For vector engine, you must specify --dimension <N> (e.g., 128)")
 				continue
 			}
-			query = models.Query{Type: models.TypeCreateSpace, Space: parts[1], User: username, EngineType: engineType, Dimension: dimension, IndexType: indexType, Metric: metric, EnableWAL: enableWAL}
+			query = models.Query{
+				Type:                   models.TypeCreateSpace,
+				Space:                  parts[1],
+				User:                   username,
+				EngineType:             engineType,
+				Dimension:              dimension,
+				IndexType:              indexType,
+				Metric:                 metric,
+				EnableWAL:              enableWAL,
+				SegmentRolloverBytes:   segmentRolloverBytes,
+				MaxSegmentsBeforeMerge: maxSegmentsBeforeMerge,
+			}
+		case "update-space-settings":
+			if len(parts) < 2 {
+				fmt.Println("Usage: update-space-settings <name> [--segment-rollover-bytes N] [--max-segments-before-merge N]")
+				continue
+			}
+			segmentRolloverBytes := int64(0)
+			maxSegmentsBeforeMerge := 0
+			for i := 2; i < len(parts); i++ {
+				if parts[i] == "--segment-rollover-bytes" && i+1 < len(parts) {
+					value, err := strconv.ParseInt(parts[i+1], 10, 64)
+					if err == nil {
+						segmentRolloverBytes = value
+					}
+					i++
+				} else if parts[i] == "--max-segments-before-merge" && i+1 < len(parts) {
+					value, err := strconv.Atoi(parts[i+1])
+					if err == nil {
+						maxSegmentsBeforeMerge = value
+					}
+					i++
+				}
+			}
+			query = models.Query{
+				Type:                   models.TypeUpdateSpaceSettings,
+				Space:                  parts[1],
+				User:                   username,
+				SegmentRolloverBytes:   segmentRolloverBytes,
+				MaxSegmentsBeforeMerge: maxSegmentsBeforeMerge,
+			}
 		case "delete-space":
 			if len(parts) < 2 {
 				fmt.Println("Usage: delete-space <name>")
@@ -1170,6 +1226,8 @@ func handleManagerCommand(managementPort string, args []string, authCfg managerA
 		getManagerStatus(baseURL, tempToken)
 	case "stats":
 		getManagerStats(baseURL, tempToken)
+	case "update-space-settings":
+		updateManagerSpaceSettings(baseURL, tempToken, args[1:])
 	case "limit":
 		if len(args) < 2 {
 			fmt.Println("Usage: shibudb manager [--port <n>] [--username <u> --password <p>] limit <new_limit>")
@@ -1334,6 +1392,7 @@ func printManagerUsage() {
 	fmt.Printf(`Manager Commands:
   status                    Show current connection limit and active connections
   stats                     Show detailed connection statistics
+  update-space-settings     [--segment-rollover-bytes N] [--max-segments-before-merge N] <space>
   limit <new_limit>         Set connection limit to specific value
   increase [amount]         Increase connection limit by amount (default: 100)
   decrease [amount]         Decrease connection limit by amount (default: 100)
@@ -1349,6 +1408,7 @@ Usage:
 
 Examples:
   shibudb manager --username admin --password admin status
+  shibudb manager --username admin --password admin update-space-settings --segment-rollover-bytes 52428800 my_space
   shibudb manager --username admin --password admin limit 2000
   shibudb manager --username admin --password admin increase 500
   shibudb manager --username admin --password admin decrease 200
@@ -1389,6 +1449,61 @@ func makeManagerRequest(method, url string, body interface{}, bearerToken string
 
 	fmt.Printf("Making request to: %s %s\n", method, url)
 	return client.Do(req)
+}
+
+func updateManagerSpaceSettings(baseURL, bearerToken string, args []string) {
+	fs := flag.NewFlagSet("update-space-settings", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	rolloverBytes := fs.Int64("segment-rollover-bytes", 0, "segment rollover threshold in bytes")
+	maxSegments := fs.Int("max-segments-before-merge", 0, "max segments before background merge")
+	usage := "Usage: shibudb manager [--port <n>] [--username <u> --password <p>] update-space-settings [--segment-rollover-bytes <bytes>] [--max-segments-before-merge <n>] <space>"
+	if err := fs.Parse(args); err != nil {
+		fmt.Printf("Error: %v\n", err)
+		fmt.Println(usage)
+		return
+	}
+	if len(fs.Args()) < 1 {
+		fmt.Println(usage)
+		return
+	}
+	if *rolloverBytes <= 0 && *maxSegments <= 0 {
+		fmt.Println("Error: provide at least one of --segment-rollover-bytes or --max-segments-before-merge (flags must come before the space name)")
+		fmt.Println(usage)
+		return
+	}
+
+	body := map[string]interface{}{
+		"space": fs.Args()[0],
+	}
+	if *rolloverBytes > 0 {
+		body["segment_rollover_bytes"] = *rolloverBytes
+	}
+	if *maxSegments > 0 {
+		body["max_segments_before_merge"] = *maxSegments
+	}
+
+	resp, err := makeManagerRequest(http.MethodPut, baseURL+"/spaces/settings", body, bearerToken)
+	if err != nil {
+		fmt.Printf("Error: Failed to connect to management server: %v\n", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	var result map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		fmt.Printf("Error: Failed to parse response: %v\n", err)
+		return
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		fmt.Printf("Error: %v\n", result["error"])
+		return
+	}
+
+	fmt.Printf("Success: %v\n", result["message"])
+	fmt.Printf("Space: %v\n", result["space"])
+	fmt.Printf("Segment Rollover Bytes: %v\n", result["segment_rollover_bytes"])
+	fmt.Printf("Max Segments Before Merge: %v\n", result["max_segments_before_merge"])
 }
 
 func getManagerStatus(baseURL, bearerToken string) {


### PR DESCRIPTION
## Description

Adds segmented hot/cold storage for both key-value and vector spaces to replace time-based or continuously persisted index snapshots.

This change introduces per-space rollover and merge settings, keeps all segment indexes loaded in memory for query fan-out, persists indexes only for sealed cold segments, rebuilds missing cold indexes on restart, and merges the oldest cold segments in the background when segment count exceeds the configured threshold. It also fixes merged segment numbering so merged cold segments retain a serial lower than the current hot segment.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Validated with unit/integration coverage for settings plumbing, rollover, restart recovery, fan-out reads/searches, background index creation, and cold-segment merges.

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Run `go test ./internal/spaces ./internal/queryengine ./internal/storage`
- [x] Run `go test -c ./E2ETests`
- [ ] Run `go test ./E2ETests -run 'TestSegmentedKeyValueE2E|TestSegmentedVectorE2E'` against a live server on `localhost:4444`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional Notes

New coverage includes storage lifecycle tests for rollover, restart rebuild, search/read fan-out, and background merges; query and space-manager tests for per-space settings defaults and live updates; and E2E tests for segmented key-value and vector spaces using custom rollover and merge settings.

The E2E suite in this repository expects a live server on `localhost:4444`; in this environment the new E2E tests were compile-verified but not fully executed against a running server.