### PR TITLE
feat(key-value storage): enabled index types for key-value storage read

### DIFF
--- a/E2ETests/key_value_e2e_test.go
+++ b/E2ETests/key_value_e2e_test.go
@@ -1,0 +1,236 @@
+package E2ETests
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/shibudb.org/shibudb-server/internal/models"
+)
+
+// kvResponse mirrors the server's JSON reply. Value is only set for GET.
+type kvResponse struct {
+	Status  string `json:"status"`
+	Message string `json:"message"`
+	Value   string `json:"value"`
+}
+
+// sendAndParse sends a query and decodes the JSON response so tests can assert
+// exact value equality (the older helpers only do substring matching, which
+// cannot distinguish values containing quotes, unicode escapes, etc).
+func sendAndParse(t *testing.T, q models.Query, conn net.Conn, reader *bufio.Reader) kvResponse {
+	t.Helper()
+	raw := sendQueryAndGetResponse(q, conn, reader)
+	var resp kvResponse
+	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &resp); err != nil {
+		t.Fatalf("failed to parse server response %q: %v", raw, err)
+	}
+	return resp
+}
+
+func kvConnect(t *testing.T) (net.Conn, *bufio.Reader) {
+	t.Helper()
+	conn, err := net.Dial("tcp", "localhost:4444")
+	if err != nil {
+		t.Fatalf("TCP connection error: %v", err)
+	}
+	reader := bufio.NewReader(conn)
+	if !Login("admin", "admin", conn, reader) {
+		conn.Close()
+		t.Fatal("Setup failed: Login failed")
+	}
+	return conn, reader
+}
+
+func kvCreateSpace(t *testing.T, space string, conn net.Conn, reader *bufio.Reader) {
+	t.Helper()
+	CleanSpace(space, conn, reader)
+	if !CreateSpaceWithSettings(models.Query{
+		Type:       models.TypeCreateSpace,
+		Space:      space,
+		EngineType: "key-value",
+		EnableWAL:  true,
+	}, conn, reader) {
+		t.Fatalf("failed to create key-value space %s", space)
+	}
+}
+
+func kvPut(t *testing.T, space, key, value string, conn net.Conn, reader *bufio.Reader) {
+	t.Helper()
+	resp := sendAndParse(t, models.Query{Type: models.TypePut, Space: space, Key: key, Value: value}, conn, reader)
+	if resp.Status != "OK" {
+		t.Fatalf("PUT %q failed: %+v", key, resp)
+	}
+}
+
+func kvGet(t *testing.T, space, key string, conn net.Conn, reader *bufio.Reader) kvResponse {
+	t.Helper()
+	return sendAndParse(t, models.Query{Type: models.TypeGet, Space: space, Key: key}, conn, reader)
+}
+
+func kvExpectValue(t *testing.T, space, key, want string, conn net.Conn, reader *bufio.Reader) {
+	t.Helper()
+	resp := kvGet(t, space, key, conn, reader)
+	if resp.Status != "OK" {
+		t.Fatalf("GET %q failed: %+v", key, resp)
+	}
+	if resp.Value != want {
+		t.Fatalf("GET %q = %q, want %q", key, resp.Value, want)
+	}
+}
+
+// TestKeyValueOverwriteAndRePutE2E verifies last-writer-wins semantics over the
+// wire: overwriting an existing key, and re-putting a key after deleting it.
+func TestKeyValueOverwriteAndRePutE2E(t *testing.T) {
+	conn, reader := kvConnect(t)
+	defer conn.Close()
+
+	space := "kv_overwrite_e2e"
+	kvCreateSpace(t, space, conn, reader)
+	defer CleanSpace(space, conn, reader)
+
+	kvPut(t, space, "k", "v1", conn, reader)
+	kvExpectValue(t, space, "k", "v1", conn, reader)
+
+	kvPut(t, space, "k", "v2", conn, reader)
+	kvExpectValue(t, space, "k", "v2", conn, reader)
+
+	resp := sendAndParse(t, models.Query{Type: models.TypeDelete, Space: space, Key: "k"}, conn, reader)
+	if resp.Status != "OK" || resp.Message != "DELETED" {
+		t.Fatalf("DELETE failed: %+v", resp)
+	}
+	if got := kvGet(t, space, "k", conn, reader); got.Status != "ERROR" {
+		t.Fatalf("GET after DELETE should error, got %+v", got)
+	}
+
+	kvPut(t, space, "k", "v3", conn, reader)
+	kvExpectValue(t, space, "k", "v3", conn, reader)
+}
+
+// TestKeyValueSpecialValuesE2E verifies that values with characters that could
+// break JSON transport or the on-disk record format round-trip byte-for-byte.
+func TestKeyValueSpecialValuesE2E(t *testing.T) {
+	conn, reader := kvConnect(t)
+	defer conn.Close()
+
+	space := "kv_special_values_e2e"
+	kvCreateSpace(t, space, conn, reader)
+	defer CleanSpace(space, conn, reader)
+
+	cases := []struct {
+		name  string
+		key   string
+		value string
+	}{
+		{"json_object", "jsonKey", `{"name":"test","nested":{"a":[1,2,3]},"quote":"he said \"hi\""}`},
+		{"unicode", "unicodeKey", "こんにちは世界 – ключ значение – 🚀"},
+		{"spaces_and_tabs", "spacedKey", "value with spaces\tand\ttabs"},
+		{"newlines", "multilineKey", "line one\nline two\r\nline three"},
+		{"quotes_backslashes", "escapeKey", `back\slash "double" 'single' and \n literal`},
+		{"numeric_string", "numKey", "0003.14000"},
+		{"single_char", "tinyKey", "x"},
+		{"large_8kb", "largeKey", strings.Repeat("Lorem ipsum dolor sit amet. ", 300)},
+		{"unicode_key", "клавиша-キー", "value for unicode key"},
+		{"special_chars_key", "key:with/slashes.and.dots|pipe", "value for special key"},
+	}
+
+	for _, tc := range cases {
+		kvPut(t, space, tc.key, tc.value, conn, reader)
+	}
+	// Read back after all writes so earlier writes may have been flushed to the
+	// data file while later ones are still in the in-memory batch.
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			kvExpectValue(t, space, tc.key, tc.value, conn, reader)
+		})
+	}
+}
+
+// TestKeyValueBulkE2E writes a larger set of keys, deletes a subset, and
+// verifies every key resolves to exactly the right state afterwards.
+func TestKeyValueBulkE2E(t *testing.T) {
+	conn, reader := kvConnect(t)
+	defer conn.Close()
+
+	space := "kv_bulk_e2e"
+	kvCreateSpace(t, space, conn, reader)
+	defer CleanSpace(space, conn, reader)
+
+	const total = 100
+	for i := 0; i < total; i++ {
+		kvPut(t, space, fmt.Sprintf("bulk-key-%03d", i), fmt.Sprintf("bulk-value-%03d", i), conn, reader)
+	}
+
+	// Delete every third key.
+	for i := 0; i < total; i += 3 {
+		key := fmt.Sprintf("bulk-key-%03d", i)
+		resp := sendAndParse(t, models.Query{Type: models.TypeDelete, Space: space, Key: key}, conn, reader)
+		if resp.Status != "OK" {
+			t.Fatalf("DELETE %q failed: %+v", key, resp)
+		}
+	}
+
+	for i := 0; i < total; i++ {
+		key := fmt.Sprintf("bulk-key-%03d", i)
+		resp := kvGet(t, space, key, conn, reader)
+		if i%3 == 0 {
+			if resp.Status != "ERROR" {
+				t.Fatalf("GET deleted key %q should error, got %+v", key, resp)
+			}
+			continue
+		}
+		want := fmt.Sprintf("bulk-value-%03d", i)
+		if resp.Status != "OK" || resp.Value != want {
+			t.Fatalf("GET %q = %+v, want value %q", key, resp, want)
+		}
+	}
+}
+
+// TestKeyValueEmptyValueRejectedE2E verifies the server rejects empty values
+// (they are unrepresentable in the storage format) and that a rejected PUT
+// neither creates a key nor clobbers an existing value.
+func TestKeyValueEmptyValueRejectedE2E(t *testing.T) {
+	conn, reader := kvConnect(t)
+	defer conn.Close()
+
+	space := "kv_empty_value_e2e"
+	kvCreateSpace(t, space, conn, reader)
+	defer CleanSpace(space, conn, reader)
+
+	resp := sendAndParse(t, models.Query{Type: models.TypePut, Space: space, Key: "k", Value: ""}, conn, reader)
+	if resp.Status != "ERROR" || !strings.Contains(resp.Message, "empty value") {
+		t.Fatalf("PUT with empty value should be rejected, got %+v", resp)
+	}
+	if got := kvGet(t, space, "k", conn, reader); got.Status != "ERROR" {
+		t.Fatalf("GET after rejected PUT should error, got %+v", got)
+	}
+
+	kvPut(t, space, "k", "real-value", conn, reader)
+	resp = sendAndParse(t, models.Query{Type: models.TypePut, Space: space, Key: "k", Value: ""}, conn, reader)
+	if resp.Status != "ERROR" {
+		t.Fatalf("second empty PUT should be rejected, got %+v", resp)
+	}
+	kvExpectValue(t, space, "k", "real-value", conn, reader)
+}
+
+// TestKeyValueGetNonExistentE2E verifies GET and DELETE of a missing key both
+// surface a clear error rather than an empty success.
+func TestKeyValueGetNonExistentE2E(t *testing.T) {
+	conn, reader := kvConnect(t)
+	defer conn.Close()
+
+	space := "kv_missing_key_e2e"
+	kvCreateSpace(t, space, conn, reader)
+	defer CleanSpace(space, conn, reader)
+
+	if resp := kvGet(t, space, "never-written", conn, reader); resp.Status != "ERROR" || !strings.Contains(resp.Message, "not found") {
+		t.Fatalf("GET missing key should return not-found error, got %+v", resp)
+	}
+	resp := sendAndParse(t, models.Query{Type: models.TypeDelete, Space: space, Key: "never-written"}, conn, reader)
+	if resp.Status != "ERROR" || !strings.Contains(resp.Message, "not found") {
+		t.Fatalf("DELETE missing key should return not-found error, got %+v", resp)
+	}
+}

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -64,7 +64,12 @@ func main() {
 				fmt.Println("Usage: put <key> <value>")
 				continue
 			}
