### PR TITLE
feat(auth): add LIST_USERS command for admin users 

### DIFF
--- a/E2ETests/auth_test.go
+++ b/E2ETests/auth_test.go
@@ -413,6 +413,113 @@ func TestVectorSpaceAdminAccess(t *testing.T) {
 	}
 }
 
+func TestListUsersAdminSuccess(t *testing.T) {
+	CleanUser("lu_user1", globalConn, globalReader)
+	CleanUser("lu_user2", globalConn, globalReader)
+
+	perms1 := map[string]string{"myspace": "write", "other": "read"}
+	if !CreateUser("admin", "lu_user1", "lu_pass1", "user", perms1, globalConn, globalReader) {
+		t.Fatal("failed to create lu_user1")
+	}
+	perms2 := map[string]string{}
+	if !CreateUser("admin", "lu_user2", "lu_pass2", "user", perms2, globalConn, globalReader) {
+		t.Fatal("failed to create lu_user2")
+	}
+
+	query := models.Query{Type: models.TypeListUsers, User: "admin"}
+	data, _ := json.Marshal(query)
+	globalConn.Write(append(data, '\n'))
+	resp, err := globalReader.ReadString('\n')
+	if err != nil {
+		t.Fatalf("server error: %v", err)
+	}
+
+	if !strings.Contains(resp, `"status":"OK"`) {
+		t.Fatalf("expected OK, got: %s", strings.TrimSpace(resp))
+	}
+	if !strings.Contains(resp, `"users"`) {
+		t.Errorf("response missing 'users' key: %s", strings.TrimSpace(resp))
+	}
+	if strings.Contains(resp, `"password"`) {
+		t.Errorf("response must not include password field: %s", strings.TrimSpace(resp))
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(resp)), &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	list, ok := parsed["users"].([]interface{})
+	if !ok {
+		t.Fatalf("'users' is not an array")
+	}
+
+	found1, found2 := false, false
+	for _, u := range list {
+		m, ok := u.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if _, hasPass := m["password"]; hasPass {
+			t.Errorf("user entry contains password field")
+		}
+		switch m["username"] {
+		case "lu_user1":
+			found1 = true
+			if m["role"] != "user" {
+				t.Errorf("lu_user1: expected role=user, got %v", m["role"])
+			}
+			if perms, ok := m["permissions"].(map[string]interface{}); ok {
+				if perms["myspace"] != "write" || perms["other"] != "read" {
+					t.Errorf("lu_user1: unexpected permissions: %v", perms)
+				}
+			} else {
+				t.Errorf("lu_user1: permissions not a map")
+			}
+		case "lu_user2":
+			found2 = true
+		}
+	}
+	if !found1 {
+		t.Errorf("lu_user1 not found in list response")
+	}
+	if !found2 {
+		t.Errorf("lu_user2 not found in list response")
+	}
+}
+
+func TestListUsersNonAdminDenied(t *testing.T) {
+	CleanUser("lu_nonadmin", globalConn, globalReader)
+	if !CreateUser("admin", "lu_nonadmin", "lu_nonadmin_pass", "user", map[string]string{}, globalConn, globalReader) {
+		t.Fatal("failed to create lu_nonadmin")
+	}
+
+	conn, err := net.Dial("tcp", "localhost:4444")
+	if err != nil {
+		t.Fatalf("TCP error: %v", err)
+	}
+	defer conn.Close()
+	reader := bufio.NewReader(conn)
+
+	if !Login("lu_nonadmin", "lu_nonadmin_pass", conn, reader) {
+		t.Fatal("login failed for lu_nonadmin")
+	}
+
+	query := models.Query{Type: models.TypeListUsers, User: "lu_nonadmin"}
+	data, _ := json.Marshal(query)
+	conn.Write(append(data, '\n'))
+	resp, err := reader.ReadString('\n')
+	if err != nil {
+		t.Fatalf("server error: %v", err)
+	}
+
+	if !strings.Contains(resp, `"ERROR"`) {
+		t.Errorf("expected error for non-admin LIST_USERS, got: %s", strings.TrimSpace(resp))
+	}
+	if strings.Contains(resp, `"users"`) {
+		t.Errorf("non-admin must not receive users list: %s", strings.TrimSpace(resp))
+	}
+}
+
 func TestVectorSpaceNoAccess(t *testing.T) {
 	CleanSpace("vector_test_no_access", globalConn, globalReader)
 	CleanUser("vector_test_no_access", globalConn, globalReader)

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -486,7 +486,7 @@ func handleConnection(conn net.Conn, spaceManager *spaces.SpaceManager, authMana
 
 		// Enforce role-based access
 		switch strings.ToUpper(query.Type) {
-		case "CREATE_SPACE", "LIST_SPACES":
+		case "CREATE_SPACE", "LIST_SPACES", "LIST_USERS":
 			if user.Role != auth.RoleAdmin {
 				fmt.Fprintf(conn, `{"status":"ERROR","message":"admin access required"}`+"\n")
 				continue
@@ -531,9 +531,17 @@ func handleConnection(conn net.Conn, spaceManager *spaces.SpaceManager, authMana
 			"status": "OK",
 		}
 
-		if strings.ToUpper(query.Type) == "GET" {
+		switch strings.ToUpper(query.Type) {
+		case "GET":
 			response["value"] = result
-		} else {
+		case "LIST_USERS":
+			var users interface{}
+			if err := json.Unmarshal([]byte(result), &users); err == nil {
+				response["users"] = users
+			} else {
+				response["message"] = result
+			}
+		default:
 			response["message"] = result
 		}
 

--- a/internal/auth/manager.go
+++ b/internal/auth/manager.go
@@ -292,3 +292,18 @@ func (a *AuthManager) GetUser(username string) (models.User, error) {
 	}
 	return u, nil
 }
+
+func (a *AuthManager) ListUsers() []models.User {
+	a.lock.RLock()
+	defer a.lock.RUnlock()
+
+	users := make([]models.User, 0, len(a.users))
+	for _, u := range a.users {
+		users = append(users, models.User{
+			Username:    u.Username,
+			Role:        u.Role,
+			Permissions: u.Permissions,
+		})
+	}
+	return users
+}

--- a/internal/models/query.go
+++ b/internal/models/query.go
@@ -15,6 +15,7 @@ const (
 	TypeUpdateUserRole        = "UPDATE_USER_ROLE"
 	TypeUpdateUserPermissions = "UPDATE_USER_PERMISSIONS"
 	TypeGetUser               = "GET_USER"
+	TypeListUsers             = "LIST_USERS"
 	TypeInsertVector          = "INSERT_VECTOR"
 	TypeDeleteVector          = "DELETE_VECTOR"
 	TypeSearchTopK            = "SEARCH_TOPK"

--- a/internal/queryengine/query_engine.go
+++ b/internal/queryengine/query_engine.go
@@ -1,6 +1,7 @@
 package queryengine
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -15,6 +16,7 @@ import (
 // Add this interface above QueryEngine
 type AuthManagerIface interface {
 	GetUser(username string) (models.User, error)
+	ListUsers() []models.User
 	CreateUser(username, password, role string, perms map[string]string) error
 	UpdateUserPassword(username string, password string) error
 	UpdateUserRole(username string, role string) error
@@ -73,6 +75,29 @@ func (qe *QueryEngine) Execute(query models.Query) (string, error) {
 			return "", err
 		}
 		return getUserResponse(&user), nil
+	case models.TypeListUsers:
+		if query.User == "" {
+			return "", errors.New("unauthenticated")
+		}
+		admin, err := qe.authManager.GetUser(query.User)
+		if err != nil || admin.Role != auth.RoleAdmin {
+			return "", errors.New("admin access required")
+		}
+		type userInfo struct {
+			Username    string            `json:"username"`
+			Role        string            `json:"role"`
+			Permissions map[string]string `json:"permissions"`
+		}
+		all := qe.authManager.ListUsers()
+		out := make([]userInfo, len(all))
+		for i, u := range all {
+			out[i] = userInfo{Username: u.Username, Role: u.Role, Permissions: u.Permissions}
+		}
+		data, err := json.Marshal(out)
+		if err != nil {
+			return "", err
+		}
+		return string(data), nil
 	case models.TypeCreateUser:
 		log.Println("Creating user:", query)
 		if query.User == "" {

--- a/internal/queryengine/query_engine_test.go
+++ b/internal/queryengine/query_engine_test.go
@@ -37,6 +37,10 @@ func (m *mockAuth) DeleteUser(username string) error {
 	return nil
 }
 
+func (m *mockAuth) ListUsers() []models.User {
+	return []models.User{}
+}
+
 func TestQueryEngine_DeleteVector(t *testing.T) {
 	dir := t.TempDir()
 	sm := spaces.NewSpaceManager(dir)

--- a/main.go
+++ b/main.go
@@ -739,6 +739,12 @@ func connectToServer(port, providedUser, providedPass string) {
 			query = models.Query{Type: models.TypeDeleteSpace, Data: parts[1], User: username}
 		case "list-spaces":
 			query = models.Query{Type: models.TypeListSpaces, User: username}
+		case "list-users":
+			if currentUser.Role != auth.RoleAdmin {
+				fmt.Println("Only admin can list users.")
+				continue
+			}
+			query = models.Query{Type: models.TypeListUsers}
 		case "put":
 			if len(parts) < 3 {
 				fmt.Println("Usage: put <key> <value>")
@@ -848,6 +854,17 @@ func printResponse(resp string) {
 		}
 		if val, ok := parsed["value"]; ok {
 			fmt.Printf("Value: %v\n", val)
+		}
+		if users, ok := parsed["users"]; ok {
+			if list, ok := users.([]interface{}); ok {
+				fmt.Printf("Users (%d):\n", len(list))
+				for _, u := range list {
+					if m, ok := u.(map[string]interface{}); ok {
+						perms := m["permissions"]
+						fmt.Printf("  - username: %v | role: %v | permissions: %v\n", m["username"], m["role"], perms)
+					}
+				}
+			}
 		}
 		fmt.Print(reset)
 	default:


### PR DESCRIPTION
Summary                                                                                                                                                                
   
  Adds a new LIST_USERS query type that allows admin users to fetch a list of all registered users. The response includes each user's username, role, and permissions —  
  passwords are explicitly excluded. Non-admin users receive an admin access required error. The CLI client exposes this as a list-users command with a client-side role
  guard.                                                                                                                                                                 
                                                                                                                                                                       
 Changes

1.  internal/models/query.go     ->             Added TypeListUsers = "LIST_USERS" constant       
2.  internal/auth/manager.go       ->           Added ListUsers() method — copies users without password field           
3. internal/queryengine/query_engine.go      -> Added LIST_USERS case in Execute(); added ListUsers() to AuthManagerIface        
4.  internal/queryengine/query_engine_test.go -> Added ListUsers() stub to mockAuth to satisfy updated interface 
5. cmd/server/server.go       ->  Gated LIST_USERS behind admin role check; deserializes JSON result into "users" response key        
6. main.go          ->  Added list-users CLI command; prints formatted user table in printResponse()       
7. E2ETests/auth_test.go  ->  Added TestListUsersAdminSuccess and TestListUsersNonAdminDenied E2E tests     

                                                                                                                                                                       
  Test plan                                                                                                                                                              
                                                                                                                                                                       
  - TestListUsersAdminSuccess — admin creates two users, calls LIST_USERS, verifies both appear with correct role and permissions, and confirms no password field is     
  present in any entry
  - TestListUsersNonAdminDenied — regular user sends LIST_USERS and receives an error response with no users key       