### PR TITLE
#36: Fix value tokenizer for handling white spaces

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/shibudb.org/shibudb-server/internal/cliinput"
+	"github.com/shibudb.org/shibudb-server/internal/cliparse"
 	"github.com/shibudb.org/shibudb-server/internal/models"
 )
 
@@ -50,7 +51,7 @@ func main() {
 			break
 		}
 
-		parts := strings.Fields(line)
+		parts := cliparse.Tokenize(line)
 		if len(parts) < 2 {
 			fmt.Println("Usage: put/get/delete <key> [value]")
 			continue
@@ -63,7 +64,7 @@ func main() {
 				fmt.Println("Usage: put <key> <value>")
 				continue
 			}
-			query = models.Query{Type: models.TypePut, Key: parts[1], Value: parts[2]}
+			query = models.Query{Type: models.TypePut, Key: parts[1], Value: cliparse.PutValue(parts)}
 		case "get":
 			query = models.Query{Type: models.TypeGet, Key: parts[1]}
 		case "delete":

--- a/internal/cliparse/cliparse.go
+++ b/internal/cliparse/cliparse.go
@@ -1,0 +1,47 @@
+package cliparse
+
+import "strings"
+
+func Tokenize(line string) []string {
+	var tokens []string
+	var cur strings.Builder
+	inToken := false
+	var quote rune // 0 when outside quotes, else the active quote character
+
+	flush := func() {
+		if inToken {
+			tokens = append(tokens, cur.String())
+			cur.Reset()
+			inToken = false
+		}
+	}
+
+	for _, r := range line {
+		switch {
+		case quote != 0:
+			if r == quote {
+				quote = 0
+			} else {
+				cur.WriteRune(r)
+			}
+			inToken = true
+		case r == '\'' || r == '"':
+			quote = r
+			inToken = true
+		case r == ' ' || r == '\t':
+			flush()
+		default:
+			cur.WriteRune(r)
+			inToken = true
+		}
+	}
+	flush()
+	return tokens
+}
+
+func PutValue(tokens []string) string {
+	if len(tokens) < 3 {
+		return ""
+	}
+	return strings.Join(tokens[2:], " ")
+}

--- a/internal/cliparse/cliparse_test.go
+++ b/internal/cliparse/cliparse_test.go
@@ -1,0 +1,147 @@
+package cliparse
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestTokenize(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"only spaces", "   ", nil},
+		{"single token", "get", []string{"get"}},
+		{"simple command", "put userName John", []string{"put", "userName", "John"}},
+		{
+			name: "unquoted multi-word value",
+			line: "put userName John Doe",
+			want: []string{"put", "userName", "John", "Doe"},
+		},
+		{
+			name: "double-quoted value with space stays one token",
+			line: `put userName "John Doe"`,
+			want: []string{"put", "userName", "John Doe"},
+		},
+		{
+			name: "single-quoted value with space stays one token",
+			line: "put userName 'John Doe'",
+			want: []string{"put", "userName", "John Doe"},
+		},
+		{
+			name: "double quotes preserve internal multiple spaces",
+			line: `put k "a    b"`,
+			want: []string{"put", "k", "a    b"},
+		},
+		{
+			name: "double quotes may contain single quotes",
+			line: `put k "it's fine"`,
+			want: []string{"put", "k", "it's fine"},
+		},
+		{
+			name: "single quotes may contain double quotes",
+			line: `put k 'say "hi"'`,
+			want: []string{"put", "k", `say "hi"`},
+		},
+		{
+			name: "empty quoted value is a real empty token",
+			line: `put k ""`,
+			want: []string{"put", "k", ""},
+		},
+		{
+			name: "leading and trailing whitespace ignored",
+			line: "  put   userName   John  ",
+			want: []string{"put", "userName", "John"},
+		},
+		{
+			name: "tabs treated as separators",
+			line: "put\tuserName\tJohn",
+			want: []string{"put", "userName", "John"},
+		},
+		{
+			name: "unterminated quote takes the rest of the line",
+			line: `put userName "John Doe`,
+			want: []string{"put", "userName", "John Doe"},
+		},
+		{
+			name: "quoted value preserves leading and trailing spaces",
+			line: `put k " padded "`,
+			want: []string{"put", "k", " padded "},
+		},
+		{
+			name: "flags on other commands are unaffected",
+			line: "create-space vectors --engine vector --dimension 128",
+			want: []string{"create-space", "vectors", "--engine", "vector", "--dimension", "128"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Tokenize(tc.line)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("Tokenize(%q) = %#v, want %#v", tc.line, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPutValue(t *testing.T) {
+	cases := []struct {
+		name   string
+		tokens []string
+		want   string
+	}{
+		{"missing value", []string{"put", "key"}, ""},
+		{"single word", []string{"put", "key", "John"}, "John"},
+		{
+			name:   "quoted value already merged",
+			tokens: []string{"put", "key", "John Doe"},
+			want:   "John Doe",
+		},
+		{
+			name:   "unquoted words rejoined",
+			tokens: []string{"put", "key", "John", "Doe"},
+			want:   "John Doe",
+		},
+		{"empty value token", []string{"put", "key", ""}, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := PutValue(tc.tokens); got != tc.want {
+				t.Fatalf("PutValue(%#v) = %q, want %q", tc.tokens, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPutRoundTrip(t *testing.T) {
+	cases := []struct {
+		line      string
+		wantKey   string
+		wantValue string
+	}{
+		{"put userName John Doe", "userName", "John Doe"},
+		{`put userName "John Doe"`, "userName", "John Doe"},
+		{"put userName 'John Doe'", "userName", "John Doe"},
+		{"put userName John", "userName", "John"},
+		{`put greeting "hello, world"`, "greeting", "hello, world"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.line, func(t *testing.T) {
+			parts := Tokenize(tc.line)
+			if len(parts) < 3 {
+				t.Fatalf("Tokenize(%q) produced %d tokens, want >= 3", tc.line, len(parts))
+			}
+			if parts[1] != tc.wantKey {
+				t.Fatalf("key = %q, want %q", parts[1], tc.wantKey)
+			}
+			if got := PutValue(parts); got != tc.wantValue {
+				t.Fatalf("value = %q, want %q", got, tc.wantValue)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ import (
 	"github.com/shibudb.org/shibudb-server/cmd/server"
 	"github.com/shibudb.org/shibudb-server/internal/auth"
 	"github.com/shibudb.org/shibudb-server/internal/cliinput"
+	"github.com/shibudb.org/shibudb-server/internal/cliparse"
 	"github.com/shibudb.org/shibudb-server/internal/models"
 	"github.com/shibudb.org/shibudb-server/internal/spaces"
 )
@@ -587,7 +588,10 @@ func connectToServer(port, providedUser, providedPass string) {
 			continue
 		}
 
-		parts := strings.Fields(line)
+		parts := cliparse.Tokenize(line)
+		if len(parts) == 0 {
+			continue
+		}
 
 		var commandsRequiringSpace = map[string]bool{
 			"put":    true,
@@ -830,10 +834,18 @@ func connectToServer(port, providedUser, providedPass string) {
 				fmt.Println("Usage: put <key> <value>")
 				continue
 			}
-			query = models.Query{Type: models.TypePut, Key: parts[1], Value: parts[2], Space: space, User: username}
+			query = models.Query{Type: models.TypePut, Key: parts[1], Value: cliparse.PutValue(parts), Space: space, User: username}
 		case "get":
+			if len(parts) < 2 {
+				fmt.Println("Usage: get <key>")
+				continue
+			}
 			query = models.Query{Type: models.TypeGet, Key: parts[1], Space: space, User: username}
 		case "delete":
+			if len(parts) < 2 {
+				fmt.Println("Usage: delete <key>")
+				continue
+			}
 			query = models.Query{Type: models.TypeDelete, Key: parts[1], Space: space, User: username}
 		case "insert-vector":
 			if space == "" {

--- a/scripts/connect-client.sh
+++ b/scripts/connect-client.sh
@@ -28,6 +28,7 @@ currentDir=$(pwd)
 
 # Set CGO environment variables based on platform
 export CGO_ENABLED=1
+export CGO_CFLAGS="-I$currentDir/resources/lib/include"
 export CGO_CXXFLAGS="-I$currentDir/resources/lib/include"
 
 # Detect OS and architecture
@@ -37,6 +38,7 @@ ARCH=$(uname -m)
 if [[ "$OS" == "Darwin" ]]; then
     # macOS
     export CGO_LDFLAGS="-L$currentDir/resources/lib/mac/apple_silicon -lfaiss -lfaiss_c -lc++"
+    export DYLD_LIBRARY_PATH="$currentDir/resources/lib/mac/apple_silicon:${DYLD_LIBRARY_PATH:-}"
 elif [[ "$OS" == "Linux" ]]; then
     # Linux
     if [[ "$ARCH" == "x86_64" ]]; then


### PR DESCRIPTION
## Description

PUT truncated any value containing spaces - `strings.Fields` split the line and only the first token (`parts[2]`) was stored, so `put userName John Doe` saved `John`. Added a quote and space aware tokenizer (`internal/cliparse`) used by both clients, the full value is now preserved.

Fixes (#36)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests: `go test ./internal/cliparse/`, covers unquoted multi-word, single/double quotes, empty/unterminated quotes, tabs.
- [x] Verified `put userName John Doe` and `put userName "John Doe"` both store `John Doe`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional Notes

Fix is client-side parsing only. Both clients (`main.go`, `cmd/client/main.go`) updated.