-			query = models.Query{Type: models.TypePut, Key: parts[1], Value: cliparse.PutValue(parts)}
+			putValue := cliparse.PutValue(parts)
+			if putValue == "" {
+				fmt.Println("Error: empty value not allowed")
+				continue
+			}
+			query = models.Query{Type: models.TypePut, Key: parts[1], Value: putValue}
 		case "get":
 			query = models.Query{Type: models.TypeGet, Key: parts[1]}
 		case "delete":

--- a/internal/index/BTreeIndex.go
+++ b/internal/index/BTreeIndex.go
@@ -1,18 +1,23 @@
 package index
 
 import (
-	"encoding/binary"
-	"github.com/google/btree"
-	"golang.org/x/sys/unix"
 	"os"
 	"sync"
 	"syscall"
+
+	"github.com/google/btree"
+	"golang.org/x/sys/unix"
 )
 
 type BTreeIndex struct {
-	lock        sync.RWMutex
+	// lock guards the btree. Lock ordering: lock before mmapLock.
+	lock  sync.RWMutex
+	btree *btree.BTree
+
+	// mmapLock guards mmapData, writeOffset, and any remap of the file
+	// (grow, rewrite). Every access to the mapping must hold it so a
+	// concurrent remap cannot unmap memory another goroutine is writing.
 	mmapLock    sync.Mutex
-	btree       *btree.BTree
 	file        *os.File
 	mmapData    []byte
 	writeOffset int
@@ -28,21 +33,7 @@ func (i Item) Less(other btree.Item) bool {
 }
 
 func NewBTreeIndex(filename string) (*BTreeIndex, error) {
-	file, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE, 0666)
-	if err != nil {
-		return nil, err
-	}
-
-	size, err := file.Seek(0, 2)
-	if err != nil {
-		return nil, err
-	}
-	if size == 0 {
-		size = 4096
-		file.Truncate(size)
-	}
-
-	mmapData, err := syscall.Mmap(int(file.Fd()), 0, int(size), syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_SHARED)
+	file, mmapData, err := openIndexFile(filename)
 	if err != nil {
 		return nil, err
 	}
@@ -52,35 +43,10 @@ func NewBTreeIndex(filename string) (*BTreeIndex, error) {
 		file:     file,
 		mmapData: mmapData,
 	}
-
-	idx.writeOffset = idx.BatchLoadFromMmap()
+	idx.writeOffset = scanIndexEntries(mmapData, func(key string, pos int64) {
+		idx.btree.ReplaceOrInsert(Item{Key: key, Value: pos})
+	})
 	return idx, nil
-}
-
-func (idx *BTreeIndex) BatchLoadFromMmap() int {
-	idx.lock.Lock()
-	idx.mmapLock.Lock()
-	defer idx.lock.Unlock()
-	defer idx.mmapLock.Unlock()
-
-	offset := 0
-	for offset+8 <= len(idx.mmapData) {
-		keySize := binary.LittleEndian.Uint32(idx.mmapData[offset : offset+4])
-		pos := binary.LittleEndian.Uint32(idx.mmapData[offset+4 : offset+8])
-		offset += 8
-
-		if offset+int(keySize) > len(idx.mmapData) {
-			break
-		}
-
-		key := string(idx.mmapData[offset : offset+int(keySize)])
-		offset += int(keySize)
-
-		if key != "" {
-			idx.btree.ReplaceOrInsert(Item{Key: key, Value: int64(pos)})
-		}
-	}
-	return offset
 }
 
 func (idx *BTreeIndex) Add(key string, pos int64) error {
@@ -88,7 +54,10 @@ func (idx *BTreeIndex) Add(key string, pos int64) error {
 	defer idx.lock.Unlock()
 
 	idx.btree.ReplaceOrInsert(Item{Key: key, Value: pos})
-	return idx.appendIndexEntry(key, pos)
+
+	idx.mmapLock.Lock()
+	defer idx.mmapLock.Unlock()
+	return idx.appendEntryLocked(key, pos)
 }
 
 func (idx *BTreeIndex) Get(key string) (int64, bool) {
@@ -119,76 +88,75 @@ func (idx *BTreeIndex) Remove(key string) error {
 	idx.lock.Lock()
 	defer idx.lock.Unlock()
 
-	item := idx.btree.Delete(Item{Key: key})
-	if item == nil {
+	if item := idx.btree.Delete(Item{Key: key}); item == nil {
 		return nil
 	}
-	return idx.persistIndex()
-}
-
-func (idx *BTreeIndex) persistIndex() error {
-	if err := syscall.Munmap(idx.mmapData); err != nil {
-		return err
-	}
-	if err := idx.file.Truncate(0); err != nil {
-		return err
-	}
-	if err := idx.file.Truncate(4096); err != nil {
-		return err
-	}
-
-	mmapData, err := syscall.Mmap(int(idx.file.Fd()), 0, 4096, syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_SHARED)
-	if err != nil {
-		return err
-	}
-	idx.mmapData = mmapData
-	idx.writeOffset = 0
-
-	idx.btree.Ascend(func(i btree.Item) bool {
-		item := i.(Item)
-		_ = idx.appendIndexEntry(item.Key, item.Value)
-		return true
-	})
-	return unix.Msync(idx.mmapData, unix.MS_SYNC)
-}
-
-func (idx *BTreeIndex) appendIndexEntry(key string, pos int64) error {
-	keyBytes := []byte(key)
-	keySize := uint32(len(keyBytes))
-	entrySize := 8 + len(keyBytes)
 
 	idx.mmapLock.Lock()
 	defer idx.mmapLock.Unlock()
+	return idx.rewriteLocked()
+}
 
-	if idx.writeOffset+entrySize > len(idx.mmapData) {
-		newSize := int64(len(idx.mmapData)*2 + entrySize + 4096)
+// Sync flushes the mapped index to disk. Add intentionally does not sync;
+// callers batch their writes and sync once.
+func (idx *BTreeIndex) Sync() error {
+	idx.mmapLock.Lock()
+	defer idx.mmapLock.Unlock()
+	return unix.Msync(idx.mmapData, unix.MS_SYNC)
+}
+
+func (idx *BTreeIndex) Close() error {
+	idx.mmapLock.Lock()
+	defer idx.mmapLock.Unlock()
+
+	if idx.mmapData != nil {
+		if err := unix.Msync(idx.mmapData, unix.MS_SYNC); err != nil {
+			_ = idx.file.Close()
+			return err
+		}
 		if err := syscall.Munmap(idx.mmapData); err != nil {
+			_ = idx.file.Close()
 			return err
 		}
-		if err := idx.file.Truncate(newSize); err != nil {
-			return err
-		}
-		mmapData, err := syscall.Mmap(int(idx.file.Fd()), 0, int(newSize), syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_SHARED)
+		idx.mmapData = nil
+	}
+	return idx.file.Close()
+}
+
+func (idx *BTreeIndex) appendEntryLocked(key string, pos int64) error {
+	entrySize := indexEntryHeaderSize + len(key)
+	if idx.writeOffset+entrySize > len(idx.mmapData) {
+		mmapData, err := growIndexFile(idx.file, idx.mmapData, entrySize)
 		if err != nil {
 			return err
 		}
 		idx.mmapData = mmapData
 	}
-
-	offset := idx.writeOffset
-	binary.LittleEndian.PutUint32(idx.mmapData[offset:offset+4], keySize)
-	binary.LittleEndian.PutUint32(idx.mmapData[offset+4:offset+8], uint32(pos))
-	copy(idx.mmapData[offset+8:offset+8+int(keySize)], keyBytes)
-
-	idx.writeOffset += entrySize
-
-	if err := unix.Msync(idx.mmapData, unix.MS_SYNC); err != nil {
-		return err
-	}
-
+	idx.writeOffset = putIndexEntry(idx.mmapData, idx.writeOffset, key, pos)
 	return nil
 }
 
-func (idx *BTreeIndex) Close() error {
-	return syscall.Munmap(idx.mmapData)
+// rewriteLocked rebuilds the on-disk log from the current in-memory state.
+// Caller must hold both lock (for btree iteration) and mmapLock.
+func (idx *BTreeIndex) rewriteLocked() error {
+	mmapData, err := resetIndexFile(idx.file, idx.mmapData)
+	if err != nil {
+		return err
+	}
+	idx.mmapData = mmapData
+	idx.writeOffset = indexHeaderSize
+
+	var appendErr error
+	idx.btree.Ascend(func(i btree.Item) bool {
+		item := i.(Item)
+		if err := idx.appendEntryLocked(item.Key, item.Value); err != nil {
+			appendErr = err
+			return false
+		}
+		return true
+	})
+	if appendErr != nil {
+		return appendErr
+	}
+	return unix.Msync(idx.mmapData, unix.MS_SYNC)
 }

--- a/internal/index/HashMapIndex.go
+++ b/internal/index/HashMapIndex.go
@@ -1,15 +1,19 @@
 package index
 
 import (
-	"encoding/binary"
-	"golang.org/x/sys/unix"
 	"os"
 	"sync"
 	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 type HashMapIndex struct {
-	data        sync.Map
+	data sync.Map
+
+	// mmapLock guards mmapData, writeOffset, and any remap of the file
+	// (grow, rewrite). Every access to the mapping must hold it so a
+	// concurrent remap cannot unmap memory another goroutine is writing.
 	mmapLock    sync.Mutex
 	file        *os.File
 	mmapData    []byte
@@ -17,21 +21,7 @@ type HashMapIndex struct {
 }
 
 func NewHashMapIndex(filename string) (*HashMapIndex, error) {
-	file, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE, 0666)
-	if err != nil {
-		return nil, err
-	}
-
-	size, err := file.Seek(0, 2)
-	if err != nil {
-		return nil, err
-	}
-	if size == 0 {
-		size = 4096
-		file.Truncate(size)
-	}
-
-	mmapData, err := syscall.Mmap(int(file.Fd()), 0, int(size), syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_SHARED)
+	file, mmapData, err := openIndexFile(filename)
 	if err != nil {
 		return nil, err
 	}
@@ -40,38 +30,18 @@ func NewHashMapIndex(filename string) (*HashMapIndex, error) {
 		file:     file,
 		mmapData: mmapData,
 	}
-
-	idx.writeOffset = idx.BatchLoadFromMmap()
+	idx.writeOffset = scanIndexEntries(mmapData, func(key string, pos int64) {
+		idx.data.Store(key, pos)
+	})
 	return idx, nil
 }
 
-func (idx *HashMapIndex) BatchLoadFromMmap() int {
+func (idx *HashMapIndex) Add(key string, pos int64) error {
+	idx.data.Store(key, pos)
+
 	idx.mmapLock.Lock()
 	defer idx.mmapLock.Unlock()
-
-	offset := 0
-	for offset+8 <= len(idx.mmapData) {
-		keySize := binary.LittleEndian.Uint32(idx.mmapData[offset : offset+4])
-		pos := binary.LittleEndian.Uint32(idx.mmapData[offset+4 : offset+8])
-		offset += 8
-
-		if offset+int(keySize) > len(idx.mmapData) {
-			break
-		}
-
-		key := string(idx.mmapData[offset : offset+int(keySize)])
-		offset += int(keySize)
-
-		if key != "" {
-			idx.data.Store(key, int64(pos))
-		}
-	}
-	return offset
-}
-
-func (idx *HashMapIndex) Add(key string, pos int64) error {
-	idx.data.Store(key, pos) // sync.Map handles locking intrinsically
-	return idx.appendIndexEntry(key, pos)
+	return idx.appendEntryLocked(key, pos)
 }
 
 func (idx *HashMapIndex) Get(key string) (int64, bool) {
@@ -92,77 +62,74 @@ func (idx *HashMapIndex) SnapshotEntries() map[string]int64 {
 }
 
 func (idx *HashMapIndex) Remove(key string) error {
-	_, ok := idx.data.Load(key)
-	if !ok {
+	if _, ok := idx.data.Load(key); !ok {
 		return nil
 	}
 	idx.data.Delete(key)
 
-	return idx.persistIndex()
+	idx.mmapLock.Lock()
+	defer idx.mmapLock.Unlock()
+	return idx.rewriteLocked()
 }
 
-func (idx *HashMapIndex) persistIndex() error {
-	if err := syscall.Munmap(idx.mmapData); err != nil {
-		return err
-	}
-	if err := idx.file.Truncate(0); err != nil {
-		return err
-	}
-	if err := idx.file.Truncate(4096); err != nil {
-		return err
-	}
-
-	mmapData, err := syscall.Mmap(int(idx.file.Fd()), 0, 4096, syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_SHARED)
-	if err != nil {
-		return err
-	}
-	idx.mmapData = mmapData
-	idx.writeOffset = 0
-
-	idx.data.Range(func(key, value interface{}) bool {
-		_ = idx.appendIndexEntry(key.(string), value.(int64))
-		return true
-	})
+// Sync flushes the mapped index to disk. Add intentionally does not sync;
+// callers batch their writes and sync once.
+func (idx *HashMapIndex) Sync() error {
+	idx.mmapLock.Lock()
+	defer idx.mmapLock.Unlock()
 	return unix.Msync(idx.mmapData, unix.MS_SYNC)
 }
 
-func (idx *HashMapIndex) appendIndexEntry(key string, pos int64) error {
-	keyBytes := []byte(key)
-	keySize := uint32(len(keyBytes))
-	entrySize := 8 + len(keyBytes)
-
+func (idx *HashMapIndex) Close() error {
 	idx.mmapLock.Lock()
 	defer idx.mmapLock.Unlock()
 
-	if idx.writeOffset+entrySize > len(idx.mmapData) {
-		newSize := int64(len(idx.mmapData)*2 + entrySize + 4096)
+	if idx.mmapData != nil {
+		if err := unix.Msync(idx.mmapData, unix.MS_SYNC); err != nil {
+			_ = idx.file.Close()
+			return err
+		}
 		if err := syscall.Munmap(idx.mmapData); err != nil {
+			_ = idx.file.Close()
 			return err
 		}
-		if err := idx.file.Truncate(newSize); err != nil {
-			return err
-		}
-		mmapData, err := syscall.Mmap(int(idx.file.Fd()), 0, int(newSize), syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_SHARED)
+		idx.mmapData = nil
+	}
+	return idx.file.Close()
+}
+
+func (idx *HashMapIndex) appendEntryLocked(key string, pos int64) error {
+	entrySize := indexEntryHeaderSize + len(key)
+	if idx.writeOffset+entrySize > len(idx.mmapData) {
+		mmapData, err := growIndexFile(idx.file, idx.mmapData, entrySize)
 		if err != nil {
 			return err
 		}
 		idx.mmapData = mmapData
 	}
-
-	offset := idx.writeOffset
-	binary.LittleEndian.PutUint32(idx.mmapData[offset:offset+4], keySize)
-	binary.LittleEndian.PutUint32(idx.mmapData[offset+4:offset+8], uint32(pos))
-	copy(idx.mmapData[offset+8:offset+8+int(keySize)], keyBytes)
-
-	idx.writeOffset += entrySize
-
-	if err := unix.Msync(idx.mmapData, unix.MS_SYNC); err != nil {
-		return err
-	}
-
+	idx.writeOffset = putIndexEntry(idx.mmapData, idx.writeOffset, key, pos)
 	return nil
 }
 
-func (idx *HashMapIndex) Close() error {
-	return syscall.Munmap(idx.mmapData)
+// rewriteLocked rebuilds the on-disk log from the current in-memory state.
+func (idx *HashMapIndex) rewriteLocked() error {
+	mmapData, err := resetIndexFile(idx.file, idx.mmapData)
+	if err != nil {
+		return err
+	}
+	idx.mmapData = mmapData
+	idx.writeOffset = indexHeaderSize
+
+	var appendErr error
+	idx.data.Range(func(key, value interface{}) bool {
+		if err := idx.appendEntryLocked(key.(string), value.(int64)); err != nil {
+			appendErr = err
+			return false
+		}
+		return true
+	})
+	if appendErr != nil {
+		return appendErr
+	}
+	return unix.Msync(idx.mmapData, unix.MS_SYNC)
 }

--- a/internal/index/format.go
+++ b/internal/index/format.go
@@ -1,0 +1,149 @@
+package index
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// On-disk key-value index format:
+//
+//	header:  magic (u32) | version (u32)
+//	entry:   keySize (u32) | pos (u64) | key bytes
+//
+// A keySize of 0 marks the end of the log; the zero-filled tail of the
+// mmap-extended file provides it implicitly. Positions are 8 bytes so data
+// files larger than 4 GiB index correctly.
+const (
+	indexMagic           uint32 = 0x53424958 // "SBIX"
+	indexFormatVersion   uint32 = 1
+	indexHeaderSize             = 8
+	indexEntryHeaderSize        = 12
+	indexInitialFileSize        = int64(4096)
+)
+
+var errBadIndexHeader = errors.New("unrecognized key-value index file format")
+
+// openIndexFile opens (creating if needed) an index file, validates or writes
+// the format header, and memory-maps the whole file.
+func openIndexFile(filename string) (*os.File, []byte, error) {
+	file, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE, 0666)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, nil, err
+	}
+
+	size := info.Size()
+	newFile := size == 0
+	if size < indexInitialFileSize {
+		size = indexInitialFileSize
+		if err := file.Truncate(size); err != nil {
+			_ = file.Close()
+			return nil, nil, err
+		}
+	}
+
+	mmapData, err := syscall.Mmap(int(file.Fd()), 0, int(size), syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_SHARED)
+	if err != nil {
+		_ = file.Close()
+		return nil, nil, err
+	}
+
+	if newFile {
+		writeIndexHeader(mmapData)
+	} else if err := checkIndexHeader(mmapData); err != nil {
+		_ = syscall.Munmap(mmapData)
+		_ = file.Close()
+		return nil, nil, fmt.Errorf("%s: %w", filename, err)
+	}
+	return file, mmapData, nil
+}
+
+func writeIndexHeader(mmapData []byte) {
+	binary.LittleEndian.PutUint32(mmapData[0:4], indexMagic)
+	binary.LittleEndian.PutUint32(mmapData[4:8], indexFormatVersion)
+}
+
+func checkIndexHeader(mmapData []byte) error {
+	if len(mmapData) < indexHeaderSize {
+		return errBadIndexHeader
+	}
+	if binary.LittleEndian.Uint32(mmapData[0:4]) != indexMagic {
+		return errBadIndexHeader
+	}
+	if version := binary.LittleEndian.Uint32(mmapData[4:8]); version != indexFormatVersion {
+		return fmt.Errorf("%w: unsupported version %d", errBadIndexHeader, version)
+	}
+	return nil
+}
+
+// scanIndexEntries walks entries from the header to the end-of-log marker
+// (or a truncated tail) and returns the offset where the next entry should
+// be appended.
+func scanIndexEntries(mmapData []byte, visit func(key string, pos int64)) int {
+	offset := indexHeaderSize
+	for offset+indexEntryHeaderSize <= len(mmapData) {
+		keySize := binary.LittleEndian.Uint32(mmapData[offset : offset+4])
+		if keySize == 0 {
+			break
+		}
+		if int(keySize) > len(mmapData)-offset-indexEntryHeaderSize {
+			break
+		}
+		pos := binary.LittleEndian.Uint64(mmapData[offset+4 : offset+12])
+		entryEnd := offset + indexEntryHeaderSize + int(keySize)
+		visit(string(mmapData[offset+indexEntryHeaderSize:entryEnd]), int64(pos))
+		offset = entryEnd
+	}
+	return offset
+}
+
+// putIndexEntry writes one entry at offset and returns the next write offset.
+// The caller must have ensured capacity.
+func putIndexEntry(mmapData []byte, offset int, key string, pos int64) int {
+	binary.LittleEndian.PutUint32(mmapData[offset:offset+4], uint32(len(key)))
+	binary.LittleEndian.PutUint64(mmapData[offset+4:offset+12], uint64(pos))
+	copy(mmapData[offset+indexEntryHeaderSize:], key)
+	return offset + indexEntryHeaderSize + len(key)
+}
+
+// growIndexFile remaps the file with enough room for at least `needed` more
+// bytes. The previous mapping is unmapped; the caller must replace its
+// reference with the returned mapping.
+func growIndexFile(file *os.File, mmapData []byte, needed int) ([]byte, error) {
+	newSize := int64(len(mmapData)*2 + needed + int(indexInitialFileSize))
+	if err := syscall.Munmap(mmapData); err != nil {
+		return nil, err
+	}
+	if err := file.Truncate(newSize); err != nil {
+		return nil, err
+	}
+	return syscall.Mmap(int(file.Fd()), 0, int(newSize), syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_SHARED)
+}
+
+// resetIndexFile truncates the file back to its initial size, remaps it, and
+// writes a fresh header. Used when rewriting the log after a removal.
+func resetIndexFile(file *os.File, mmapData []byte) ([]byte, error) {
+	if err := syscall.Munmap(mmapData); err != nil {
+		return nil, err
+	}
+	if err := file.Truncate(0); err != nil {
+		return nil, err
+	}
+	if err := file.Truncate(indexInitialFileSize); err != nil {
+		return nil, err
+	}
+	newData, err := syscall.Mmap(int(file.Fd()), 0, int(indexInitialFileSize), syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_SHARED)
+	if err != nil {
+		return nil, err
+	}
+	writeIndexHeader(newData)
+	return newData, nil
+}

--- a/internal/index/format_test.go
+++ b/internal/index/format_test.go
@@ -1,0 +1,172 @@
+package index
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func newIndexForTest(t *testing.T, indexType, filename string) KeyValueIndex {
+	t.Helper()
+	idx, err := NewKeyValueIndex(filename, indexType)
+	if err != nil {
+		t.Fatalf("open %s index: %v", indexType, err)
+	}
+	return idx
+}
+
+// Regression: positions used to be persisted as uint32, silently truncating
+// offsets in data files larger than 4 GiB.
+func TestIndex_LargePositionRoundTrip(t *testing.T) {
+	for _, indexType := range []string{"hashmap", "btree"} {
+		t.Run(indexType, func(t *testing.T) {
+			filename := filepath.Join(t.TempDir(), "large_pos.idx")
+			bigPos := int64(5) << 30 // > 4 GiB
+
+			idx := newIndexForTest(t, indexType, filename)
+			if err := idx.Add("big", bigPos); err != nil {
+				t.Fatalf("Add: %v", err)
+			}
+			if err := idx.Close(); err != nil {
+				t.Fatalf("Close: %v", err)
+			}
+
+			idx = newIndexForTest(t, indexType, filename)
+			defer idx.Close()
+			pos, ok := idx.Get("big")
+			if !ok || pos != bigPos {
+				t.Fatalf("expected %d after reload, got %d (ok=%v)", bigPos, pos, ok)
+			}
+		})
+	}
+}
+
+// Regression: reloading used to scan the zero-filled tail of the mmap and set
+// the write offset near the end of the file, so every reopen+write cycle grew
+// the file even with a constant number of entries.
+func TestIndex_ReopenDoesNotGrowFile(t *testing.T) {
+	for _, indexType := range []string{"hashmap", "btree"} {
+		t.Run(indexType, func(t *testing.T) {
+			filename := filepath.Join(t.TempDir(), "regrow.idx")
+
+			for cycle := 0; cycle < 5; cycle++ {
+				idx := newIndexForTest(t, indexType, filename)
+				for i := 0; i < 10; i++ {
+					if err := idx.Add(fmt.Sprintf("key%d", i), int64(cycle*100+i)); err != nil {
+						t.Fatalf("Add: %v", err)
+					}
+				}
+				if err := idx.Close(); err != nil {
+					t.Fatalf("Close: %v", err)
+				}
+			}
+
+			info, err := os.Stat(filename)
+			if err != nil {
+				t.Fatalf("stat: %v", err)
+			}
+			if info.Size() != indexInitialFileSize {
+				t.Fatalf("file grew to %d bytes across reopen cycles, expected %d", info.Size(), indexInitialFileSize)
+			}
+
+			// Note: rewriting the same keys appends duplicate log entries;
+			// last write wins on reload.
+			idx := newIndexForTest(t, indexType, filename)
+			defer idx.Close()
+			for i := 0; i < 10; i++ {
+				pos, ok := idx.Get(fmt.Sprintf("key%d", i))
+				if !ok || pos != int64(400+i) {
+					t.Fatalf("key%d: expected %d, got %d (ok=%v)", i, 400+i, pos, ok)
+				}
+			}
+		})
+	}
+}
+
+// Old-format files (no header) must fail loading so callers rebuild them from
+// the data file instead of silently misparsing entries.
+func TestIndex_RejectsUnrecognizedFormat(t *testing.T) {
+	for _, indexType := range []string{"hashmap", "btree"} {
+		t.Run(indexType, func(t *testing.T) {
+			filename := filepath.Join(t.TempDir(), "old_format.idx")
+
+			// Simulate an old-format file: entries with no header, 4-byte
+			// positions, zero-padded to the initial mmap size.
+			raw := make([]byte, indexInitialFileSize)
+			copy(raw, []byte{4, 0, 0, 0, 100, 0, 0, 0, 'k', 'e', 'y', '1'})
+			if err := os.WriteFile(filename, raw, 0666); err != nil {
+				t.Fatalf("write old-format file: %v", err)
+			}
+
+			if _, err := NewKeyValueIndex(filename, indexType); err == nil {
+				t.Fatal("expected error opening old-format index file, got nil")
+			}
+		})
+	}
+}
+
+func TestIndex_SyncPersistsWithoutClose(t *testing.T) {
+	for _, indexType := range []string{"hashmap", "btree"} {
+		t.Run(indexType, func(t *testing.T) {
+			filename := filepath.Join(t.TempDir(), "sync.idx")
+
+			idx := newIndexForTest(t, indexType, filename)
+			defer idx.Close()
+			if err := idx.Add("key1", 42); err != nil {
+				t.Fatalf("Add: %v", err)
+			}
+			if err := idx.Sync(); err != nil {
+				t.Fatalf("Sync: %v", err)
+			}
+
+			// The mapping is MAP_SHARED, so a second reader through the file
+			// must observe the synced entry.
+			other := newIndexForTest(t, indexType, filename)
+			defer other.Close()
+			pos, ok := other.Get("key1")
+			if !ok || pos != 42 {
+				t.Fatalf("expected 42 after Sync, got %d (ok=%v)", pos, ok)
+			}
+		})
+	}
+}
+
+// Regression: Remove used to munmap and remap the file without holding the
+// mmap lock, racing with concurrent Adds writing through the old mapping.
+// Run with -race to exercise this.
+func TestIndex_ConcurrentAddRemove(t *testing.T) {
+	for _, indexType := range []string{"hashmap", "btree"} {
+		t.Run(indexType, func(t *testing.T) {
+			filename := filepath.Join(t.TempDir(), "concurrent.idx")
+			idx := newIndexForTest(t, indexType, filename)
+			defer idx.Close()
+
+			const workers = 8
+			const opsPerWorker = 200
+
+			var wg sync.WaitGroup
+			for w := 0; w < workers; w++ {
+				wg.Add(1)
+				go func(w int) {
+					defer wg.Done()
+					for i := 0; i < opsPerWorker; i++ {
+						key := fmt.Sprintf("key-%d-%d", w, i)
+						if err := idx.Add(key, int64(i)); err != nil {
+							t.Errorf("Add: %v", err)
+							return
+						}
+						if i%10 == 0 {
+							if err := idx.Remove(key); err != nil {
+								t.Errorf("Remove: %v", err)
+								return
+							}
+						}
+					}
+				}(w)
+			}
+			wg.Wait()
+		})
+	}
+}

--- a/internal/index/interface.go
+++ b/internal/index/interface.go
@@ -5,6 +5,9 @@ type KeyValueIndex interface {
 	Get(key string) (int64, bool)
 	SnapshotEntries() map[string]int64
 	Remove(key string) error
+	// Sync flushes buffered index writes to disk. Add does not sync on its
+	// own; callers batch Adds and call Sync once. Close also syncs.
+	Sync() error
 	Close() error
 }
 

--- a/internal/queryengine/query_engine.go
+++ b/internal/queryengine/query_engine.go
@@ -288,6 +288,9 @@ func (qe *QueryEngine) Execute(query models.Query) (string, error) {
 		}
 		switch query.Type {
 		case models.TypePut:
+			if query.Value == "" {
+				return "", errors.New("empty value not allowed")
+			}
 			return "OK", engine.Put(query.Key, query.Value)
 		case models.TypeGet:
 			return engine.Get(query.Key)

--- a/internal/queryengine/query_engine_test.go
+++ b/internal/queryengine/query_engine_test.go
@@ -191,6 +191,60 @@ func TestQueryEngine_CreateSpaceSurvivesRestart(t *testing.T) {
 	}
 }
 
+func TestQueryEngine_PutRejectsEmptyValue(t *testing.T) {
+	dir := t.TempDir()
+	sm := spaces.NewSpaceManager(dir)
+	defer sm.CloseAll()
+
+	qe := NewQueryEngine(sm, &mockAuth{})
+
+	space := "kv_empty_value"
+	if _, err := qe.Execute(models.Query{
+		Type:       models.TypeCreateSpace,
+		Space:      space,
+		EngineType: "key-value",
+		User:       "admin",
+	}); err != nil {
+		t.Fatalf("CreateSpace failed: %v", err)
+	}
+
+	_, err := qe.Execute(models.Query{
+		Type:  models.TypePut,
+		Space: space,
+		Key:   "k1",
+		Value: "",
+	})
+	if err == nil {
+		t.Fatal("Expected error for PUT with empty value, got nil")
+	}
+	if !strings.Contains(err.Error(), "empty value") {
+		t.Fatalf("Expected 'empty value' error, got: %v", err)
+	}
+
+	// The key must not exist after the rejected PUT.
+	if res, err := qe.Execute(models.Query{
+		Type:  models.TypeGet,
+		Space: space,
+		Key:   "k1",
+	}); err == nil {
+		t.Fatalf("Expected error from GET after rejected PUT, got res=%q", res)
+	}
+
+	// A normal PUT on the same space still works.
+	res, err := qe.Execute(models.Query{
+		Type:  models.TypePut,
+		Space: space,
+		Key:   "k1",
+		Value: "v1",
+	})
+	if err != nil {
+		t.Fatalf("PUT with non-empty value failed: %v", err)
+	}
+	if res != "OK" {
+		t.Fatalf("result = %q, want OK", res)
+	}
+}
+
 func TestQueryEngine_UpdateSpaceSettings(t *testing.T) {
 	dir := t.TempDir()
 	sm := spaces.NewSpaceManager(dir)

--- a/internal/storage/key_value_storage.go
+++ b/internal/storage/key_value_storage.go
@@ -19,7 +19,7 @@ import (
 type kvSegment struct {
 	meta     SegmentMeta
 	dataFile *os.File
-	index    map[string]int64
+	index    kvindex.KeyValueIndex
 }
 
 // kvBatchEntry is a single staged write in the in-memory batch. A deleted entry
@@ -48,11 +48,10 @@ type ShibuDB struct {
 	manifest         *SegmentManifest
 	segments         []*kvSegment
 
-	indexBuildQueue chan int64
-	mergeQueue      chan struct{}
-	backgroundStop  chan struct{}
-	backgroundWG    sync.WaitGroup
-	indexType       string
+	mergeQueue     chan struct{}
+	backgroundStop chan struct{}
+	backgroundWG   sync.WaitGroup
+	indexType      string
 }
 
 func OpenDBWithPathsAndWAL(dataPath, walPath, indexPath string, enableWAL bool, indexType string) (*ShibuDB, error) {
@@ -76,7 +75,6 @@ func OpenDBWithPathsAndWALAndSettings(dataPath, walPath, indexPath string, enabl
 		layout:           NewSegmentLayout(filepath.Dir(dataPath), "data", ".db", ".idx"),
 		primaryDataPath:  dataPath,
 		primaryIndexPath: indexPath,
-		indexBuildQueue:  make(chan int64, 32),
 		mergeQueue:       make(chan struct{}, 1),
 		backgroundStop:   make(chan struct{}),
 		indexType:        indexType,
@@ -167,12 +165,18 @@ func (db *ShibuDB) loadSegments() error {
 			return err
 		}
 
-		var entries map[string]int64
+		var segIndex kvindex.KeyValueIndex
 		if idx == len(db.manifest.Segments)-1 {
-			entries, err = scanKeyValueDataFile(desc.DataPath)
+			// Hot segment: the index can lag the data file after a crash
+			// (records are fsynced before index entries), so always rebuild
+			// it from the data file. The hot segment is bounded by the
+			// rollover size, so this scan is cheap.
+			if _, err = RebuildKeyValueIndex(desc.DataPath, desc.IndexPath, db.indexType); err == nil {
+				segIndex, err = kvindex.NewKeyValueIndex(desc.IndexPath, db.indexType)
+			}
 			meta.State = SegmentStateHot
 		} else {
-			entries, err = loadOrBuildKeyValueSegmentIndex(desc, db.indexType)
+			segIndex, err = loadOrBuildKeyValueSegmentIndex(desc, db.indexType)
 			meta.State = SegmentStateCold
 		}
 		if err != nil {
@@ -187,7 +191,7 @@ func (db *ShibuDB) loadSegments() error {
 		db.segments = append(db.segments, &kvSegment{
 			meta:     meta,
 			dataFile: dataFile,
-			index:    entries,
+			index:    segIndex,
 		})
 		manifestChanged = true
 	}
@@ -201,8 +205,7 @@ func (db *ShibuDB) loadSegments() error {
 }
 
 func (db *ShibuDB) startBackgroundWorkers() {
-	db.backgroundWG.Add(2)
-	go db.indexBuildWorker()
+	db.backgroundWG.Add(1)
 	go db.mergeWorker()
 }
 
@@ -298,10 +301,17 @@ func (db *ShibuDB) FlushBatch() error {
 			if err != nil {
 				return err
 			}
-			active.index[key] = pos
+			// Deletes are indexed like puts: the entry points at the delete
+			// record so the tombstone shadows the key in older segments.
+			if err := active.index.Add(key, pos); err != nil {
+				return err
+			}
 		}
 
 		if err := active.dataFile.Sync(); err != nil {
+			return err
+		}
+		if err := active.index.Sync(); err != nil {
 			return err
 		}
 		if info, err := active.dataFile.Stat(); err == nil {
@@ -343,7 +353,7 @@ func (db *ShibuDB) Get(key string) (string, error) {
 
 	for idx := len(db.segments) - 1; idx >= 0; idx-- {
 		segment := db.segments[idx]
-		pos, exists := segment.index[key]
+		pos, exists := segment.index.Get(key)
 		if !exists {
 			continue
 		}
@@ -430,6 +440,7 @@ func (db *ShibuDB) Close() error {
 		db.lock.Lock()
 		for _, segment := range db.segments {
 			_ = segment.dataFile.Close()
+			_ = segment.index.Close()
 		}
 		db.lock.Unlock()
 
@@ -464,18 +475,6 @@ func (db *ShibuDB) MaintenanceFlush() {
 	}
 }
 
-func (db *ShibuDB) indexBuildWorker() {
-	defer db.backgroundWG.Done()
-	for {
-		select {
-		case <-db.backgroundStop:
-			return
-		case id := <-db.indexBuildQueue:
-			db.buildIndexForSegment(id)
-		}
-	}
-}
-
 func (db *ShibuDB) mergeWorker() {
 	defer db.backgroundWG.Done()
 	for {
@@ -487,45 +486,6 @@ func (db *ShibuDB) mergeWorker() {
 			}
 		}
 	}
-}
-
-func (db *ShibuDB) buildIndexForSegment(id int64) {
-	db.lock.Lock()
-	segment := db.segmentByIDLocked(id)
-	if segment == nil || id == db.manifest.ActiveSegmentID {
-		db.lock.Unlock()
-		return
-	}
-	segment.meta.State = SegmentStateIndexing
-	db.updateSegmentMetaLocked(segment.meta)
-	dataPath := db.layout.Descriptor(segment.meta).DataPath
-	indexPath := db.layout.Descriptor(segment.meta).IndexPath
-	_ = WriteSegmentManifest(db.layout, db.manifest)
-	db.lock.Unlock()
-
-	if _, err := RebuildKeyValueIndex(dataPath, indexPath, db.indexType); err != nil {
-		log.Printf("build key-value segment index failed for segment %d: %v", id, err)
-		db.lock.Lock()
-		if segment := db.segmentByIDLocked(id); segment != nil {
-			segment.meta.State = SegmentStateSealed
-			db.updateSegmentMetaLocked(segment.meta)
-			_ = WriteSegmentManifest(db.layout, db.manifest)
-		}
-		db.lock.Unlock()
-		return
-	}
-
-	db.lock.Lock()
-	if segment := db.segmentByIDLocked(id); segment != nil {
-		segment.meta.State = SegmentStateCold
-		if info, err := os.Stat(dataPath); err == nil {
-			segment.meta.SizeBytes = info.Size()
-		}
-		db.updateSegmentMetaLocked(segment.meta)
-		_ = WriteSegmentManifest(db.layout, db.manifest)
-		db.scheduleMergeCheckLocked()
-	}
-	db.lock.Unlock()
 }
 
 func (db *ShibuDB) tryMergeOldestColdSegments() bool {
@@ -590,11 +550,14 @@ func (db *ShibuDB) tryMergeOldestColdSegments() bool {
 	secondIdx := db.segmentIndexByIDLocked(second.meta.ID)
 	if firstIdx < 0 || secondIdx < 0 || secondIdx <= firstIdx {
 		_ = mergedFile.Close()
+		_ = mergedIndex.Close()
 		return false
 	}
 
 	_ = db.segments[firstIdx].dataFile.Close()
+	_ = db.segments[firstIdx].index.Close()
 	_ = db.segments[secondIdx].dataFile.Close()
+	_ = db.segments[secondIdx].index.Close()
 	_ = os.Remove(firstDesc.DataPath)
 	_ = os.Remove(firstDesc.IndexPath)
 
@@ -609,7 +572,7 @@ func (db *ShibuDB) tryMergeOldestColdSegments() bool {
 	return len(db.segments) > db.settings.MaxSegmentsBeforeMerge
 }
 
-func (db *ShibuDB) mergeSegments(newID int64, firstDesc, secondDesc SegmentDescriptor) (SegmentMeta, map[string]int64, *os.File, error) {
+func (db *ShibuDB) mergeSegments(newID int64, firstDesc, secondDesc SegmentDescriptor) (SegmentMeta, kvindex.KeyValueIndex, *os.File, error) {
 	latestRecords, err := collectLatestKeyValueRecords(firstDesc.DataPath, secondDesc.DataPath)
 	if err != nil {
 		return SegmentMeta{}, nil, nil, err
@@ -624,12 +587,13 @@ func (db *ShibuDB) mergeSegments(newID int64, firstDesc, secondDesc SegmentDescr
 		return SegmentMeta{}, nil, nil, err
 	}
 
-	entries, err := loadKeyValueIndexEntries(mergedIndexPath, db.indexType)
+	mergedIndex, err := kvindex.NewKeyValueIndex(mergedIndexPath, db.indexType)
 	if err != nil {
 		return SegmentMeta{}, nil, nil, err
 	}
 	dataFile, err := os.OpenFile(mergedDataPath, os.O_RDWR|os.O_CREATE, 0666)
 	if err != nil {
+		_ = mergedIndex.Close()
 		return SegmentMeta{}, nil, nil, err
 	}
 
@@ -643,7 +607,7 @@ func (db *ShibuDB) mergeSegments(newID int64, firstDesc, secondDesc SegmentDescr
 	if info, err := dataFile.Stat(); err == nil {
 		meta.SizeBytes = info.Size()
 	}
-	return meta, entries, dataFile, nil
+	return meta, mergedIndex, dataFile, nil
 }
 
 func (db *ShibuDB) rotateHotSegmentLocked() error {
@@ -655,7 +619,10 @@ func (db *ShibuDB) rotateHotSegmentLocked() error {
 		return nil
 	}
 
-	active.meta.State = SegmentStateSealed
+	// The hot segment's index is kept current by FlushBatch and was synced
+	// just before rotation, so the sealed segment is immediately cold — no
+	// background index build is needed.
+	active.meta.State = SegmentStateCold
 	active.meta.SealedAtUnixNs = time.Now().UnixNano()
 	db.updateSegmentMetaLocked(active.meta)
 
@@ -672,19 +639,23 @@ func (db *ShibuDB) rotateHotSegmentLocked() error {
 	if err != nil {
 		return err
 	}
+	newIndex, err := kvindex.NewKeyValueIndex(db.layout.IndexPath(newID), db.indexType)
+	if err != nil {
+		_ = newDataFile.Close()
+		return err
+	}
 
 	db.manifest.ActiveSegmentID = newID
 	db.manifest.Segments = append(db.manifest.Segments, newMeta)
 	db.segments = append(db.segments, &kvSegment{
 		meta:     newMeta,
 		dataFile: newDataFile,
-		index:    make(map[string]int64),
+		index:    newIndex,
 	})
 	if err := WriteSegmentManifest(db.layout, db.manifest); err != nil {
 		return err
 	}
 
-	db.enqueueIndexBuildLocked(active.meta.ID)
 	db.scheduleMergeCheckLocked()
 	return nil
 }
@@ -701,7 +672,7 @@ func (db *ShibuDB) activeSegmentLocked() *kvSegment {
 func (db *ShibuDB) keyExistsLocked(key string) (bool, error) {
 	for idx := len(db.segments) - 1; idx >= 0; idx-- {
 		segment := db.segments[idx]
-		pos, exists := segment.index[key]
+		pos, exists := segment.index.Get(key)
 		if !exists {
 			continue
 		}
@@ -745,19 +716,6 @@ func (db *ShibuDB) segmentIndexByIDLocked(id int64) int {
 		}
 	}
 	return -1
-}
-
-func (db *ShibuDB) enqueueIndexBuildLocked(id int64) {
-	select {
-	case db.indexBuildQueue <- id:
-	default:
-		go func() {
-			select {
-			case db.indexBuildQueue <- id:
-			case <-db.backgroundStop:
-			}
-		}()
-	}
 }
 
 func (db *ShibuDB) scheduleMergeCheckLocked() {
@@ -830,51 +788,10 @@ func readKeyValueRecordAt(file *os.File, pos int64) (string, string, bool, error
 	return string(keyBytes), string(valBytes), false, nil
 }
 
-func scanKeyValueDataFile(dataPath string) (map[string]int64, error) {
-	file, err := os.OpenFile(dataPath, os.O_RDWR|os.O_CREATE, 0666)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
-	offsets := make(map[string]int64)
-	var offset int64
-	for {
-		header := make([]byte, 8)
-		n, err := io.ReadFull(file, header)
-		if err == io.EOF || (err == io.ErrUnexpectedEOF && n == 0) {
-			break
-		}
-		if err == io.ErrUnexpectedEOF {
-			break
-		}
-		if err != nil {
-			return nil, err
-		}
-
-		keySize := binary.LittleEndian.Uint32(header[0:4])
-		valSize := binary.LittleEndian.Uint32(header[4:8])
-		keyBytes := make([]byte, keySize)
-		if _, err := io.ReadFull(file, keyBytes); err != nil {
-			if err == io.EOF || err == io.ErrUnexpectedEOF {
-				break
-			}
-			return nil, err
-		}
-		if _, err := io.CopyN(io.Discard, file, int64(valSize)); err != nil {
-			if err == io.EOF || err == io.ErrUnexpectedEOF {
-				break
-			}
-			return nil, err
-		}
-
-		offsets[string(keyBytes)] = offset
-		offset += int64(8) + int64(keySize) + int64(valSize)
-	}
-	return offsets, nil
-}
-
-func loadOrBuildKeyValueSegmentIndex(desc SegmentDescriptor, indexType string) (map[string]int64, error) {
+// loadOrBuildKeyValueSegmentIndex opens a cold segment's index for serving
+// reads, rebuilding it from the data file when it is missing or unreadable
+// (e.g. an old-format file that fails the header check).
+func loadOrBuildKeyValueSegmentIndex(desc SegmentDescriptor, indexType string) (kvindex.KeyValueIndex, error) {
 	if _, err := os.Stat(desc.IndexPath); err != nil {
 		if !os.IsNotExist(err) {
 			return nil, err
@@ -882,26 +799,17 @@ func loadOrBuildKeyValueSegmentIndex(desc SegmentDescriptor, indexType string) (
 		if _, rebuildErr := RebuildKeyValueIndex(desc.DataPath, desc.IndexPath, indexType); rebuildErr != nil {
 			return nil, rebuildErr
 		}
-		return loadKeyValueIndexEntries(desc.IndexPath, indexType)
+		return kvindex.NewKeyValueIndex(desc.IndexPath, indexType)
 	}
 
-	entries, err := loadKeyValueIndexEntries(desc.IndexPath, indexType)
+	idx, err := kvindex.NewKeyValueIndex(desc.IndexPath, indexType)
 	if err == nil {
-		return entries, nil
+		return idx, nil
 	}
 	if _, rebuildErr := RebuildKeyValueIndex(desc.DataPath, desc.IndexPath, indexType); rebuildErr != nil {
 		return nil, rebuildErr
 	}
-	return loadKeyValueIndexEntries(desc.IndexPath, indexType)
-}
-
-func loadKeyValueIndexEntries(indexPath string, indexType string) (map[string]int64, error) {
-	idx, err := kvindex.NewKeyValueIndex(indexPath, indexType)
-	if err != nil {
-		return nil, err
-	}
-	defer idx.Close()
-	return idx.SnapshotEntries(), nil
+	return kvindex.NewKeyValueIndex(desc.IndexPath, indexType)
 }
 
 func collectLatestKeyValueRecords(paths ...string) (map[string][]byte, error) {

--- a/internal/storage/key_value_storage.go
+++ b/internal/storage/key_value_storage.go
@@ -236,6 +236,14 @@ func (db *ShibuDB) replayWAL() {
 }
 
 func (db *ShibuDB) PutBatch(key, value string) error {
+	// Empty values are unrepresentable in the on-disk format (valSize == 0 is
+	// the delete tombstone), so they are rejected at the entry points (query
+	// engine, CLIs) and silently ignored here. This also drops any legacy
+	// empty-value records during WAL replay.
+	if value == "" {
+		return nil
+	}
+
 	// With WAL enabled, the write must be durable before we acknowledge it:
 	// persist (and fsync) the WAL record first, then stage it in the in-memory
 	// batch for the asynchronous data-file flush. walMu serializes WAL appends

--- a/internal/storage/key_value_storage_test.go
+++ b/internal/storage/key_value_storage_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -321,6 +322,53 @@ func TestDeleteBatchedSemantics(t *testing.T) {
 	}
 	if _, err := db.Get("k"); !errors.Is(err, errKeyDeleted) {
 		t.Errorf("Get(k) after put+delete in one batch = %v, want errKeyDeleted (no resurrection)", err)
+	}
+}
+
+// TestPutBatchIgnoresEmptyValue verifies the storage engine treats an empty
+// value as a no-op: valSize == 0 is the on-disk delete tombstone, so an empty
+// put must never be written (it would read back as a deleted key).
+func TestPutBatchIgnoresEmptyValue(t *testing.T) {
+	dir := t.TempDir()
+	dataPath := filepath.Join(dir, "storage.db")
+	walPath := filepath.Join(dir, "wal.db")
+	indexPath := filepath.Join(dir, "index.dat")
+
+	db, err := OpenDBWithPathsAndWAL(dataPath, walPath, indexPath, true, "btree")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	// An empty put is accepted (nil error) but stores nothing.
+	if err := db.PutBatch("emptyKey", ""); err != nil {
+		t.Fatalf("PutBatch with empty value returned error: %v", err)
+	}
+	if _, err := db.Get("emptyKey"); !errors.Is(err, errKeyNotFound) {
+		t.Errorf("Get(emptyKey) before flush = %v, want errKeyNotFound", err)
+	}
+	if err := db.FlushBatch(); err != nil {
+		t.Fatalf("FlushBatch: %v", err)
+	}
+	if _, err := db.Get("emptyKey"); !errors.Is(err, errKeyNotFound) {
+		t.Errorf("Get(emptyKey) after flush = %v, want errKeyNotFound", err)
+	}
+
+	// An empty put must not clobber an existing value either.
+	if err := db.PutBatch("k", "v1"); err != nil {
+		t.Fatalf("PutBatch(k, v1): %v", err)
+	}
+	if err := db.FlushBatch(); err != nil {
+		t.Fatalf("FlushBatch: %v", err)
+	}
+	if err := db.PutBatch("k", ""); err != nil {
+		t.Fatalf("PutBatch(k, empty): %v", err)
+	}
+	if err := db.FlushBatch(); err != nil {
+		t.Fatalf("FlushBatch after empty put: %v", err)
+	}
+	if val, err := db.Get("k"); err != nil || val != "v1" {
+		t.Errorf("Get(k) after empty put = (%q, %v), want (\"v1\", nil)", val, err)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -834,7 +834,12 @@ func connectToServer(port, providedUser, providedPass string) {
 				fmt.Println("Usage: put <key> <value>")
 				continue
 			}
-			query = models.Query{Type: models.TypePut, Key: parts[1], Value: cliparse.PutValue(parts), Space: space, User: username}
+			putValue := cliparse.PutValue(parts)
+			if putValue == "" {
+				fmt.Println("Error: empty value not allowed")
+				continue
+			}
+			query = models.Query{Type: models.TypePut, Key: parts[1], Value: putValue, Space: space, User: username}
 		case "get":
 			if len(parts) < 2 {
 				fmt.Println("Usage: get <key>")


### PR DESCRIPTION
## Description

The key-value engine previously loaded `.idx` files only to snapshot them into plain Go maps — the configured `indexType` (`hashmap`/`btree`) had no effect on any lookup. This PR makes `kvindex.KeyValueIndex` the real per-segment index serving all reads and writes, and fixes the index-file bugs that blocked putting it on the hot path.

### Index package fixes (`internal/index`)

- **New versioned on-disk format** (`format.go`, shared by both index types): magic + version header, then `keySize(u32) | pos(u64) | key` entries with a zero `keySize` as end-of-log marker.
  - **8-byte positions** — positions were stored as `uint32`, silently corrupting offsets for data files over 4 GiB.
  - **End-of-log marker** — loading used to scan the zero-filled mmap tail and set the write offset near the end of the file, so the file grew on every reopen.
  - Old-format files fail the header check and are transparently rebuilt from the data file.
- **Remap race fixed** — `Remove` munmapped/remapped the file without holding `mmapLock`, racing with concurrent `Add`s writing through the old mapping.
- **Batched durability** — `Add` no longer msyncs per entry; new `Sync()` on the `KeyValueIndex` interface flushes once per batch. `Close` now syncs, unmaps, and closes the file descriptor (previously leaked).

### Engine wiring (`internal/storage/key_value_storage.go`)

- `kvSegment` holds a `kvindex.KeyValueIndex` instead of `map[string]int64`; `Get`/`keyExists` route through `index.Get(key)`, so `indexType` is now a genuine engine choice.
- `FlushBatch` adds entries to the hot segment's index (tombstones included, preserving shadowing semantics) and syncs it once after the data-file fsync.
- **Hot segment index is always rebuilt at startup** (crash-safe: the mmap index may lag the fsynced data file; the segment is bounded by rollover size so the scan is cheap). Cold segments open their `.idx` directly and keep it for the segment lifetime.
- **Background index-build worker removed** — the hot index is complete and durable at rotation, so sealed segments go straight to cold. `RebuildKeyValueIndex` remains as the recovery/repair path.
- Merge returns an opened index for the merged segment; merge install and `Close` now close segment indexes alongside data files.

### Migration

None required. Pre-existing `.idx` files fail the new header check on first open and are rebuilt automatically from their data files.

### Tests

- New `internal/index/format_test.go` regression suite: >4 GiB position round-trip, file-growth-on-reopen, old-format rejection, sync-without-close visibility, and concurrent add/remove under `-race`.
- `go test -race ./internal/index ./internal/storage` passes, plus `queryengine`, `spaces`, `maintenance`, and `wal` suites.

Fixes # https://github.com/shibudb-org/shibudb-server/issues/42

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Unit test cases
- [x] E2E test cases

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules