### PR TITLE
#31: Fix bugs in WAL implementation due to incorrect handling of file offsets

### DIFF
--- a/internal/storage/flat_meta_vector_storage.go
+++ b/internal/storage/flat_meta_vector_storage.go
@@ -714,12 +714,12 @@ func (e *FlatMetaVectorEngine) replayWAL() error {
 		return nil
 	}
 	for _, entry := range records {
-		keyBytes := []byte(entry[0])
+		keyBytes := []byte(entry.Key)
 		if len(keyBytes) != 8 {
 			return fmt.Errorf("invalid WAL key length: expected 8, got %d", len(keyBytes))
 		}
 		id := int64(binary.LittleEndian.Uint64(keyBytes))
-		if len(entry[1]) == 0 {
+		if entry.Flag == 'D' {
 			e.lock.Lock()
 			_, existed := e.metadata[id]
 			e.indexRemoveLocked(id)
@@ -729,7 +729,7 @@ func (e *FlatMetaVectorEngine) replayWAL() error {
 			}
 			continue
 		}
-		metaBytes, vec, err := decodeFlatMetaWALValue([]byte(entry[1]), e.dim)
+		metaBytes, vec, err := decodeFlatMetaWALValue([]byte(entry.Value), e.dim)
 		if err != nil {
 			return fmt.Errorf("decode WAL value for id %d: %w", id, err)
 		}

--- a/internal/storage/flat_meta_vector_storage.go
+++ b/internal/storage/flat_meta_vector_storage.go
@@ -176,7 +176,7 @@ func (e *FlatMetaVectorEngine) RemoveVector(id int64) error {
 	if e.wal != nil {
 		key := make([]byte, 8)
 		binary.LittleEndian.PutUint64(key, uint64(id))
-		if err := e.wal.WriteEntry(string(key), ""); err != nil {
+		if err := e.wal.WriteDelete(string(key)); err != nil {
 			return err
 		}
 	}

--- a/internal/storage/flat_meta_vector_storage.go
+++ b/internal/storage/flat_meta_vector_storage.go
@@ -719,7 +719,7 @@ func (e *FlatMetaVectorEngine) replayWAL() error {
 			return fmt.Errorf("invalid WAL key length: expected 8, got %d", len(keyBytes))
 		}
 		id := int64(binary.LittleEndian.Uint64(keyBytes))
-		if entry.Flag == 'D' {
+		if entry.Flag == wal.EntryDeleted {
 			e.lock.Lock()
 			_, existed := e.metadata[id]
 			e.indexRemoveLocked(id)

--- a/internal/storage/flat_meta_vector_storage_test.go
+++ b/internal/storage/flat_meta_vector_storage_test.go
@@ -319,6 +319,45 @@ func TestFlatMetaWALReplay(t *testing.T) {
 	assertIDSet(t, ids, 7)
 }
 
+func TestFlatMetaWALDeleteAndReplay(t *testing.T) {
+	dir := t.TempDir()
+	dataPath := filepath.Join(dir, "flat_meta_data.db")
+	walPath := filepath.Join(dir, "flat_meta_wal.db")
+	specs := []MetadataFieldSpec{
+		{Name: "user_id", Type: MetadataTypeString},
+		{Name: "age", Type: MetadataTypeInt},
+	}
+
+	e1, err := NewFlatMetaVectorEngine(dataPath, walPath, 2, faiss.MetricL2, specs, true)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	const id = 4
+	if err := e1.InsertVectorWithMetadata(id, []float32{0, 0}, map[string]any{"user_id": "eve", "age": 35.0}); err != nil {
+		t.Fatalf("insert %d: %v", id, err)
+	}
+
+	key := make([]byte, 8)
+	binary.LittleEndian.PutUint64(key, uint64(id))
+	if err := e1.wal.WriteDelete(string(key)); err != nil {
+		t.Fatalf("write delete to wal %d: %v", id, err)
+	}
+
+	if err := e1.Close(); err != nil { // Close flushes the append-only data file.
+		t.Fatalf("close: %v", err)
+	}
+
+	e2, err := NewFlatMetaVectorEngine(dataPath, walPath, 2, faiss.MetricL2, specs, true)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	t.Cleanup(func() { _ = e2.Close() })
+
+	if _, err := e2.GetVectorByID(id); err == nil {
+		t.Fatalf("expected id %d to be removed after restart due to pending delete entry in WAL", id)
+	}
+}
+
 func TestFlatMetaValidation(t *testing.T) {
 	specs := []MetadataFieldSpec{
 		{Name: "user_id", Type: MetadataTypeString},

--- a/internal/storage/key_value_storage.go
+++ b/internal/storage/key_value_storage.go
@@ -205,17 +205,14 @@ func (db *ShibuDB) replayWAL() {
 		return
 	}
 	for _, entry := range entries {
-		if len(entry) != 2 {
-			continue
-		}
-		if entry[1] == "" {
-			if err := db.Delete(entry[0]); err != nil && !errors.Is(err, errKeyDeleted) && !errors.Is(err, errKeyNotFound) {
-				log.Printf("WAL replay delete failed for %q: %v", entry[0], err)
+		if entry.Flag == wal.EntryDeleted {
+			if err := db.Delete(entry.Key); err != nil && !errors.Is(err, errKeyDeleted) && !errors.Is(err, errKeyNotFound) {
+				log.Printf("WAL replay delete failed for %q: %v", entry.Key, err)
 			}
 			continue
 		}
-		if err := db.PutBatch(entry[0], entry[1]); err != nil {
-			log.Printf("WAL replay put failed for %q: %v", entry[0], err)
+		if err := db.PutBatch(entry.Key, entry.Value); err != nil {
+			log.Printf("WAL replay put failed for %q: %v", entry.Key, err)
 		}
 	}
 	if err := db.FlushBatch(); err != nil {

--- a/internal/storage/key_value_storage_test.go
+++ b/internal/storage/key_value_storage_test.go
@@ -133,6 +133,49 @@ func TestShibuDB(t *testing.T) {
 		}
 	})
 
+	// Test Delete followed by Put on the same key with a different value
+	// and WAL replay gives us the new value
+	t.Run("DeleteKeyPutKeyAndWALReplay", func(t *testing.T) {
+		db, err = OpenDBWithPathsAndWAL("test_storage.db", "test_wal.db", "test_index.dat", true)
+		if err != nil {
+			t.Fatalf("Failed to open test DB: %v", err)
+		}
+
+		// Put and flush a key
+		db.PutBatch("deleteAndPutMe", "tempValue")
+		db.FlushBatch()
+
+		// Delete the key
+		err := db.Delete("deleteAndPutMe")
+		if err != nil {
+			t.Errorf("Delete failed: %v", err)
+		}
+
+		// Re-insert the key
+		err = db.Put("deleteAndPutMe", "newValue")
+		if err != nil {
+			t.Errorf("Put failed: %v", err)
+		}
+
+		// Close and reopen the database to simulate crash recovery
+		db.Close()
+		db, err = OpenDBWithPathsAndWAL("test_storage.db", "test_wal.db", "test_index.dat", true)
+		if err != nil {
+			t.Fatalf("Failed to reopen DB for WAL replay test: %v", err)
+		}
+		defer db.Close()
+
+		// Try to get the deleted key
+		val, err := db.Get("deleteAndPutMe")
+		if err != nil {
+			t.Errorf("Failed to retrieve key after delete followed by put: %v", err)
+
+		}
+		if val != "newValue" {
+			t.Errorf("Expected 'newValue', got '%s'", val)
+		}
+	})
+
 	// Test Multiple Entries in Single Flush
 	t.Run("FlushMultipleEntries", func(t *testing.T) {
 		// Add multiple entries

--- a/internal/storage/vector_storage.go
+++ b/internal/storage/vector_storage.go
@@ -659,17 +659,14 @@ func (ve *VectorEngineImpl) replayWAL() error {
 	}
 
 	for _, entry := range records {
-		if len(entry) != 2 {
-			continue
-		}
-		keyBytes := []byte(entry[0])
+		keyBytes := []byte(entry.Key)
 		if len(keyBytes) != 8 {
 			return fmt.Errorf("invalid WAL key length: expected 8, got %d", len(keyBytes))
 		}
 		id := int64(binary.LittleEndian.Uint64(keyBytes))
 
 		// Check if this is a deletion (empty value)
-		if len(entry[1]) == 0 {
+		if entry.Flag == wal.EntryDeleted {
 			// IMPORTANT: do not write to WAL here again — just remove.
 			if err := ve.removeAfterWAL(id); err != nil {
 				return fmt.Errorf("replay remove id=%d: %w", id, err)
@@ -677,7 +674,7 @@ func (ve *VectorEngineImpl) replayWAL() error {
 			continue
 		}
 
-		vec, err := bytesToFloat32Array([]byte(entry[1]))
+		vec, err := bytesToFloat32Array([]byte(entry.Value))
 		if err != nil {
 			return fmt.Errorf("WAL decode: %w", err)
 		}

--- a/internal/storage/vector_storage.go
+++ b/internal/storage/vector_storage.go
@@ -523,7 +523,7 @@ func (ve *VectorEngineImpl) RemoveVector(id int64) error {
 	if ve.wal != nil {
 		key := make([]byte, 8)
 		binary.LittleEndian.PutUint64(key, uint64(id))
-		if err := ve.wal.WriteEntry(string(key), ""); err != nil {
+		if err := ve.wal.WriteDelete(string(key)); err != nil {
 			return err
 		}
 	}

--- a/internal/storage/vector_storage_flat_l2_test.go
+++ b/internal/storage/vector_storage_flat_l2_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"encoding/binary"
 	"log"
 	"math/rand"
 	"os"
@@ -353,6 +354,45 @@ func TestVectorEngineImpl_InsertAndSearch(t *testing.T) {
 		}
 		if reflect.DeepEqual(stored, vec1) {
 			t.Errorf("Stored vector should not match first inserted vector")
+		}
+	})
+
+	t.Run("Replay after insert and write delete to WAL", func(t *testing.T) {
+		// Create a fresh engine for this test
+		cleanDataPath := "testdata/vector_data_ivf_insert_after_remove.db"
+		cleanIndexPath := "testdata/vector_index_ivf_insert_after_remove.faiss"
+		cleanWalPath := "testdata/vector_wal_ivf_insert_after_remove.db"
+
+		os.Remove(cleanDataPath)
+		os.Remove(cleanIndexPath)
+		os.Remove(cleanWalPath)
+
+		cleanVe, err := NewVectorEngine(cleanDataPath, cleanIndexPath, cleanWalPath, maxVectorSize, indexDesc, metric, true)
+		if err != nil {
+			t.Skipf("Failed to create clean engine: %v", err)
+		}
+		defer cleanVe.Close()
+		defer func() {
+			os.Remove(cleanDataPath)
+			os.Remove(cleanIndexPath)
+			os.Remove(cleanWalPath)
+		}()
+		id := int64(8888)
+		if err := cleanVe.InsertVector(id, randomVector(maxVectorSize)); err != nil {
+			t.Errorf("InsertVector failed: %v", err)
+		}
+		key := make([]byte, 8)
+		binary.LittleEndian.PutUint64(key, uint64(id))
+		if err := cleanVe.wal.WriteDelete(string(key)); err != nil {
+			t.Errorf("write delete to wal failed: %v", err)
+		}
+		if err := cleanVe.replayWAL(); err != nil {
+			t.Errorf("replayWAL failed: %v", err)
+		}
+
+		// Vector should be removed after replaying WAL
+		if _, err = cleanVe.GetVectorByID(id); err == nil {
+			t.Error("Expected error when getting removed vector")
 		}
 	})
 }

--- a/internal/storage/vector_storage_ivf256_flat_test.go
+++ b/internal/storage/vector_storage_ivf256_flat_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"encoding/binary"
 	"math/rand"
 	"os"
 	"reflect"
@@ -294,6 +295,45 @@ func TestVectorEngineImpl_InsertAndSearch_IVF256Flat(t *testing.T) {
 		}
 		if reflect.DeepEqual(stored, vec1) {
 			t.Errorf("Stored vector should not match first inserted vector")
+		}
+	})
+
+	t.Run("Replay after insert and write delete to WAL", func(t *testing.T) {
+		// Create a fresh engine for this test
+		cleanDataPath := "testdata/vector_data_ivf256_insert_after_remove.db"
+		cleanIndexPath := "testdata/vector_index_ivf256_insert_after_remove.faiss"
+		cleanWalPath := "testdata/vector_wal_ivf256_insert_after_remove.db"
+
+		os.Remove(cleanDataPath)
+		os.Remove(cleanIndexPath)
+		os.Remove(cleanWalPath)
+
+		cleanVe, err := NewVectorEngine(cleanDataPath, cleanIndexPath, cleanWalPath, maxVectorSize, indexDesc, metric, true)
+		if err != nil {
+			t.Skipf("Failed to create clean engine: %v", err)
+		}
+		defer cleanVe.Close()
+		defer func() {
+			os.Remove(cleanDataPath)
+			os.Remove(cleanIndexPath)
+			os.Remove(cleanWalPath)
+		}()
+		id := int64(8888)
+		if err := cleanVe.InsertVector(id, randomVector(maxVectorSize)); err != nil {
+			t.Errorf("InsertVector failed: %v", err)
+		}
+		key := make([]byte, 8)
+		binary.LittleEndian.PutUint64(key, uint64(id))
+		if err := cleanVe.wal.WriteDelete(string(key)); err != nil {
+			t.Errorf("write delete to wal failed: %v", err)
+		}
+		if err := cleanVe.replayWAL(); err != nil {
+			t.Errorf("replayWAL failed: %v", err)
+		}
+
+		// Vector should be removed after replaying WAL
+		if _, err = cleanVe.GetVectorByID(id); err == nil {
+			t.Error("Expected error when getting removed vector")
 		}
 	})
 }

--- a/internal/storage/vector_storage_ivf_flat_test.go
+++ b/internal/storage/vector_storage_ivf_flat_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"encoding/binary"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -295,6 +296,45 @@ func TestVectorEngineImpl_InsertAndSearch_IVF32Flat(t *testing.T) {
 		}
 		if reflect.DeepEqual(stored, vec1) {
 			t.Errorf("Stored vector should not match first inserted vector")
+		}
+	})
+
+	t.Run("Replay after insert and write delete to WAL", func(t *testing.T) {
+		// Create a fresh engine for this test
+		cleanDataPath := "testdata/vector_data_ivf_insert_after_remove.db"
+		cleanIndexPath := "testdata/vector_index_ivf_insert_after_remove.faiss"
+		cleanWalPath := "testdata/vector_wal_ivf_insert_after_remove.db"
+
+		os.Remove(cleanDataPath)
+		os.Remove(cleanIndexPath)
+		os.Remove(cleanWalPath)
+
+		cleanVe, err := NewVectorEngine(cleanDataPath, cleanIndexPath, cleanWalPath, maxVectorSize, indexDesc, metric, true)
+		if err != nil {
+			t.Skipf("Failed to create clean engine: %v", err)
+		}
+		defer cleanVe.Close()
+		defer func() {
+			os.Remove(cleanDataPath)
+			os.Remove(cleanIndexPath)
+			os.Remove(cleanWalPath)
+		}()
+		id := int64(8888)
+		if err := cleanVe.InsertVector(id, randomVector(maxVectorSize)); err != nil {
+			t.Errorf("InsertVector failed: %v", err)
+		}
+		key := make([]byte, 8)
+		binary.LittleEndian.PutUint64(key, uint64(id))
+		if err := cleanVe.wal.WriteDelete(string(key)); err != nil {
+			t.Errorf("write delete to wal failed: %v", err)
+		}
+		if err := cleanVe.replayWAL(); err != nil {
+			t.Errorf("replayWAL failed: %v", err)
+		}
+
+		// Vector should be removed after replaying WAL
+		if _, err = cleanVe.GetVectorByID(id); err == nil {
+			t.Error("Expected error when getting removed vector")
 		}
 	})
 }

--- a/internal/storage/vector_storage_ivf_pq_test.go
+++ b/internal/storage/vector_storage_ivf_pq_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"encoding/binary"
 	"math/rand"
 	"os"
 	"reflect"
@@ -294,6 +295,44 @@ func TestVectorEngineImpl_InsertAndSearch_IVF32PQ4(t *testing.T) {
 		}
 		if reflect.DeepEqual(stored, vec1) {
 			t.Errorf("Stored vector should not match first inserted vector")
+		}
+	})
+	t.Run("Replay after insert and write delete to WAL", func(t *testing.T) {
+		// Create a fresh engine for this test
+		cleanDataPath := "testdata/vector_data_ivf_pq_insert_after_remove.db"
+		cleanIndexPath := "testdata/vector_index_ivf_pq_insert_after_remove.faiss"
+		cleanWalPath := "testdata/vector_wal_ivf_pq_insert_after_remove.db"
+
+		os.Remove(cleanDataPath)
+		os.Remove(cleanIndexPath)
+		os.Remove(cleanWalPath)
+
+		cleanVe, err := NewVectorEngine(cleanDataPath, cleanIndexPath, cleanWalPath, maxVectorSize, indexDesc, metric, true)
+		if err != nil {
+			t.Skipf("Failed to create clean engine: %v", err)
+		}
+		defer cleanVe.Close()
+		defer func() {
+			os.Remove(cleanDataPath)
+			os.Remove(cleanIndexPath)
+			os.Remove(cleanWalPath)
+		}()
+		id := int64(8888)
+		if err := cleanVe.InsertVector(id, randomVector(maxVectorSize)); err != nil {
+			t.Errorf("InsertVector failed: %v", err)
+		}
+		key := make([]byte, 8)
+		binary.LittleEndian.PutUint64(key, uint64(id))
+		if err := cleanVe.wal.WriteDelete(string(key)); err != nil {
+			t.Errorf("write delete to wal failed: %v", err)
+		}
+		if err := cleanVe.replayWAL(); err != nil {
+			t.Errorf("replayWAL failed: %v", err)
+		}
+
+		// Vector should be removed after replaying WAL
+		if _, err = cleanVe.GetVectorByID(id); err == nil {
+			t.Error("Expected error when getting removed vector")
 		}
 	})
 }

--- a/internal/storage/vector_storage_multi_client_benchmark_test.go
+++ b/internal/storage/vector_storage_multi_client_benchmark_test.go
@@ -256,7 +256,7 @@ func runVectorEngineMultiClientInsertBenchmark(t *testing.T, enableWAL bool) {
 	avgIndex := totalIndexTime / time.Duration(insertCount)
 	avgWALCommit := totalWALCommitTime / time.Duration(insertCount)
 	avgExplicitSync := (totalWALWriteTime + totalWALCommitTime) / time.Duration(insertCount)
-	syncShare := 100 * float64((totalWALWriteTime+totalWALCommitTime).Nanoseconds()) / float64(totalInsertTime.Nanoseconds())
+	syncShare := 100 * float64((totalWALWriteTime + totalWALCommitTime).Nanoseconds()) / float64(totalInsertTime.Nanoseconds())
 
 	mode := "WAL enabled"
 	if !enableWAL {

--- a/internal/wal/wal.go
+++ b/internal/wal/wal.go
@@ -20,9 +20,9 @@ type WALEntry struct {
 }
 
 const (
-	EntryPending  byte = 'P'
-	EntryCommited byte = 'C'
-	EntryDeleted  byte = 'D'
+	EntryPending   byte = 'P'
+	EntryCommitted byte = 'C'
+	EntryDeleted   byte = 'D'
 )
 
 func OpenWAL(filename string) (*WAL, error) {
@@ -73,7 +73,7 @@ func (w *WAL) WriteEntry(key, value string) error {
 }
 
 // Utility to read the WAL entry header starting at the current offset in the file.
-// It is not thread-safe and must be called from a thread safe context
+// It is not thread-safe and must be called from a thread safe context.
 func (w *WAL) readHeader() (keySize uint32, valSize uint32, commitFlag byte, err error) {
 	header := make([]byte, 9)
 	_, err = io.ReadFull(w.file, header)
@@ -90,7 +90,7 @@ func (w *WAL) WriteDelete(key string) error {
 	w.lock.Lock()
 	defer w.lock.Unlock()
 
-	_, err := w.file.Seek(0, io.SeekEnd) // Ensure we start at the absolute end
+	offset, err := w.file.Seek(0, io.SeekEnd) // Ensure we start at the absolute end
 	if err != nil {
 		return err
 	}
@@ -109,7 +109,15 @@ func (w *WAL) WriteDelete(key string) error {
 		return err
 	}
 
-	return w.file.Sync()
+	err = w.file.Sync()
+	if err != nil {
+		return err
+	}
+
+	if w.oldestPendingOffset < 0 {
+		w.oldestPendingOffset = offset
+	}
+	return nil
 }
 
 func (w *WAL) MarkCommitted() error {
@@ -121,7 +129,7 @@ func (w *WAL) MarkCommitted() error {
 		return nil
 	}
 
-	commitByte := []byte{EntryCommited}
+	commitByte := []byte{EntryCommitted}
 	offset := w.oldestPendingOffset
 	for offset >= 0 {
 		_, err := w.file.Seek(offset, io.SeekStart)
@@ -132,6 +140,10 @@ func (w *WAL) MarkCommitted() error {
 		if err == io.EOF {
 			break
 		}
+		if err != nil {
+			return err
+		}
+
 		_, err = w.file.Seek(-1, io.SeekCurrent)
 		if err != nil {
 			return err
@@ -168,7 +180,7 @@ func (w *WAL) Replay() ([]*WALEntry, error) {
 			return nil, err
 		}
 
-		if commitFlag == EntryCommited {
+		if commitFlag == EntryCommitted {
 			// Skip bytes for key and value since the transaction is commited
 			_, err := w.file.Seek(int64(keySize)+int64(valSize), io.SeekCurrent)
 			if err != nil {

--- a/internal/wal/wal.go
+++ b/internal/wal/wal.go
@@ -8,21 +8,39 @@ import (
 )
 
 type WAL struct {
-	file *os.File
-	lock sync.Mutex
+	file                *os.File
+	lock                sync.Mutex
+	oldestPendingOffset int64
 }
+
+type WALEntry struct {
+	Key   string
+	Value string
+	Flag  byte
+}
+
+const (
+	EntryPending  byte = 'P'
+	EntryCommited byte = 'C'
+	EntryDeleted  byte = 'D'
+)
 
 func OpenWAL(filename string) (*WAL, error) {
 	file, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE, 0666) // Remove O_APPEND
 	if err != nil {
 		return nil, err
 	}
-	return &WAL{file: file}, nil
+	return &WAL{file: file, oldestPendingOffset: -1}, nil
 }
 
 func (w *WAL) WriteEntry(key, value string) error {
+
 	w.lock.Lock()
 	defer w.lock.Unlock()
+	offset, err := w.file.Seek(0, io.SeekEnd) // Ensure we start at the absolute end
+	if err != nil {
+		return err
+	}
 
 	keyBytes := []byte(key)
 	valBytes := []byte(value)
@@ -33,22 +51,49 @@ func (w *WAL) WriteEntry(key, value string) error {
 	buf := make([]byte, 9+len(keyBytes)+len(valBytes)) // Extra byte for commit flag
 	binary.LittleEndian.PutUint32(buf[0:4], keySize)
 	binary.LittleEndian.PutUint32(buf[4:8], valSize)
-	buf[8] = 'P' // 'P' means pending commit
+	buf[8] = EntryPending
 	copy(buf[9:9+len(keyBytes)], keyBytes)
 	copy(buf[9+len(keyBytes):], valBytes)
 
-	_, err := w.file.Write(buf)
+	_, err = w.file.Write(buf)
 	if err != nil {
 		return err
 	}
 
 	// Force sync to ensure data is written before unlocking
-	return w.file.Sync()
+	err = w.file.Sync()
+	if err != nil {
+		return err
+	}
+
+	if w.oldestPendingOffset < 0 {
+		w.oldestPendingOffset = offset
+	}
+	return nil
+}
+
+// Utility to read the WAL entry header starting at the current offset in the file.
+// It is not thread-safe and must be called from a thread safe context
+func (w *WAL) readHeader() (keySize uint32, valSize uint32, commitFlag byte, err error) {
+	header := make([]byte, 9)
+	_, err = io.ReadFull(w.file, header)
+	if err != nil {
+		return
+	}
+	keySize = binary.LittleEndian.Uint32(header[0:4])
+	valSize = binary.LittleEndian.Uint32(header[4:8])
+	commitFlag = header[8]
+	return
 }
 
 func (w *WAL) WriteDelete(key string) error {
 	w.lock.Lock()
 	defer w.lock.Unlock()
+
+	_, err := w.file.Seek(0, io.SeekEnd) // Ensure we start at the absolute end
+	if err != nil {
+		return err
+	}
 
 	keyBytes := []byte(key)
 	keySize := uint32(len(keyBytes))
@@ -56,10 +101,10 @@ func (w *WAL) WriteDelete(key string) error {
 	buf := make([]byte, 9+len(keyBytes))
 	binary.LittleEndian.PutUint32(buf[0:4], keySize)
 	binary.LittleEndian.PutUint32(buf[4:8], 0) // value size 0
-	buf[8] = 'D'                               // 'D' means delete
+	buf[8] = EntryDeleted
 	copy(buf[9:], keyBytes)
 
-	_, err := w.file.Write(buf)
+	_, err = w.file.Write(buf)
 	if err != nil {
 		return err
 	}
@@ -68,48 +113,68 @@ func (w *WAL) WriteDelete(key string) error {
 }
 
 func (w *WAL) MarkCommitted() error {
+
 	w.lock.Lock()
 	defer w.lock.Unlock()
 
-	_, err := w.file.Seek(8, io.SeekStart)
+	if w.oldestPendingOffset < 0 {
+		return nil
+	}
+
+	commitByte := []byte{EntryCommited}
+	offset := w.oldestPendingOffset
+	for offset >= 0 {
+		_, err := w.file.Seek(offset, io.SeekStart)
+		if err != nil {
+			return err
+		}
+		keySize, valSize, _, err := w.readHeader()
+		if err == io.EOF {
+			break
+		}
+		_, err = w.file.Seek(-1, io.SeekCurrent)
+		if err != nil {
+			return err
+		}
+		_, err = w.file.Write(commitByte)
+		offset += 9 + int64(keySize) + int64(valSize)
+	}
+	err := w.file.Sync()
 	if err != nil {
 		return err
 	}
-
-	commitByte := []byte{'C'}
-	_, err = w.file.Write(commitByte)
-	if err != nil {
-		return err
-	}
-
-	return w.file.Sync() // Ensure changes are flushed
+	// All pending entries have been commited
+	w.oldestPendingOffset = -1
+	return nil
 }
 
-func (w *WAL) Replay() ([][2]string, error) {
+func (w *WAL) Replay() ([]*WALEntry, error) {
 	w.lock.Lock()
 	defer w.lock.Unlock()
+
+	var entries []*WALEntry
 
 	_, err := w.file.Seek(0, io.SeekStart) // Ensure we start at the absolute beginning
 	if err != nil {
 		return nil, err
 	}
 
-	var entries [][2]string
 	for {
-		header := make([]byte, 9)
-		_, err := io.ReadFull(w.file, header)
+		keySize, valSize, commitFlag, err := w.readHeader()
+
 		if err == io.EOF {
 			break // Properly handle EOF
 		} else if err != nil {
 			return nil, err
 		}
 
-		keySize := binary.LittleEndian.Uint32(header[0:4])
-		valSize := binary.LittleEndian.Uint32(header[4:8])
-		commitFlag := header[8]
-
-		if commitFlag == 'C' {
-			continue // Skip already committed transactions
+		if commitFlag == EntryCommited {
+			// Skip bytes for key and value since the transaction is commited
+			_, err := w.file.Seek(int64(keySize)+int64(valSize), io.SeekCurrent)
+			if err != nil {
+				return nil, err
+			}
+			continue
 		}
 
 		keyBytes := make([]byte, keySize)
@@ -129,8 +194,11 @@ func (w *WAL) Replay() ([][2]string, error) {
 		if err != nil {
 			return nil, err
 		}
-
-		entries = append(entries, [2]string{string(keyBytes), string(valBytes)})
+		entries = append(entries, &WALEntry{
+			Key:   string(keyBytes),
+			Value: string(valBytes),
+			Flag:  commitFlag,
+		})
 	}
 	return entries, nil
 }
@@ -138,6 +206,7 @@ func (w *WAL) Replay() ([][2]string, error) {
 func (w *WAL) Clear() error {
 	w.lock.Lock()
 	defer w.lock.Unlock()
+	w.oldestPendingOffset = -1
 	return os.Truncate(w.file.Name(), 0)
 }
 

--- a/internal/wal/wal_test.go
+++ b/internal/wal/wal_test.go
@@ -46,7 +46,7 @@ func TestWAL(t *testing.T) {
 		if err != nil {
 			t.Errorf("Replay failed: %v", err)
 		}
-		if len(entries) != 1 || entries[0][0] != "key1" || entries[0][1] != "value1" {
+		if len(entries) != 1 || entries[0].Key != "key1" || entries[0].Value != "value1" {
 			t.Errorf("Unexpected replay data: %v", entries)
 		}
 		printWALState("After ReplayBeforeCommit")
@@ -62,7 +62,7 @@ func TestWAL(t *testing.T) {
 		printWALState("After MarkCommitted")
 	})
 
-	// Test Replay after commit
+	// Test Replay after committing
 	t.Run("ReplayAfterCommit", func(t *testing.T) {
 		printWALState("Before ReplayAfterCommit")
 		entries, err := w.Replay()
@@ -75,6 +75,55 @@ func TestWAL(t *testing.T) {
 		printWALState("After ReplayAfterCommit")
 	})
 
+	// Test WriteEntry, MarkCommited, WriteEntry and Replay
+	t.Run("WriteEntryMarkCommitedWriteEntryReplay", func(t *testing.T) {
+		printWALState("Before WriteEntryMarkCommitWriteEntryAndReplay")
+		err := w.WriteEntry("key2", "value2")
+		if err != nil {
+			t.Errorf("WriteEntry failed: %v", err)
+		}
+		err = w.MarkCommitted()
+		if err != nil {
+			t.Errorf("MarkCommitted failed: %v", err)
+		}
+		err = w.WriteEntry("longKey3", "longValue3")
+		if err != nil {
+			t.Errorf("WriteEntry failed: %v", err)
+		}
+		entries, err := w.Replay()
+		if err != nil {
+			t.Errorf("Replay failed: %v", err)
+		}
+		if len(entries) != 1 || entries[0].Key != "longKey3" || entries[0].Value != "longValue3" {
+			t.Errorf("Unexpected replay data: %v", entries)
+		}
+
+		printWALState("After WriteEntryAndReplayAfterCommit")
+	})
+
+	// Test MarkCommitted() on the third entry
+	t.Run("MarkCommitted2", func(t *testing.T) {
+		printWALState("Before MarkCommitted")
+		err := w.MarkCommitted()
+		if err != nil {
+			t.Errorf("MarkCommitted failed: %v", err)
+		}
+		printWALState("After MarkCommitted")
+	})
+
+	// Test Replay after committing the third entry
+	t.Run("ReplayAfterCommit2", func(t *testing.T) {
+		printWALState("Before ReplayAfterCommit2")
+		entries, err := w.Replay()
+		if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
+			t.Errorf("Replay failed: %v", err)
+		}
+		if len(entries) != 0 {
+			t.Errorf("Expected no entries after commit, but got: %v", entries)
+		}
+		printWALState("After ReplayAfterCommit2")
+	})
+
 	t.Run("WriteDelete", func(t *testing.T) {
 		printWALState("Before WriteDelete")
 		err := w.WriteDelete("deletedKey")
@@ -85,10 +134,8 @@ func TestWAL(t *testing.T) {
 		if err != nil {
 			t.Errorf("Replay failed after WriteDelete: %v", err)
 		}
-		for _, entry := range entries {
-			if entry[0] == "deletedKey" {
-				t.Errorf("Expected 'deletedKey' to be skipped in replay, but found in entries")
-			}
+		if len(entries) != 1 || entries[0].Key != "deletedKey" || entries[0].Value != "" || entries[0].Flag != EntryDeleted {
+			t.Errorf("Expected a single DELETE entry for 'deletedKey', but got: %v", entries)
 		}
 		printWALState("After WriteDelete")
 	})

--- a/internal/wal/wal_test.go
+++ b/internal/wal/wal_test.go
@@ -62,7 +62,7 @@ func TestWAL(t *testing.T) {
 		printWALState("After MarkCommitted")
 	})
 
-	// Test Replay after committing
+	// Test Replay after commit
 	t.Run("ReplayAfterCommit", func(t *testing.T) {
 		printWALState("Before ReplayAfterCommit")
 		entries, err := w.Replay()

--- a/internal/wal/wal_test.go
+++ b/internal/wal/wal_test.go
@@ -140,6 +140,18 @@ func TestWAL(t *testing.T) {
 		printWALState("After WriteDelete")
 	})
 
+	t.Run("CommitAndReplayAfterDelete", func(t *testing.T) {
+		printWALState("Before CommitAndReplayAfterDelete")
+		err := w.MarkCommitted()
+		if err != nil {
+			t.Errorf("MarkCommitted failed: %v", err)
+		}
+		entries, err := w.Replay()
+		if len(entries) != 0 {
+			t.Errorf("Expected no entries after commit, but got: %v", entries)
+		}
+		printWALState("After CommitAndReplayAfterDelete")
+	})
 	// Test Clear()
 	t.Run("Clear", func(t *testing.T) {
 		printWALState("Before Clear")


### PR DESCRIPTION
## Description

Resolve bugs arising from incorrect assumptions about the file offset in the WAL.
- Fix WriteEntry() and WriteDelete() to always seek to the end of the file.
- Update WriteEntry() to keep track of the offset in the file for the oldest pending entry.
- Fix Replay() to skip bytes for the key and value by advancing the file offset when encountering committed entries and return typed entries allowing callers to differentiate between pending and deleted entries.
- Fix MarkCommitted() to start from the offset of the oldest pending entry and continue marking all further entries as committed.

Fixes #31 

## Type of change

Please delete options that are not relevant.
- [✓] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added additional tests `TestWAL/WriteEntryMarkCommitedWriteEntryReplay`, `TestWAL/ReplayAfterCommit2` and `TestWAL/MarkCommitted2` which ensures that the WAL handles writing of a new entry after a committed entry correctly without clobbering the previous entry. It also validates that Replay() skips committed records correctly.

Updated `TestWAL/WriteDelete` to expect a single entry with a Deleted flag instead of no entries, it was previously passing because of a bug in Replay() which was not consuming all the bytes for committed records causing the reading of subsequent entries from incorrect offsets in the file.

- [✓] TestWAL/WriteEntryMarkCommitedWriteEntryReplay
- [✓] TestWAL/MarkCommitted2
- [✓] TestWAL/ReplayAfterCommit2
- [✓] TestWAL/WriteDelete

## Checklist:

- [✓] My code follows the style guidelines of this project
- [✓] I have performed a self-review of my own code
- [✓] I have commented my code, particularly in hard-to-understand areas
- [✓] I have made corresponding changes to the documentation
- [✓] My changes generate no new warnings
- [✓] I have added tests that prove my fix is effective or that my feature works
- [✓] New and existing unit tests pass locally with my changes
- [✓] Any dependent changes have been merged and published in downstream modules

## Additional Notes
I see additional opportunities for refactoring the WAL implementation in line with DRY principles by refactoring WriteEntry and WriteDelete to use a common helper since the logic for both these operations is essentially the same (apart from tracking the last pending offset). I have already split out the logic for reading the header for an entry for sharing between Replay() and MarkCommitted()