### PR TITLE
[SDB-47] Removed segmentation from faiss vector index

### DIFF
--- a/E2ETests/segmented_storage_e2e_test.go
+++ b/E2ETests/segmented_storage_e2e_test.go
@@ -106,7 +106,7 @@ func TestSegmentedKeyValueE2E(t *testing.T) {
 	}
 }
 
-func TestSegmentedVectorE2E(t *testing.T) {
+func TestFAISSVectorSingleFileE2E(t *testing.T) {
 	conn, err := net.Dial("tcp", "localhost:4444")
 	if err != nil {
 		t.Fatalf("TCP connection error: %v", err)
@@ -133,7 +133,7 @@ func TestSegmentedVectorE2E(t *testing.T) {
 		SegmentRolloverBytes:   48,
 		MaxSegmentsBeforeMerge: 5,
 	}, conn, reader) {
-		t.Fatalf("failed to create segmented vector space")
+		t.Fatalf("failed to create FAISS vector space")
 	}
 
 	vectors := []struct {
@@ -171,10 +171,6 @@ func TestSegmentedVectorE2E(t *testing.T) {
 		}
 	}
 
-	if !UpdateSpaceSettings(space, 40, 5, conn, reader) {
-		t.Fatalf("failed to update segmented vector settings")
-	}
-
 	resp := sendQueryAndGetResponse(models.Query{
 		Type:  models.TypeInsertVector,
 		Space: space,
@@ -198,7 +194,7 @@ func TestSegmentedVectorE2E(t *testing.T) {
 			Dimension: 1,
 		}, conn, reader)
 		if !strings.Contains(resp, item.id) {
-			t.Fatalf("SEARCH_TOPK after settings update for %s did not return expected id: %s", item.id, resp)
+			t.Fatalf("SEARCH_TOPK after additional insert for %s did not return expected id: %s", item.id, resp)
 		}
 	}
 }

--- a/docs/ADMINISTRATION.md
+++ b/docs/ADMINISTRATION.md
@@ -115,8 +115,9 @@ The management API also supports updating space settings:
 - HTTP: `PUT /spaces/settings`
 
 Important behavior:
-- Segment rollover / merge settings apply to **Flat** and **HNSW** vector index types (segmented vector storage).
-- For training-based vector index types (**IVF**, **PQ**, …), segment settings do not apply.
+- Segment rollover / merge settings do not apply to FAISS vector indexes; they
+  use a single data file for every index type.
+- The filterable Flat vector engine and key-value engine still use segmented storage.
 
 ## Rebuilding a space index
 

--- a/docs/DYNAMIC_CONNECTION_LIMITING.md
+++ b/docs/DYNAMIC_CONNECTION_LIMITING.md
@@ -162,7 +162,8 @@ shibudb manager --username admin --password admin decrease 200
 shibudb manager --username admin --password admin health
 
 # Update space storage settings (admin-only)
-# NOTE: Segment settings apply to Flat/HNSW segmented storage; training indexes (IVF/PQ) ignore/reject these settings.
+# NOTE: FAISS vector indexes use single-file storage and reject segment settings.
+# Key-value and filterable Flat vector spaces still support these settings.
 shibudb manager --username admin --password admin update-space-settings \
   --segment-rollover-bytes 52428800 \
   --max-segments-before-merge 20 \

--- a/docs/VECTOR_ENGINE.md
+++ b/docs/VECTOR_ENGINE.md
@@ -565,6 +565,10 @@ RANGE-SEARCH 0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8 1.0
 
 ### Batch Vector Operations
 
+FAISS-backed spaces coalesce individual `INSERT-VECTOR` requests received
+between maintenance flushes and add them to the FAISS index in one batch. The
+wire protocol remains one vector per command.
+
 ```bash
 # Insert multiple vectors efficiently
 INSERT-VECTOR 1 1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0

--- a/internal/spaces/space_manager.go
+++ b/internal/spaces/space_manager.go
@@ -407,13 +407,9 @@ func normalizeSpaceMeta(meta spaceMeta) spaceMeta {
 		meta.Metric = ""
 		meta.IndexedMetadataFields = nil
 	}
-	if meta.EngineType == "vector" {
-		settings := storage.NormalizeVectorSpaceSettings(meta.IndexType, storage.SpaceSettings{
-			SegmentRolloverBytes:   meta.SegmentRolloverBytes,
-			MaxSegmentsBeforeMerge: meta.MaxSegmentsBeforeMerge,
-		})
-		meta.SegmentRolloverBytes = settings.SegmentRolloverBytes
-		meta.MaxSegmentsBeforeMerge = settings.MaxSegmentsBeforeMerge
+	if meta.EngineType == "vector" && len(meta.IndexedMetadataFields) == 0 {
+		meta.SegmentRolloverBytes = 0
+		meta.MaxSegmentsBeforeMerge = 0
 	} else {
 		settings := storage.NormalizeSpaceSettings(storage.SpaceSettings{
 			SegmentRolloverBytes:   meta.SegmentRolloverBytes,
@@ -596,13 +592,13 @@ func (sm *SpaceManager) UpdateSpaceSettings(space string, settings storage.Space
 	}
 
 	var applied storage.SpaceSettings
-	if meta.EngineType == "vector" && !storage.VectorSegmentsEnabled(meta.IndexType) {
+	if meta.EngineType == "vector" && len(meta.IndexedMetadataFields) == 0 {
 		if settings.SegmentRolloverBytes > 0 || settings.MaxSegmentsBeforeMerge > 0 {
-			return fmt.Errorf("segment settings do not apply to vector index type %q (only Flat and HNSW use segmented storage)", meta.IndexType)
+			return fmt.Errorf("segment settings do not apply to FAISS vector index type %q", meta.IndexType)
 		}
 		meta.SegmentRolloverBytes = 0
 		meta.MaxSegmentsBeforeMerge = 0
-		applied = storage.NormalizeVectorSpaceSettings(meta.IndexType, storage.SpaceSettings{})
+		applied = storage.SpaceSettings{}
 	} else {
 		if settings.SegmentRolloverBytes > 0 {
 			meta.SegmentRolloverBytes = settings.SegmentRolloverBytes

--- a/internal/spaces/space_manager_test.go
+++ b/internal/spaces/space_manager_test.go
@@ -519,25 +519,29 @@ func TestSpaceManager_VectorTrainingIndexClearsSegmentSettings(t *testing.T) {
 	}
 }
 
-func TestSpaceManager_UpdateSpaceSettingsRejectsSegmentForTrainingVector(t *testing.T) {
-	dir := t.TempDir()
-	sm := NewSpaceManager(dir)
-	defer sm.CloseAll()
+func TestSpaceManager_UpdateSpaceSettingsRejectsSegmentForFAISSVector(t *testing.T) {
+	for _, indexType := range []string{"Flat", "HNSW32,Flat", "IVF32,Flat"} {
+		t.Run(indexType, func(t *testing.T) {
+			dir := t.TempDir()
+			sm := NewSpaceManager(dir)
+			defer sm.CloseAll()
 
-	if _, err := sm.CreateSpaceWithSettings("ivf_upd", "vector", 8, "IVF32,Flat", "L2", true, storage.SpaceSettings{}); err != nil {
-		t.Fatalf("CreateSpaceWithSettings: %v", err)
-	}
-	if err := sm.UpdateSpaceSettings("ivf_upd", storage.SpaceSettings{
-		SegmentRolloverBytes: 1024,
-	}); err == nil {
-		t.Fatal("expected error when updating segment settings for IVF space")
-	}
-	if err := sm.UpdateSpaceSettings("ivf_upd", storage.SpaceSettings{}); err != nil {
-		t.Fatalf("no-op update: %v", err)
+			if _, err := sm.CreateSpaceWithSettings("faiss_upd", "vector", 8, indexType, "L2", true, storage.SpaceSettings{}); err != nil {
+				t.Fatalf("CreateSpaceWithSettings: %v", err)
+			}
+			if err := sm.UpdateSpaceSettings("faiss_upd", storage.SpaceSettings{
+				SegmentRolloverBytes: 1024,
+			}); err == nil {
+				t.Fatalf("expected error when updating segment settings for %s space", indexType)
+			}
+			if err := sm.UpdateSpaceSettings("faiss_upd", storage.SpaceSettings{}); err != nil {
+				t.Fatalf("no-op update: %v", err)
+			}
+		})
 	}
 }
 
-func TestSpaceManager_VectorFlatKeepsSegmentSettings(t *testing.T) {
+func TestSpaceManager_FAISSFlatClearsSegmentSettings(t *testing.T) {
 	dir := t.TempDir()
 	sm := NewSpaceManager(dir)
 	defer sm.CloseAll()
@@ -552,8 +556,30 @@ func TestSpaceManager_VectorFlatKeepsSegmentSettings(t *testing.T) {
 	if !ok {
 		t.Fatal("SpaceMeta missing")
 	}
+	if meta.SegmentRolloverBytes != 0 || meta.MaxSegmentsBeforeMerge != 0 {
+		t.Fatalf("FAISS Flat space should clear segment settings, got rollover=%d merge=%d",
+			meta.SegmentRolloverBytes, meta.MaxSegmentsBeforeMerge)
+	}
+}
+
+func TestSpaceManager_FilterableFlatKeepsSegmentSettings(t *testing.T) {
+	dir := t.TempDir()
+	sm := NewSpaceManager(dir)
+	defer sm.CloseAll()
+
+	if _, err := sm.CreateSpaceWithSettingsAndMetadata(
+		"flat_meta_seg", "vector", 4, "Flat", "L2", true,
+		storage.SpaceSettings{SegmentRolloverBytes: 2048, MaxSegmentsBeforeMerge: 9},
+		[]storage.MetadataFieldSpec{{Name: "user_id", Type: storage.MetadataTypeString}},
+	); err != nil {
+		t.Fatalf("CreateSpaceWithSettingsAndMetadata: %v", err)
+	}
+	meta, ok := sm.SpaceMeta("flat_meta_seg")
+	if !ok {
+		t.Fatal("SpaceMeta missing")
+	}
 	if meta.SegmentRolloverBytes != 2048 || meta.MaxSegmentsBeforeMerge != 9 {
-		t.Fatalf("Flat space should keep segment settings, got rollover=%d merge=%d",
+		t.Fatalf("filterable Flat space lost segment settings, got rollover=%d merge=%d",
 			meta.SegmentRolloverBytes, meta.MaxSegmentsBeforeMerge)
 	}
 }

--- a/internal/storage/engine.go
+++ b/internal/storage/engine.go
@@ -20,22 +20,6 @@ func NormalizeSpaceSettings(settings SpaceSettings) SpaceSettings {
 	return settings
 }
 
-// VectorSegmentsEnabled is true for index types that use segmented vector storage
-// (Flat, HNSW). Training-based indexes (IVF, PQ, …) use a single file and ignore
-// segment rollover / merge settings.
-func VectorSegmentsEnabled(indexType string) bool {
-	return requiredTrainCountForIndex(indexType) == 0
-}
-
-// NormalizeVectorSpaceSettings applies segment defaults for Flat/HNSW, and clears
-// segment fields for training-based vector index types.
-func NormalizeVectorSpaceSettings(indexType string, settings SpaceSettings) SpaceSettings {
-	if !VectorSegmentsEnabled(indexType) {
-		return SpaceSettings{}
-	}
-	return NormalizeSpaceSettings(settings)
-}
-
 type SpaceSettingsApplier interface {
 	UpdateSpaceSettings(settings SpaceSettings) error
 }

--- a/internal/storage/flat_meta_vector_storage.go
+++ b/internal/storage/flat_meta_vector_storage.go
@@ -29,8 +29,8 @@ import (
 // the WAL, and the in-memory indexes are rebuilt by scanning the segments on
 // open.
 //
-// Persistence uses the same segmented layout as the key-value and Flat/HNSW
-// vector engines: writes land in the active (hot) segment, which is sealed and
+// Persistence uses the same segmented layout as the key-value engine: writes
+// land in the active (hot) segment, which is sealed and
 // rolled over to a fresh file once it exceeds SegmentRolloverBytes, and a
 // background worker compacts the oldest cold segments once the segment count
 // exceeds MaxSegmentsBeforeMerge. Because all live state is kept in memory,

--- a/internal/storage/rebuild_test.go
+++ b/internal/storage/rebuild_test.go
@@ -95,7 +95,9 @@ func TestRebuildVectorIndexFlat(t *testing.T) {
 	if err := ve.InsertVector(22, vec2); err != nil {
 		t.Fatalf("InsertVector 22 failed: %v", err)
 	}
-	ve.flushData(true)
+	if err := ve.FlushBatch(); err != nil {
+		t.Fatalf("FlushBatch failed: %v", err)
+	}
 	if err := ve.RemoveVector(22); err != nil {
 		t.Fatalf("RemoveVector 22 failed: %v", err)
 	}

--- a/internal/storage/segmented_storage_lifecycle_test.go
+++ b/internal/storage/segmented_storage_lifecycle_test.go
@@ -165,7 +165,9 @@ func TestFAISSVectorIndexesNeverRollOver(t *testing.T) {
 					t.Fatalf("InsertVector %d failed: %v", id, err)
 				}
 			}
-			ve.flushData(true)
+			if err := ve.FlushBatch(); err != nil {
+				t.Fatalf("FlushBatch failed: %v", err)
+			}
 
 			if ve.store == nil || len(ve.manifest.Segments) != 1 {
 				t.Fatalf("FAISS index %q did not retain a single store", indexDesc)
@@ -200,7 +202,9 @@ func TestFAISSVectorSearchTopKExpandsOnlyWhenResultsAreFiltered(t *testing.T) {
 			t.Fatalf("InsertVector %d failed: %v", id, err)
 		}
 	}
-	ve.flushData(true)
+	if err := ve.FlushBatch(); err != nil {
+		t.Fatalf("FlushBatch failed: %v", err)
+	}
 
 	// Simulate stale FAISS entries that must be filtered. SearchTopK should retry
 	// only in this exceptional case instead of always requesting k*8 candidates.
@@ -236,7 +240,9 @@ func TestFAISSVectorCompactsLegacySegmentedLayout(t *testing.T) {
 	if err := ve.InsertVector(1, []float32{1, 0, 0, 0}); err != nil {
 		t.Fatalf("InsertVector failed: %v", err)
 	}
-	ve.flushData(true)
+	if err := ve.FlushBatch(); err != nil {
+		t.Fatalf("FlushBatch failed: %v", err)
+	}
 	if err := ve.Close(); err != nil {
 		t.Fatalf("Close failed: %v", err)
 	}

--- a/internal/storage/segmented_storage_lifecycle_test.go
+++ b/internal/storage/segmented_storage_lifecycle_test.go
@@ -177,6 +177,52 @@ func TestFAISSVectorIndexesNeverRollOver(t *testing.T) {
 	}
 }
 
+func TestFAISSVectorSearchTopKExpandsOnlyWhenResultsAreFiltered(t *testing.T) {
+	dir := t.TempDir()
+	ve, err := NewVectorEngine(
+		filepath.Join(dir, "vector_data.db"),
+		filepath.Join(dir, "vector_index.faiss"),
+		filepath.Join(dir, "vector_wal.db"),
+		2, "Flat", faiss.MetricL2, false,
+	)
+	if err != nil {
+		t.Fatalf("NewVectorEngine failed: %v", err)
+	}
+	defer ve.Close()
+
+	for id, vector := range map[int64][]float32{
+		1: {0, 0},
+		2: {0.1, 0},
+		3: {1, 0},
+		4: {2, 0},
+	} {
+		if err := ve.InsertVector(id, vector); err != nil {
+			t.Fatalf("InsertVector %d failed: %v", id, err)
+		}
+	}
+	ve.flushData(true)
+
+	// Simulate stale FAISS entries that must be filtered. SearchTopK should retry
+	// only in this exceptional case instead of always requesting k*8 candidates.
+	ve.lock.Lock()
+	ve.segments[0].deletedIDs[1] = true
+	ve.segments[0].deletedIDs[2] = true
+	ve.lock.Unlock()
+
+	ids, _, err := ve.SearchTopK([]float32{0, 0}, 2)
+	if err != nil {
+		t.Fatalf("SearchTopK failed: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 3 || ids[1] != 4 {
+		t.Fatalf("SearchTopK returned %v, want [3 4]", ids)
+	}
+
+	ids, dists, err := ve.SearchTopK([]float32{0, 0}, 0)
+	if err != nil || len(ids) != 0 || len(dists) != 0 {
+		t.Fatalf("SearchTopK k=0 returned ids=%v dists=%v err=%v", ids, dists, err)
+	}
+}
+
 func TestFAISSVectorCompactsLegacySegmentedLayout(t *testing.T) {
 	dir := t.TempDir()
 	dataPath := filepath.Join(dir, "vector_data.db")

--- a/internal/storage/segmented_storage_lifecycle_test.go
+++ b/internal/storage/segmented_storage_lifecycle_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"encoding/binary"
 	"os"
 	"path/filepath"
 	"strings"
@@ -59,7 +60,6 @@ func TestSegmentedKeyValueRestartRebuildsMissingColdIndex(t *testing.T) {
 	if _, err := os.Stat(firstIndexPath); err != nil {
 		t.Fatalf("expected cold index file to exist: %v", err)
 	}
-
 	if err := os.Remove(firstIndexPath); err != nil {
 		t.Fatalf("remove cold index failed: %v", err)
 	}
@@ -132,103 +132,63 @@ func TestSegmentedKeyValueMergesOldestColdSegments(t *testing.T) {
 		t.Fatalf("expected merged cold segment id %d to remain less than hot id %d", mergedID, hotID)
 	}
 
-	if got, err := db.Get("alpha"); err != nil || got != strings.Repeat("a", 96) {
-		t.Fatalf("Get alpha after merge = %q, err=%v", got, err)
-	}
-	if got, err := db.Get("beta"); err != nil || got != strings.Repeat("b", 96) {
-		t.Fatalf("Get beta after merge = %q, err=%v", got, err)
-	}
-	if got, err := db.Get("gamma"); err != nil || got != strings.Repeat("c", 96) {
-		t.Fatalf("Get gamma after merge = %q, err=%v", got, err)
-	}
-}
-
-func TestSegmentedVectorRestartAndSearchAcrossSegments(t *testing.T) {
-	dir := t.TempDir()
-	dataPath := filepath.Join(dir, "vector_data.db")
-	indexPath := filepath.Join(dir, "vector_index.faiss")
-	walPath := filepath.Join(dir, "vector_wal.db")
-
-	ve, err := NewVectorEngineWithSettings(dataPath, indexPath, walPath, 4, "Flat", faiss.MetricL2, true, SpaceSettings{
-		SegmentRolloverBytes:   48,
-		MaxSegmentsBeforeMerge: 10,
-	})
-	if err != nil {
-		t.Fatalf("NewVectorEngineWithSettings failed: %v", err)
-	}
-
-	vec1 := []float32{1, 0, 0, 0}
-	vec2 := []float32{0, 1, 0, 0}
-	vec3 := []float32{0, 0, 1, 0}
-
-	if err := ve.InsertVector(1, vec1); err != nil {
-		t.Fatalf("InsertVector 1 failed: %v", err)
-	}
-	if err := ve.InsertVector(2, vec2); err != nil {
-		t.Fatalf("InsertVector 2 failed: %v", err)
-	}
-	ve.flushData(true)
-
-	if err := ve.InsertVector(3, vec3); err != nil {
-		t.Fatalf("InsertVector 3 failed: %v", err)
-	}
-	ve.flushData(true)
-
-	waitForCondition(t, 3*time.Second, func() bool {
-		ve.lock.RLock()
-		defer ve.lock.RUnlock()
-		return len(ve.segments) >= 2 && ve.segments[0].meta.State == SegmentStateCold
-	}, "first vector segment to become cold")
-
-	if ids, _, err := ve.SearchTopK(vec1, 3); err != nil || len(ids) == 0 || ids[0] != 1 {
-		t.Fatalf("SearchTopK for vec1 returned ids=%v err=%v", ids, err)
-	}
-	if ids, _, err := ve.SearchTopK(vec3, 3); err != nil || len(ids) == 0 || ids[0] != 3 {
-		t.Fatalf("SearchTopK for vec3 returned ids=%v err=%v", ids, err)
-	}
-
-	firstIndexPath := ve.layout.Descriptor(ve.segments[0].meta).IndexPath
-	if err := os.Remove(firstIndexPath); err != nil {
-		t.Fatalf("remove vector cold index failed: %v", err)
-	}
-	if err := ve.Close(); err != nil {
-		t.Fatalf("Close failed: %v", err)
-	}
-
-	reopened, err := NewVectorEngineWithSettings(dataPath, indexPath, walPath, 4, "Flat", faiss.MetricL2, true, SpaceSettings{
-		SegmentRolloverBytes:   48,
-		MaxSegmentsBeforeMerge: 10,
-	})
-	if err != nil {
-		t.Fatalf("reopen vector engine failed: %v", err)
-	}
-	defer reopened.Close()
-
-	if ids, _, err := reopened.SearchTopK(vec1, 3); err != nil || len(ids) == 0 || ids[0] != 1 {
-		t.Fatalf("SearchTopK vec1 after restart returned ids=%v err=%v", ids, err)
-	}
-	if ids, _, err := reopened.SearchTopK(vec3, 3); err != nil || len(ids) == 0 || ids[0] != 3 {
-		t.Fatalf("SearchTopK vec3 after restart returned ids=%v err=%v", ids, err)
-	}
-	if _, err := os.Stat(firstIndexPath); err != nil {
-		t.Fatalf("expected vector cold index to be rebuilt on startup: %v", err)
-	}
-}
-
-func TestSegmentedVectorTrainingFallbackOnMissingColdIndex(t *testing.T) {
-	dir := t.TempDir()
-	dataPath := filepath.Join(dir, "vector_data.db")
-	indexPath := filepath.Join(dir, "vector_index.faiss")
-	walPath := filepath.Join(dir, "vector_wal.db")
-
-	ve, err := NewVectorEngineWithSettings(dataPath, indexPath, walPath, 8, "IVF32,Flat", faiss.MetricL2, true, SpaceSettings{})
-	if err != nil {
-		t.Fatalf("NewVectorEngineWithSettings failed: %v", err)
-	}
-	for i := 0; i < 4; i++ {
-		if err := ve.InsertVector(int64(300+i), randomVector(8)); err != nil {
-			t.Fatalf("InsertVector %d failed: %v", i, err)
+	for key, want := range map[string]string{
+		"alpha": strings.Repeat("a", 96),
+		"beta":  strings.Repeat("b", 96),
+		"gamma": strings.Repeat("c", 96),
+	} {
+		if got, err := db.Get(key); err != nil || got != want {
+			t.Fatalf("Get %s after merge = %q, err=%v", key, got, err)
 		}
+	}
+}
+
+func TestFAISSVectorIndexesNeverRollOver(t *testing.T) {
+	for _, indexDesc := range []string{"Flat", "HNSW32,Flat", "IVF32,Flat"} {
+		t.Run(indexDesc, func(t *testing.T) {
+			dir := t.TempDir()
+			dataPath := filepath.Join(dir, "vector_data.db")
+			indexPath := filepath.Join(dir, "vector_index.faiss")
+			walPath := filepath.Join(dir, "vector_wal.db")
+
+			ve, err := NewVectorEngineWithSettings(dataPath, indexPath, walPath, 4, indexDesc, faiss.MetricL2, true, SpaceSettings{
+				SegmentRolloverBytes:   1,
+				MaxSegmentsBeforeMerge: 1,
+			})
+			if err != nil {
+				t.Fatalf("NewVectorEngineWithSettings failed: %v", err)
+			}
+			defer ve.Close()
+
+			for id := int64(1); id <= 64; id++ {
+				if err := ve.InsertVector(id, []float32{float32(id), 1, 2, 3}); err != nil {
+					t.Fatalf("InsertVector %d failed: %v", id, err)
+				}
+			}
+			ve.flushData(true)
+
+			if len(ve.segments) != 1 || len(ve.manifest.Segments) != 1 {
+				t.Fatalf("FAISS index %q rolled over: segments=%d manifest=%d", indexDesc, len(ve.segments), len(ve.manifest.Segments))
+			}
+			if matches, err := filepath.Glob(filepath.Join(dir, "vector_segment_*")); err != nil || len(matches) != 0 {
+				t.Fatalf("unexpected FAISS segment files %v, err=%v", matches, err)
+			}
+		})
+	}
+}
+
+func TestFAISSVectorCompactsLegacySegmentedLayout(t *testing.T) {
+	dir := t.TempDir()
+	dataPath := filepath.Join(dir, "vector_data.db")
+	indexPath := filepath.Join(dir, "vector_index.faiss")
+	walPath := filepath.Join(dir, "vector_wal.db")
+
+	ve, err := NewVectorEngine(dataPath, indexPath, walPath, 4, "Flat", faiss.MetricL2, true)
+	if err != nil {
+		t.Fatalf("NewVectorEngine failed: %v", err)
+	}
+	if err := ve.InsertVector(1, []float32{1, 0, 0, 0}); err != nil {
+		t.Fatalf("InsertVector failed: %v", err)
 	}
 	ve.flushData(true)
 	if err := ve.Close(); err != nil {
@@ -238,8 +198,15 @@ func TestSegmentedVectorTrainingFallbackOnMissingColdIndex(t *testing.T) {
 	sealedDataPath := filepath.Join(dir, "vector_segment_000001.db")
 	sealedIndexPath := filepath.Join(dir, "vector_segment_000001.faiss")
 	if err := os.Rename(dataPath, sealedDataPath); err != nil {
-		t.Fatalf("rename primary data to sealed segment failed: %v", err)
+		t.Fatalf("rename primary data: %v", err)
 	}
+	record := make([]byte, 8+4*4)
+	binary.LittleEndian.PutUint64(record[:8], 2)
+	copy(record[8:], float32ArrayToBytes([]float32{0, 1, 0, 0}))
+	if err := os.WriteFile(dataPath, record, 0666); err != nil {
+		t.Fatalf("write active data: %v", err)
+	}
+
 	manifest := &SegmentManifest{
 		Version:         currentSegmentManifestVersion,
 		NextSegmentID:   3,
@@ -253,157 +220,25 @@ func TestSegmentedVectorTrainingFallbackOnMissingColdIndex(t *testing.T) {
 		t.Fatalf("WriteSegmentManifest failed: %v", err)
 	}
 
-	reopened, err := NewVectorEngineWithSettings(dataPath, indexPath, walPath, 8, "IVF32,Flat", faiss.MetricL2, true, SpaceSettings{})
+	reopened, err := NewVectorEngine(dataPath, indexPath, walPath, 4, "Flat", faiss.MetricL2, true)
 	if err != nil {
-		t.Fatalf("expected reopen with training fallback to Flat, got err=%v", err)
+		t.Fatalf("reopen failed: %v", err)
 	}
 	defer reopened.Close()
-	// Training-based indexes compact legacy multi-segment layouts to the primary
-	// data file on open; sealed per-segment FAISS files are not expected.
-	if _, err := os.Stat(sealedIndexPath); err == nil {
-		t.Fatalf("did not expect sealed index file %q for training index layout", sealedIndexPath)
-	}
-}
 
-func TestSegmentedVectorNoFallbackOnNonTrainingColdIndexFailure(t *testing.T) {
-	dir := t.TempDir()
-	dataPath := filepath.Join(dir, "vector_data.db")
-	indexPath := filepath.Join(dir, "vector_index.faiss")
-	walPath := filepath.Join(dir, "vector_wal.db")
-
-	ve, err := NewVectorEngineWithSettings(dataPath, indexPath, walPath, 4, "Flat", faiss.MetricL2, true, SpaceSettings{
-		SegmentRolloverBytes:   48,
-		MaxSegmentsBeforeMerge: 10,
-	})
-	if err != nil {
-		t.Fatalf("NewVectorEngineWithSettings failed: %v", err)
-	}
-	if err := ve.InsertVector(1, []float32{1, 0, 0, 0}); err != nil {
-		t.Fatalf("InsertVector 1 failed: %v", err)
-	}
-	if err := ve.InsertVector(2, []float32{0, 1, 0, 0}); err != nil {
-		t.Fatalf("InsertVector 2 failed: %v", err)
-	}
-	ve.flushData(true)
-	waitForCondition(t, 3*time.Second, func() bool {
-		ve.lock.RLock()
-		defer ve.lock.RUnlock()
-		return len(ve.segments) >= 2 && ve.segments[0].meta.State == SegmentStateCold
-	}, "first vector segment to become cold")
-
-	firstIndexPath := ve.layout.Descriptor(ve.segments[0].meta).IndexPath
-	firstDataPath := ve.layout.Descriptor(ve.segments[0].meta).DataPath
-	if err := os.Remove(firstIndexPath); err != nil {
-		t.Fatalf("remove vector cold index failed: %v", err)
-	}
-	if err := ve.Close(); err != nil {
-		t.Fatalf("Close failed: %v", err)
-	}
-	if err := os.Remove(firstDataPath); err != nil {
-		t.Fatalf("remove vector cold data failed: %v", err)
-	}
-
-	_, err = NewVectorEngineWithSettings(dataPath, indexPath, walPath, 4, "Flat", faiss.MetricL2, true, SpaceSettings{
-		SegmentRolloverBytes:   48,
-		MaxSegmentsBeforeMerge: 10,
-	})
-	if err == nil {
-		t.Fatal("expected reopen to fail without Flat fallback for non-training rebuild errors")
-	}
-}
-
-func TestSegmentedVectorMergesOldestColdSegments(t *testing.T) {
-	dir := t.TempDir()
-	dataPath := filepath.Join(dir, "vector_data.db")
-	indexPath := filepath.Join(dir, "vector_index.faiss")
-	walPath := filepath.Join(dir, "vector_wal.db")
-
-	ve, err := NewVectorEngineWithSettings(dataPath, indexPath, walPath, 4, "Flat", faiss.MetricL2, true, SpaceSettings{
-		SegmentRolloverBytes:   48,
-		MaxSegmentsBeforeMerge: 2,
-	})
-	if err != nil {
-		t.Fatalf("NewVectorEngineWithSettings failed: %v", err)
-	}
-	defer ve.Close()
-
-	vectors := []struct {
-		id  int64
-		vec []float32
-	}{
-		{1, []float32{1, 0, 0, 0}},
-		{2, []float32{0, 1, 0, 0}},
-		{3, []float32{0, 0, 1, 0}},
-		{4, []float32{0, 0, 0, 1}},
-	}
-
-	for _, item := range vectors {
-		if err := ve.InsertVector(item.id, item.vec); err != nil {
-			t.Fatalf("InsertVector %d failed: %v", item.id, err)
+	for id, query := range map[int64][]float32{
+		1: {1, 0, 0, 0},
+		2: {0, 1, 0, 0},
+	} {
+		ids, _, err := reopened.SearchTopK(query, 1)
+		if err != nil || len(ids) != 1 || ids[0] != id {
+			t.Fatalf("SearchTopK id=%d returned ids=%v err=%v", id, ids, err)
 		}
-		ve.flushData(true)
 	}
-
-	waitForCondition(t, 5*time.Second, func() bool {
-		ve.lock.RLock()
-		defer ve.lock.RUnlock()
-		return len(ve.segments) == 2
-	}, "vector cold segment merge")
-
-	ve.lock.RLock()
-	mergedID := ve.segments[0].meta.ID
-	hotID := ve.segments[len(ve.segments)-1].meta.ID
-	ve.lock.RUnlock()
-	if mergedID >= hotID {
-		t.Fatalf("expected merged cold segment id %d to remain less than hot id %d", mergedID, hotID)
+	if len(reopened.manifest.Segments) != 1 {
+		t.Fatalf("expected compacted single-file manifest, got %d segments", len(reopened.manifest.Segments))
 	}
-
-	if ids, _, err := ve.SearchTopK(vectors[0].vec, 4); err != nil || len(ids) == 0 || ids[0] != 1 {
-		t.Fatalf("SearchTopK merged vec1 returned ids=%v err=%v", ids, err)
-	}
-	if ids, _, err := ve.SearchTopK(vectors[3].vec, 4); err != nil || len(ids) == 0 || ids[0] != 4 {
-		t.Fatalf("SearchTopK hot vec4 returned ids=%v err=%v", ids, err)
-	}
-}
-
-func TestSegmentedVectorSearchTopKInnerProductOrdering(t *testing.T) {
-	dir := t.TempDir()
-	dataPath := filepath.Join(dir, "vector_data.db")
-	indexPath := filepath.Join(dir, "vector_index.faiss")
-	walPath := filepath.Join(dir, "vector_wal.db")
-
-	ve, err := NewVectorEngineWithSettings(dataPath, indexPath, walPath, 2, "Flat", faiss.MetricInnerProduct, true, SpaceSettings{
-		SegmentRolloverBytes:   24,
-		MaxSegmentsBeforeMerge: 10,
-	})
-	if err != nil {
-		t.Fatalf("NewVectorEngineWithSettings failed: %v", err)
-	}
-	defer ve.Close()
-
-	if err := ve.InsertVector(1, []float32{1, 0}); err != nil {
-		t.Fatalf("InsertVector 1 failed: %v", err)
-	}
-	ve.flushData(true)
-	if err := ve.InsertVector(2, []float32{0.5, 0}); err != nil {
-		t.Fatalf("InsertVector 2 failed: %v", err)
-	}
-	ve.flushData(true)
-
-	waitForCondition(t, 3*time.Second, func() bool {
-		ve.lock.RLock()
-		defer ve.lock.RUnlock()
-		return len(ve.segments) >= 2
-	}, "multiple inner-product vector segments")
-
-	ids, _, err := ve.SearchTopK([]float32{1, 0}, 2)
-	if err != nil {
-		t.Fatalf("SearchTopK failed: %v", err)
-	}
-	if len(ids) < 2 {
-		t.Fatalf("expected 2 ids, got %v", ids)
-	}
-	if ids[0] != 1 || ids[1] != 2 {
-		t.Fatalf("expected higher inner-product hit first, got %v", ids)
+	if _, err := os.Stat(sealedDataPath); !os.IsNotExist(err) {
+		t.Fatalf("legacy segment data still exists, err=%v", err)
 	}
 }

--- a/internal/storage/segmented_storage_lifecycle_test.go
+++ b/internal/storage/segmented_storage_lifecycle_test.go
@@ -167,8 +167,8 @@ func TestFAISSVectorIndexesNeverRollOver(t *testing.T) {
 			}
 			ve.flushData(true)
 
-			if len(ve.segments) != 1 || len(ve.manifest.Segments) != 1 {
-				t.Fatalf("FAISS index %q rolled over: segments=%d manifest=%d", indexDesc, len(ve.segments), len(ve.manifest.Segments))
+			if ve.store == nil || len(ve.manifest.Segments) != 1 {
+				t.Fatalf("FAISS index %q did not retain a single store", indexDesc)
 			}
 			if matches, err := filepath.Glob(filepath.Join(dir, "vector_segment_*")); err != nil || len(matches) != 0 {
 				t.Fatalf("unexpected FAISS segment files %v, err=%v", matches, err)
@@ -205,8 +205,8 @@ func TestFAISSVectorSearchTopKExpandsOnlyWhenResultsAreFiltered(t *testing.T) {
 	// Simulate stale FAISS entries that must be filtered. SearchTopK should retry
 	// only in this exceptional case instead of always requesting k*8 candidates.
 	ve.lock.Lock()
-	ve.segments[0].deletedIDs[1] = true
-	ve.segments[0].deletedIDs[2] = true
+	ve.store.deletedIDs[1] = true
+	ve.store.deletedIDs[2] = true
 	ve.lock.Unlock()
 
 	ids, _, err := ve.SearchTopK([]float32{0, 0}, 2)

--- a/internal/storage/vector_storage.go
+++ b/internal/storage/vector_storage.go
@@ -327,6 +327,9 @@ func (ve *VectorEngineImpl) SearchTopK(query []float32, k int) ([]int64, []float
 	if len(query) != ve.maxVectorSize {
 		return nil, nil, errors.New("invalid query size")
 	}
+	if k <= 0 {
+		return []int64{}, []float32{}, nil
+	}
 	ve.lock.RLock()
 	defer ve.lock.RUnlock()
 
@@ -336,13 +339,38 @@ func (ve *VectorEngineImpl) SearchTopK(query []float32, k int) ([]int64, []float
 	}
 	shadowed := make(map[int64]struct{})
 	candidates := make([]pair, 0, k*len(ve.segments))
-	searchK := int64(maxInt(k*8, 32))
 
 	for segIdx := len(ve.segments) - 1; segIdx >= 0; segIdx-- {
 		segment := ve.segments[segIdx]
-		dists, labels, err := segment.index.Search(query, searchK)
-		if err != nil {
-			return nil, nil, err
+		searchK := int64(k)
+		var dists []float32
+		var labels []int64
+		for {
+			var err error
+			dists, labels, err = segment.index.Search(query, searchK)
+			if err != nil {
+				return nil, nil, err
+			}
+			valid := 0
+			for _, label := range labels {
+				if label < 0 || segment.deletedIDs[label] {
+					continue
+				}
+				if _, seen := shadowed[label]; seen {
+					continue
+				}
+				if _, exists := segment.fileOffsets[label]; exists {
+					valid++
+				}
+			}
+			total := segment.index.Ntotal()
+			if valid >= k || searchK >= total {
+				break
+			}
+			searchK *= 2
+			if searchK > total {
+				searchK = total
+			}
 		}
 		for i, label := range labels {
 			if label < 0 {
@@ -936,13 +964,6 @@ func writeMergedVectorDataFile(dataPath string, records map[int64][]byte) error 
 		return err
 	}
 	return os.Rename(tmpPath, dataPath)
-}
-
-func maxInt(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
 }
 
 func (ve *VectorEngineImpl) activeIndexDesc() string {

--- a/internal/storage/vector_storage.go
+++ b/internal/storage/vector_storage.go
@@ -29,18 +29,9 @@ var ErrDeletionNotSupported = errors.New("vector deletion not supported for HNSW
 type VectorEngineImpl struct {
 	wal           *wal.WAL
 	maxVectorSize int
-	settings      SpaceSettings
 
 	indexType string
 	metric    int
-
-	// vectorSegmentationEnabled is true for Flat and HNSW (no training batch).
-	// When false (IVF, PQ, …): single vector data file, no hot rollover or cold
-	// merge, and no sealed per-segment on-disk FAISS files. The active segment
-	// still uses IDMap,Flat for incremental updates; a configured IVF/PQ index
-	// is produced only for sealed segments when segmentation is enabled.
-	// Legacy multi-segment manifests are compacted to the primary data file on open.
-	vectorSegmentationEnabled bool
 
 	layout           SegmentLayout
 	primaryDataPath  string
@@ -61,10 +52,6 @@ type VectorEngineImpl struct {
 		id  int64
 		vec []float32
 	}
-	indexBuildQueue chan int64
-	mergeQueue      chan struct{}
-	backgroundStop  chan struct{}
-	backgroundWG    sync.WaitGroup
 }
 
 var _ VectorEngine = (*VectorEngineImpl)(nil)
@@ -86,7 +73,7 @@ func NewVectorEngine(dataPath, indexPath, walPath string, maxVectorSize int, ind
 	return NewVectorEngineWithSettings(dataPath, indexPath, walPath, maxVectorSize, indexDesc, metric, enableWAL, SpaceSettings{})
 }
 
-func NewVectorEngineWithSettings(dataPath, indexPath, walPath string, maxVectorSize int, indexDesc string, metric int, enableWAL bool, settings SpaceSettings) (*VectorEngineImpl, error) {
+func NewVectorEngineWithSettings(dataPath, indexPath, walPath string, maxVectorSize int, indexDesc string, metric int, enableWAL bool, _ SpaceSettings) (*VectorEngineImpl, error) {
 	var w *wal.WAL
 	var err error
 	if enableWAL {
@@ -97,18 +84,13 @@ func NewVectorEngineWithSettings(dataPath, indexPath, walPath string, maxVectorS
 	}
 
 	e := &VectorEngineImpl{
-		wal:                       w,
-		maxVectorSize:             maxVectorSize,
-		settings:                  NormalizeVectorSpaceSettings(indexDesc, settings),
-		indexType:                 indexDesc,
-		metric:                    metric,
-		vectorSegmentationEnabled: requiredTrainCountForIndex(indexDesc) == 0,
-		layout:                    NewSegmentLayout(filepath.Dir(dataPath), "vector", ".db", ".faiss"),
-		primaryDataPath:           dataPath,
-		primaryIndexPath:          indexPath,
-		indexBuildQueue:           make(chan int64, 32),
-		mergeQueue:                make(chan struct{}, 1),
-		backgroundStop:            make(chan struct{}),
+		wal:              w,
+		maxVectorSize:    maxVectorSize,
+		indexType:        indexDesc,
+		metric:           metric,
+		layout:           NewSegmentLayout(filepath.Dir(dataPath), "vector", ".db", ".faiss"),
+		primaryDataPath:  dataPath,
+		primaryIndexPath: indexPath,
 	}
 
 	manifest, err := e.loadOrCreateManifest()
@@ -120,13 +102,11 @@ func NewVectorEngineWithSettings(dataPath, indexPath, walPath string, maxVectorS
 	}
 	e.manifest = manifest
 
-	if !e.vectorSegmentationEnabled {
-		if err := e.compactNonSegmentedTrainingLayoutIfNeeded(); err != nil {
-			if e.wal != nil {
-				_ = e.wal.Close()
-			}
-			return nil, err
+	if err := e.compactLegacySegmentedLayoutIfNeeded(); err != nil {
+		if e.wal != nil {
+			_ = e.wal.Close()
 		}
+		return nil, err
 	}
 
 	if err := e.loadSegments(); err != nil {
@@ -136,7 +116,6 @@ func NewVectorEngineWithSettings(dataPath, indexPath, walPath string, maxVectorS
 		return nil, err
 	}
 
-	e.startBackgroundWorkers()
 	if enableWAL {
 		if err := e.replayWAL(); err != nil {
 			return nil, fmt.Errorf("WAL replay failed: %w", err)
@@ -146,11 +125,7 @@ func NewVectorEngineWithSettings(dataPath, indexPath, walPath string, maxVectorS
 	return e, nil
 }
 
-func (ve *VectorEngineImpl) UpdateSpaceSettings(settings SpaceSettings) error {
-	ve.lock.Lock()
-	defer ve.lock.Unlock()
-	ve.settings = NormalizeVectorSpaceSettings(ve.indexType, settings)
-	ve.scheduleMergeCheckLocked()
+func (ve *VectorEngineImpl) UpdateSpaceSettings(_ SpaceSettings) error {
 	return nil
 }
 
@@ -184,14 +159,13 @@ func (ve *VectorEngineImpl) loadOrCreateManifest() (*SegmentManifest, error) {
 	return manifest, nil
 }
 
-// compactNonSegmentedTrainingLayoutIfNeeded merges a legacy multi-segment manifest
-// into the primary vector data file. Training-based indexes never use per-segment
-// rollover; older builds may still have left multiple segments on disk.
-func (ve *VectorEngineImpl) compactNonSegmentedTrainingLayoutIfNeeded() error {
+// compactLegacySegmentedLayoutIfNeeded merges data created by older versions
+// into the single-file layout now used by every FAISS index type.
+func (ve *VectorEngineImpl) compactLegacySegmentedLayoutIfNeeded() error {
 	if len(ve.manifest.Segments) <= 1 {
 		return nil
 	}
-	log.Printf("storage: merging %d vector segments into single-file layout for training index %q",
+	log.Printf("storage: merging %d legacy vector segments into single-file layout for FAISS index %q",
 		len(ve.manifest.Segments), ve.indexType)
 
 	paths := make([]string, 0, len(ve.manifest.Segments))
@@ -259,13 +233,7 @@ func (ve *VectorEngineImpl) loadSegments() error {
 	ve.manifest.ActiveSegmentID = ve.manifest.Segments[len(ve.manifest.Segments)-1].ID
 	for idx, meta := range ve.manifest.Segments {
 		desc := ve.layout.Descriptor(meta)
-		flags := os.O_RDWR
-		// Only the active/hot segment is allowed to be created on open. Cold segment
-		// files must exist; recreating them would hide data loss/corruption.
-		if meta.ID == ve.manifest.ActiveSegmentID {
-			flags |= os.O_CREATE
-		}
-		dataFile, err := os.OpenFile(desc.DataPath, flags, 0666)
+		dataFile, err := os.OpenFile(desc.DataPath, os.O_RDWR|os.O_CREATE, 0666)
 		if err != nil {
 			return err
 		}
@@ -276,17 +244,8 @@ func (ve *VectorEngineImpl) loadSegments() error {
 			return err
 		}
 
-		var index faiss.Index
-		if idx == len(ve.manifest.Segments)-1 {
-			// Training indexes always use a Flat IDMap in the active segment so
-			// incremental inserts and RemoveIDs stay well-defined; configured
-			// IVF/PQ indexes exist only on sealed segments when segmentation is on.
-			index, err = buildVectorIndexFromDataFile(desc.DataPath, ve.maxVectorSize, ve.hotSegmentIndexDesc(), ve.metric)
-			meta.State = SegmentStateHot
-		} else {
-			index, err = loadOrBuildVectorSegmentIndex(desc, ve.maxVectorSize, ve.indexType, ve.metric)
-			meta.State = SegmentStateCold
-		}
+		index, err := buildVectorIndexFromDataFile(desc.DataPath, ve.maxVectorSize, ve.activeIndexDesc(), ve.metric)
+		meta.State = SegmentStateHot
 		if err != nil {
 			_ = dataFile.Close()
 			return err
@@ -306,12 +265,6 @@ func (ve *VectorEngineImpl) loadSegments() error {
 	}
 
 	return WriteSegmentManifest(ve.layout, ve.manifest)
-}
-
-func (ve *VectorEngineImpl) startBackgroundWorkers() {
-	ve.backgroundWG.Add(2)
-	go ve.indexBuildWorker()
-	go ve.mergeWorker()
 }
 
 func (ve *VectorEngineImpl) InsertVector(id int64, vector []float32) error {
@@ -599,7 +552,7 @@ func (ve *VectorEngineImpl) appendTombstoneToDataFile(id int64) error {
 		active.meta.SizeBytes = info.Size()
 		ve.updateSegmentMetaLocked(active.meta)
 	}
-	return ve.rotateHotSegmentLocked()
+	return nil
 }
 
 func (ve *VectorEngineImpl) Close() error {
@@ -612,9 +565,6 @@ func (ve *VectorEngineImpl) Close() error {
 
 		// Final flush of any pending data-file writes
 		ve.flushData(true)
-
-		close(ve.backgroundStop)
-		ve.backgroundWG.Wait()
 
 		if ve.wal != nil {
 			_ = ve.wal.Close()
@@ -777,14 +727,10 @@ func (ve *VectorEngineImpl) flushData(force bool) {
 		active.meta.SizeBytes = info.Size()
 		ve.updateSegmentMetaLocked(active.meta)
 	}
-	rotateErr := ve.rotateHotSegmentLocked()
 	ve.lock.Unlock()
 
 	if err := active.dataFile.Sync(); err != nil {
 		log.Printf("data file sync failed: %v", err)
-	}
-	if rotateErr != nil {
-		log.Printf("hot segment rotation failed: %v", rotateErr)
 	}
 }
 
@@ -829,313 +775,6 @@ func (ve *VectorEngineImpl) updateSegmentMetaLocked(meta SegmentMeta) {
 			break
 		}
 	}
-}
-
-func (ve *VectorEngineImpl) rotateHotSegmentLocked() error {
-	if !ve.vectorSegmentationEnabled {
-		return nil
-	}
-	active := ve.activeSegmentLocked()
-	if active == nil || active.meta.SizeBytes < ve.settings.SegmentRolloverBytes {
-		return nil
-	}
-
-	active.meta.State = SegmentStateSealed
-	active.meta.SealedAtUnixNs = time.Now().UnixNano()
-	ve.updateSegmentMetaLocked(active.meta)
-
-	newID := ve.manifest.NextSegmentID
-	ve.manifest.NextSegmentID++
-	newMeta := SegmentMeta{
-		ID:              newID,
-		State:           SegmentStateHot,
-		DataFile:        ve.layout.DataFileName(newID),
-		IndexFile:       ve.layout.IndexFileName(newID),
-		CreatedAtUnixNs: time.Now().UnixNano(),
-	}
-	index, err := faiss.IndexFactory(ve.maxVectorSize, "IDMap,"+ve.hotSegmentIndexDesc(), ve.metric)
-	if err != nil {
-		return err
-	}
-	dataFile, err := os.OpenFile(ve.layout.DataPath(newID), os.O_RDWR|os.O_CREATE, 0666)
-	if err != nil {
-		index.Delete()
-		return err
-	}
-
-	ve.manifest.ActiveSegmentID = newID
-	ve.manifest.Segments = append(ve.manifest.Segments, newMeta)
-	ve.segments = append(ve.segments, &vectorSegment{
-		meta:             newMeta,
-		dataFile:         dataFile,
-		index:            index,
-		fileOffsets:      make(map[int64]int64),
-		deletedIDs:       make(map[int64]bool),
-		pendingUpsertIDs: make(map[int64]struct{}),
-	})
-	if err := WriteSegmentManifest(ve.layout, ve.manifest); err != nil {
-		return err
-	}
-
-	ve.enqueueIndexBuildLocked(active.meta.ID)
-	ve.scheduleMergeCheckLocked()
-	return nil
-}
-
-func (ve *VectorEngineImpl) indexBuildWorker() {
-	defer ve.backgroundWG.Done()
-	for {
-		select {
-		case <-ve.backgroundStop:
-			return
-		case id := <-ve.indexBuildQueue:
-			ve.buildIndexForSegment(id)
-		}
-	}
-}
-
-func (ve *VectorEngineImpl) mergeWorker() {
-	defer ve.backgroundWG.Done()
-	for {
-		select {
-		case <-ve.backgroundStop:
-			return
-		case <-ve.mergeQueue:
-			for ve.tryMergeOldestColdSegments() {
-			}
-		}
-	}
-}
-
-func (ve *VectorEngineImpl) buildIndexForSegment(id int64) {
-	ve.lock.Lock()
-	segment := ve.segmentByIDLocked(id)
-	if segment == nil || id == ve.manifest.ActiveSegmentID {
-		ve.lock.Unlock()
-		return
-	}
-	segment.meta.State = SegmentStateIndexing
-	ve.updateSegmentMetaLocked(segment.meta)
-	desc := ve.layout.Descriptor(segment.meta)
-	_ = WriteSegmentManifest(ve.layout, ve.manifest)
-	ve.lock.Unlock()
-
-	if err := buildSealedVectorIndex(desc.DataPath, desc.IndexPath, ve.maxVectorSize, ve.indexType, ve.metric); err != nil {
-		log.Printf("build vector segment index failed for segment %d: %v", id, err)
-		ve.lock.Lock()
-		if segment := ve.segmentByIDLocked(id); segment != nil {
-			segment.meta.State = SegmentStateSealed
-			ve.updateSegmentMetaLocked(segment.meta)
-			_ = WriteSegmentManifest(ve.layout, ve.manifest)
-		}
-		ve.lock.Unlock()
-		return
-	}
-
-	ve.lock.Lock()
-	if segment := ve.segmentByIDLocked(id); segment != nil {
-		segment.meta.State = SegmentStateCold
-		if info, err := os.Stat(desc.DataPath); err == nil {
-			segment.meta.SizeBytes = info.Size()
-		}
-		ve.updateSegmentMetaLocked(segment.meta)
-		_ = WriteSegmentManifest(ve.layout, ve.manifest)
-		ve.scheduleMergeCheckLocked()
-	}
-	ve.lock.Unlock()
-}
-
-func (ve *VectorEngineImpl) tryMergeOldestColdSegments() bool {
-	ve.lock.Lock()
-	if !ve.vectorSegmentationEnabled {
-		ve.lock.Unlock()
-		return false
-	}
-	if len(ve.segments) <= ve.settings.MaxSegmentsBeforeMerge {
-		ve.lock.Unlock()
-		return false
-	}
-
-	var first, second *vectorSegment
-	for _, segment := range ve.segments {
-		if segment.meta.ID == ve.manifest.ActiveSegmentID {
-			continue
-		}
-		if segment.meta.State != SegmentStateCold {
-			continue
-		}
-		if first == nil {
-			first = segment
-			continue
-		}
-		second = segment
-		break
-	}
-	if first == nil || second == nil {
-		ve.lock.Unlock()
-		return false
-	}
-
-	first.meta.State = SegmentStateMerging
-	second.meta.State = SegmentStateMerging
-	ve.updateSegmentMetaLocked(first.meta)
-	ve.updateSegmentMetaLocked(second.meta)
-	newID := second.meta.ID
-	firstDesc := ve.layout.Descriptor(first.meta)
-	secondDesc := ve.layout.Descriptor(second.meta)
-	_ = WriteSegmentManifest(ve.layout, ve.manifest)
-	ve.lock.Unlock()
-
-	meta, mergedIndex, dataFile, offsets, deletedIDs, err := ve.mergeSegments(newID, firstDesc, secondDesc)
-	if err != nil {
-		log.Printf("merge vector segments %d and %d failed: %v", first.meta.ID, second.meta.ID, err)
-		ve.lock.Lock()
-		if segment := ve.segmentByIDLocked(first.meta.ID); segment != nil {
-			segment.meta.State = SegmentStateCold
-			ve.updateSegmentMetaLocked(segment.meta)
-		}
-		if segment := ve.segmentByIDLocked(second.meta.ID); segment != nil {
-			segment.meta.State = SegmentStateCold
-			ve.updateSegmentMetaLocked(segment.meta)
-		}
-		_ = WriteSegmentManifest(ve.layout, ve.manifest)
-		ve.lock.Unlock()
-		return false
-	}
-
-	ve.lock.Lock()
-	defer ve.lock.Unlock()
-	firstIdx := ve.segmentIndexByIDLocked(first.meta.ID)
-	secondIdx := ve.segmentIndexByIDLocked(second.meta.ID)
-	if firstIdx < 0 || secondIdx <= firstIdx {
-		_ = dataFile.Close()
-		mergedIndex.Delete()
-		return false
-	}
-
-	ve.segments[firstIdx].index.Delete()
-	ve.segments[secondIdx].index.Delete()
-	_ = ve.segments[firstIdx].dataFile.Close()
-	_ = ve.segments[secondIdx].dataFile.Close()
-	_ = os.Remove(firstDesc.DataPath)
-	_ = os.Remove(firstDesc.IndexPath)
-
-	mergedSegment := &vectorSegment{
-		meta:             meta,
-		dataFile:         dataFile,
-		index:            mergedIndex,
-		fileOffsets:      offsets,
-		deletedIDs:       deletedIDs,
-		pendingUpsertIDs: make(map[int64]struct{}),
-	}
-	ve.segments = append(append([]*vectorSegment{}, mergedSegment), ve.segments[secondIdx+1:]...)
-	ve.manifest.Segments = append(append([]SegmentMeta{}, meta), ve.manifest.Segments[secondIdx+1:]...)
-	_ = WriteSegmentManifest(ve.layout, ve.manifest)
-	return len(ve.segments) > ve.settings.MaxSegmentsBeforeMerge
-}
-
-func (ve *VectorEngineImpl) mergeSegments(newID int64, firstDesc, secondDesc SegmentDescriptor) (SegmentMeta, faiss.Index, *os.File, map[int64]int64, map[int64]bool, error) {
-	records, err := collectLatestVectorRecords(ve.maxVectorSize, firstDesc.DataPath, secondDesc.DataPath)
-	if err != nil {
-		return SegmentMeta{}, nil, nil, nil, nil, err
-	}
-
-	dataPath := ve.layout.DataPath(newID)
-	indexPath := ve.layout.IndexPath(newID)
-	if err := writeMergedVectorDataFile(dataPath, records); err != nil {
-		return SegmentMeta{}, nil, nil, nil, nil, err
-	}
-	if err := buildSealedVectorIndex(dataPath, indexPath, ve.maxVectorSize, ve.indexType, ve.metric); err != nil {
-		return SegmentMeta{}, nil, nil, nil, nil, err
-	}
-	index, err := faiss.ReadIndex(indexPath, 0)
-	if err != nil {
-		return SegmentMeta{}, nil, nil, nil, nil, err
-	}
-	dataFile, err := os.OpenFile(dataPath, os.O_RDWR|os.O_CREATE, 0666)
-	if err != nil {
-		index.Delete()
-		return SegmentMeta{}, nil, nil, nil, nil, err
-	}
-	offsets, deletedIDs, err := scanVectorDataFile(dataPath, ve.maxVectorSize)
-	if err != nil {
-		index.Delete()
-		_ = dataFile.Close()
-		return SegmentMeta{}, nil, nil, nil, nil, err
-	}
-
-	meta := SegmentMeta{
-		ID:              newID,
-		State:           SegmentStateCold,
-		DataFile:        filepath.Base(dataPath),
-		IndexFile:       filepath.Base(indexPath),
-		CreatedAtUnixNs: time.Now().UnixNano(),
-	}
-	if info, err := dataFile.Stat(); err == nil {
-		meta.SizeBytes = info.Size()
-	}
-	return meta, index, dataFile, offsets, deletedIDs, nil
-}
-
-func (ve *VectorEngineImpl) enqueueIndexBuildLocked(id int64) {
-	select {
-	case ve.indexBuildQueue <- id:
-	default:
-		go func() {
-			select {
-			case ve.indexBuildQueue <- id:
-			case <-ve.backgroundStop:
-			}
-		}()
-	}
-}
-
-func (ve *VectorEngineImpl) scheduleMergeCheckLocked() {
-	select {
-	case ve.mergeQueue <- struct{}{}:
-	default:
-	}
-}
-
-func (ve *VectorEngineImpl) segmentByIDLocked(id int64) *vectorSegment {
-	for _, segment := range ve.segments {
-		if segment.meta.ID == id {
-			return segment
-		}
-	}
-	return nil
-}
-
-func (ve *VectorEngineImpl) segmentIndexByIDLocked(id int64) int {
-	for idx, segment := range ve.segments {
-		if segment.meta.ID == id {
-			return idx
-		}
-	}
-	return -1
-}
-
-func loadOrBuildVectorSegmentIndex(desc SegmentDescriptor, dimension int, indexDesc string, metric int) (faiss.Index, error) {
-	index, err := faiss.ReadIndex(desc.IndexPath, 0)
-	if err == nil {
-		return index, nil
-	}
-	if err := buildSealedVectorIndex(desc.DataPath, desc.IndexPath, dimension, indexDesc, metric); err != nil {
-		return nil, err
-	}
-	return faiss.ReadIndex(desc.IndexPath, 0)
-}
-
-func buildSealedVectorIndex(dataPath, indexPath string, dimension int, indexDesc string, metric int) error {
-	if _, err := RebuildVectorIndex(dataPath, indexPath, dimension, indexDesc, metric); err == nil {
-		return nil
-	} else if !isVectorRebuildTrainingError(err) {
-		return err
-	}
-	return func() error {
-		_, err := RebuildVectorIndex(dataPath, indexPath, dimension, "Flat", metric)
-		return err
-	}()
 }
 
 func buildVectorIndexFromDataFile(dataPath string, dimension int, indexDesc string, metric int) (faiss.Index, error) {
@@ -1306,7 +945,7 @@ func maxInt(a, b int) int {
 	return b
 }
 
-func (ve *VectorEngineImpl) hotSegmentIndexDesc() string {
+func (ve *VectorEngineImpl) activeIndexDesc() string {
 	if requiredTrainCountForIndex(ve.indexType) > 0 {
 		return "Flat"
 	}

--- a/internal/storage/vector_storage.go
+++ b/internal/storage/vector_storage.go
@@ -37,7 +37,7 @@ type VectorEngineImpl struct {
 	primaryDataPath  string
 	primaryIndexPath string
 	manifest         *SegmentManifest
-	segments         []*vectorSegment
+	store            *vectorStore
 
 	// Lifecycle / checkpointing
 	closeOnce         sync.Once
@@ -56,15 +56,13 @@ type VectorEngineImpl struct {
 
 var _ VectorEngine = (*VectorEngineImpl)(nil)
 
-type vectorSegment struct {
-	meta        SegmentMeta
+type vectorStore struct {
 	dataFile    *os.File
 	index       faiss.Index
 	fileOffsets map[int64]int64
 	deletedIDs  map[int64]bool
-	// pendingUpsertIDs tracks IDs present in the FAISS index but not yet flushed to
-	// the data file. RemoveIDs on some IVF variants aborts if the ID is missing;
-	// we only remove when replacing an existing vector (disk or pending).
+	// pendingUpsertIDs tracks IDs added to FAISS but not yet flushed to disk, so
+	// repeated inserts can replace the pending index entry.
 	pendingUpsertIDs map[int64]struct{}
 }
 
@@ -109,7 +107,7 @@ func NewVectorEngineWithSettings(dataPath, indexPath, walPath string, maxVectorS
 		return nil, err
 	}
 
-	if err := e.loadSegments(); err != nil {
+	if err := e.loadStore(); err != nil {
 		if e.wal != nil {
 			_ = e.wal.Close()
 		}
@@ -221,49 +219,46 @@ func (ve *VectorEngineImpl) compactLegacySegmentedLayoutIfNeeded() error {
 	return WriteSegmentManifest(ve.layout, ve.manifest)
 }
 
-func (ve *VectorEngineImpl) loadSegments() error {
+func (ve *VectorEngineImpl) loadStore() error {
 	ve.lock.Lock()
 	defer ve.lock.Unlock()
 
-	ve.segments = nil
-	if len(ve.manifest.Segments) == 0 {
-		return errors.New("segment manifest has no segments")
+	ve.store = nil
+	if len(ve.manifest.Segments) != 1 {
+		return fmt.Errorf("FAISS manifest must contain one storage file, got %d", len(ve.manifest.Segments))
 	}
 
-	ve.manifest.ActiveSegmentID = ve.manifest.Segments[len(ve.manifest.Segments)-1].ID
-	for idx, meta := range ve.manifest.Segments {
-		desc := ve.layout.Descriptor(meta)
-		dataFile, err := os.OpenFile(desc.DataPath, os.O_RDWR|os.O_CREATE, 0666)
-		if err != nil {
-			return err
-		}
-
-		offsets, deletedIDs, err := scanVectorDataFile(desc.DataPath, ve.maxVectorSize)
-		if err != nil {
-			_ = dataFile.Close()
-			return err
-		}
-
-		index, err := buildVectorIndexFromDataFile(desc.DataPath, ve.maxVectorSize, ve.activeIndexDesc(), ve.metric)
-		meta.State = SegmentStateHot
-		if err != nil {
-			_ = dataFile.Close()
-			return err
-		}
-		if info, err := dataFile.Stat(); err == nil {
-			meta.SizeBytes = info.Size()
-		}
-		ve.manifest.Segments[idx] = meta
-		ve.segments = append(ve.segments, &vectorSegment{
-			meta:             meta,
-			dataFile:         dataFile,
-			index:            index,
-			fileOffsets:      offsets,
-			deletedIDs:       deletedIDs,
-			pendingUpsertIDs: make(map[int64]struct{}),
-		})
+	meta := ve.manifest.Segments[0]
+	ve.manifest.ActiveSegmentID = meta.ID
+	desc := ve.layout.Descriptor(meta)
+	dataFile, err := os.OpenFile(desc.DataPath, os.O_RDWR|os.O_CREATE, 0666)
+	if err != nil {
+		return err
 	}
 
+	offsets, deletedIDs, err := scanVectorDataFile(desc.DataPath, ve.maxVectorSize)
+	if err != nil {
+		_ = dataFile.Close()
+		return err
+	}
+
+	index, err := buildVectorIndexFromDataFile(desc.DataPath, ve.maxVectorSize, ve.activeIndexDesc(), ve.metric)
+	if err != nil {
+		_ = dataFile.Close()
+		return err
+	}
+	meta.State = SegmentStateHot
+	if info, err := dataFile.Stat(); err == nil {
+		meta.SizeBytes = info.Size()
+	}
+	ve.manifest.Segments[0] = meta
+	ve.store = &vectorStore{
+		dataFile:         dataFile,
+		index:            index,
+		fileOffsets:      offsets,
+		deletedIDs:       deletedIDs,
+		pendingUpsertIDs: make(map[int64]struct{}),
+	}
 	return WriteSegmentManifest(ve.layout, ve.manifest)
 }
 
@@ -297,28 +292,28 @@ func (ve *VectorEngineImpl) insertAfterWAL(id int64, vector []float32) error {
 	ve.lock.Lock()
 	defer ve.lock.Unlock()
 
-	active := ve.activeSegmentLocked()
-	if active == nil {
-		return errors.New("no active vector segment")
+	store := ve.store
+	if store == nil {
+		return errors.New("vector storage is not initialized")
 	}
 
 	replace := false
-	if _, ok := active.pendingUpsertIDs[id]; ok {
+	if _, ok := store.pendingUpsertIDs[id]; ok {
 		replace = true
-	} else if _, ok := active.fileOffsets[id]; ok && !active.deletedIDs[id] {
+	} else if _, ok := store.fileOffsets[id]; ok && !store.deletedIDs[id] {
 		replace = true
 	}
 	if replace {
 		sel, _ := faiss.NewIDSelectorBatch([]int64{id})
-		_, _ = active.index.RemoveIDs(sel)
+		_, _ = store.index.RemoveIDs(sel)
 		sel.Delete()
 	}
 
-	if err := active.index.AddWithIDs(vector, []int64{id}); err != nil {
+	if err := store.index.AddWithIDs(vector, []int64{id}); err != nil {
 		return err
 	}
-	delete(active.deletedIDs, id)
-	active.pendingUpsertIDs[id] = struct{}{}
+	delete(store.deletedIDs, id)
+	store.pendingUpsertIDs[id] = struct{}{}
 	ve.enqueuePersist(id, vector)
 	return nil
 }
@@ -333,78 +328,57 @@ func (ve *VectorEngineImpl) SearchTopK(query []float32, k int) ([]int64, []float
 	ve.lock.RLock()
 	defer ve.lock.RUnlock()
 
-	type pair struct {
-		id  int64
-		dst float32
+	store := ve.store
+	if store == nil {
+		return nil, nil, errors.New("vector storage is not initialized")
 	}
-	shadowed := make(map[int64]struct{})
-	candidates := make([]pair, 0, k*len(ve.segments))
 
-	for segIdx := len(ve.segments) - 1; segIdx >= 0; segIdx-- {
-		segment := ve.segments[segIdx]
-		searchK := int64(k)
-		var dists []float32
-		var labels []int64
-		for {
-			var err error
-			dists, labels, err = segment.index.Search(query, searchK)
-			if err != nil {
-				return nil, nil, err
+	searchK := int64(k)
+	var dists []float32
+	var labels []int64
+	for {
+		var err error
+		dists, labels, err = store.index.Search(query, searchK)
+		if err != nil {
+			return nil, nil, err
+		}
+		valid := 0
+		for _, label := range labels {
+			if label < 0 || store.deletedIDs[label] {
+				continue
 			}
-			valid := 0
-			for _, label := range labels {
-				if label < 0 || segment.deletedIDs[label] {
-					continue
-				}
-				if _, seen := shadowed[label]; seen {
-					continue
-				}
-				if _, exists := segment.fileOffsets[label]; exists {
-					valid++
-				}
-			}
-			total := segment.index.Ntotal()
-			if valid >= k || searchK >= total {
-				break
-			}
-			searchK *= 2
-			if searchK > total {
-				searchK = total
+			if _, exists := store.fileOffsets[label]; exists {
+				valid++
 			}
 		}
-		for i, label := range labels {
-			if label < 0 {
-				continue
-			}
-			if _, seen := shadowed[label]; seen {
-				continue
-			}
-			if segment.deletedIDs[label] {
-				continue
-			}
-			if _, exists := segment.fileOffsets[label]; !exists {
-				continue
-			}
-			candidates = append(candidates, pair{id: label, dst: dists[i]})
+		total := store.index.Ntotal()
+		if valid >= k || searchK >= total {
+			break
 		}
-		for id := range segment.fileOffsets {
-			shadowed[id] = struct{}{}
+		// Expand only when stale or unflushed entries were filtered. The normal
+		// path asks FAISS for exactly k neighbors.
+		searchK *= 2
+		if searchK > total {
+			searchK = total
 		}
 	}
 
-	sort.Slice(candidates, func(i, j int) bool {
-		return betterDistanceForMetric(ve.metric, candidates[i].dst, candidates[j].dst)
-	})
-	if len(candidates) > k {
-		candidates = candidates[:k]
+	ids := make([]int64, 0, k)
+	filteredDists := make([]float32, 0, k)
+	for i, label := range labels {
+		if label < 0 || store.deletedIDs[label] {
+			continue
+		}
+		if _, exists := store.fileOffsets[label]; !exists {
+			continue
+		}
+		ids = append(ids, label)
+		filteredDists = append(filteredDists, dists[i])
+		if len(ids) == k {
+			break
+		}
 	}
-	ids := make([]int64, len(candidates))
-	dists := make([]float32, len(candidates))
-	for i, candidate := range candidates {
-		ids[i] = candidate.id
-		dists[i] = candidate.dst
-	}
-	return ids, dists, nil
+	return ids, filteredDists, nil
 }
 
 func (ve *VectorEngineImpl) RangeSearch(query []float32, radius float32) ([]int64, []float32, error) {
@@ -414,43 +388,37 @@ func (ve *VectorEngineImpl) RangeSearch(query []float32, radius float32) ([]int6
 
 	ve.lock.RLock()
 	defer ve.lock.RUnlock()
+	store := ve.store
+	if store == nil {
+		return nil, nil, errors.New("vector storage is not initialized")
+	}
 
 	type pair struct {
 		id  int64
 		dst float32
 	}
-	shadowed := make(map[int64]struct{})
 	var ps []pair
 
-	for segIdx := len(ve.segments) - 1; segIdx >= 0; segIdx-- {
-		segment := ve.segments[segIdx]
-		res, err := segment.index.RangeSearch(query, radius)
-		if err != nil {
-			return nil, nil, err
-		}
-		labels, dists := res.Labels()
-		lims := res.Lims()
-		if len(lims) != 2 {
-			res.Delete()
-			return nil, nil, fmt.Errorf("expected 1 query, got %d", len(lims)-1)
-		}
-		for i := int(lims[0]); i < int(lims[1]); i++ {
-			if _, seen := shadowed[labels[i]]; seen {
-				continue
-			}
-			if segment.deletedIDs[labels[i]] {
-				continue
-			}
-			if _, exists := segment.fileOffsets[labels[i]]; !exists {
-				continue
-			}
-			ps = append(ps, pair{id: labels[i], dst: dists[i]})
-		}
-		res.Delete()
-		for id := range segment.fileOffsets {
-			shadowed[id] = struct{}{}
-		}
+	res, err := store.index.RangeSearch(query, radius)
+	if err != nil {
+		return nil, nil, err
 	}
+	labels, dists := res.Labels()
+	lims := res.Lims()
+	if len(lims) != 2 {
+		res.Delete()
+		return nil, nil, fmt.Errorf("expected 1 query, got %d", len(lims)-1)
+	}
+	for i := int(lims[0]); i < int(lims[1]); i++ {
+		if store.deletedIDs[labels[i]] {
+			continue
+		}
+		if _, exists := store.fileOffsets[labels[i]]; !exists {
+			continue
+		}
+		ps = append(ps, pair{id: labels[i], dst: dists[i]})
+	}
+	res.Delete()
 
 	sort.Slice(ps, func(i, j int) bool {
 		return betterDistanceForMetric(ve.metric, ps[i].dst, ps[j].dst)
@@ -467,26 +435,23 @@ func (ve *VectorEngineImpl) RangeSearch(query []float32, radius float32) ([]int6
 func (ve *VectorEngineImpl) GetVectorByID(id int64) ([]float32, error) {
 	ve.lock.RLock()
 	defer ve.lock.RUnlock()
-	for idx := len(ve.segments) - 1; idx >= 0; idx-- {
-		segment := ve.segments[idx]
-		offset, ok := segment.fileOffsets[id]
-		if !ok {
-			continue
-		}
-		if segment.deletedIDs[id] {
-			return nil, fmt.Errorf("ID %d not found", id)
-		}
-		recordSize := 8 + 4*ve.maxVectorSize
-		buf := make([]byte, recordSize)
-		if _, err := segment.dataFile.ReadAt(buf, offset); err != nil {
-			return nil, fmt.Errorf("read vector at offset %d: %w", offset, err)
-		}
-		if len(buf) >= 12 && binary.LittleEndian.Uint32(buf[8:12]) == tombstoneMarker {
-			return nil, fmt.Errorf("ID %d not found", id)
-		}
-		return bytesToFloat32Array(buf[8:])
+	store := ve.store
+	if store == nil {
+		return nil, errors.New("vector storage is not initialized")
 	}
-	return nil, fmt.Errorf("ID %d not found", id)
+	offset, ok := store.fileOffsets[id]
+	if !ok || store.deletedIDs[id] {
+		return nil, fmt.Errorf("ID %d not found", id)
+	}
+	recordSize := 8 + 4*ve.maxVectorSize
+	buf := make([]byte, recordSize)
+	if _, err := store.dataFile.ReadAt(buf, offset); err != nil {
+		return nil, fmt.Errorf("read vector at offset %d: %w", offset, err)
+	}
+	if len(buf) >= 12 && binary.LittleEndian.Uint32(buf[8:12]) == tombstoneMarker {
+		return nil, fmt.Errorf("ID %d not found", id)
+	}
+	return bytesToFloat32Array(buf[8:])
 }
 
 func (ve *VectorEngineImpl) RemoveVector(id int64) error {
@@ -525,9 +490,9 @@ func (ve *VectorEngineImpl) removeAfterWAL(id int64) error {
 	ve.lock.Lock()
 	defer ve.lock.Unlock()
 
-	active := ve.activeSegmentLocked()
-	if active == nil {
-		return errors.New("no active vector segment")
+	store := ve.store
+	if store == nil {
+		return errors.New("vector storage is not initialized")
 	}
 
 	sel, err := faiss.NewIDSelectorBatch([]int64{id})
@@ -536,12 +501,12 @@ func (ve *VectorEngineImpl) removeAfterWAL(id int64) error {
 	}
 	defer sel.Delete()
 
-	_, err = active.index.RemoveIDs(sel)
+	_, err = store.index.RemoveIDs(sel)
 	if err != nil {
 		log.Printf("warning: RemoveIDs failed for index type %s: %v", ve.indexType, err)
 	}
-	active.deletedIDs[id] = true
-	delete(active.pendingUpsertIDs, id)
+	store.deletedIDs[id] = true
+	delete(store.pendingUpsertIDs, id)
 
 	return nil
 }
@@ -553,12 +518,12 @@ func (ve *VectorEngineImpl) appendTombstoneToDataFile(id int64) error {
 	ve.lock.Lock()
 	defer ve.lock.Unlock()
 
-	active := ve.activeSegmentLocked()
-	if active == nil {
-		return errors.New("no active vector segment")
+	store := ve.store
+	if store == nil {
+		return errors.New("vector storage is not initialized")
 	}
 
-	pos, err := active.dataFile.Seek(0, io.SeekEnd)
+	pos, err := store.dataFile.Seek(0, io.SeekEnd)
 	if err != nil {
 		return err
 	}
@@ -567,19 +532,15 @@ func (ve *VectorEngineImpl) appendTombstoneToDataFile(id int64) error {
 	binary.LittleEndian.PutUint64(buf[0:8], uint64(id))
 	binary.LittleEndian.PutUint32(buf[8:12], tombstoneMarker)
 	// rest is zero; same size as a normal vector record
-	if _, err := active.dataFile.Write(buf); err != nil {
+	if _, err := store.dataFile.Write(buf); err != nil {
 		return err
 	}
-	if err := active.dataFile.Sync(); err != nil {
+	if err := store.dataFile.Sync(); err != nil {
 		return err
 	}
-	active.fileOffsets[id] = pos
-	active.deletedIDs[id] = true
-	delete(active.pendingUpsertIDs, id)
-	if info, err := active.dataFile.Stat(); err == nil {
-		active.meta.SizeBytes = info.Size()
-		ve.updateSegmentMetaLocked(active.meta)
-	}
+	store.fileOffsets[id] = pos
+	store.deletedIDs[id] = true
+	delete(store.pendingUpsertIDs, id)
 	return nil
 }
 
@@ -598,9 +559,9 @@ func (ve *VectorEngineImpl) Close() error {
 			_ = ve.wal.Close()
 		}
 		ve.lock.Lock()
-		for _, segment := range ve.segments {
-			_ = segment.dataFile.Close()
-			segment.index.Delete()
+		if ve.store != nil {
+			_ = ve.store.dataFile.Close()
+			ve.store.index.Delete()
 		}
 		ve.lock.Unlock()
 	})
@@ -615,10 +576,11 @@ func (ve *VectorEngineImpl) checkpoint() error {
 
 	ve.lock.RLock()
 	defer ve.lock.RUnlock()
-	for _, segment := range ve.segments {
-		if err := segment.dataFile.Sync(); err != nil {
-			return fmt.Errorf("sync data file: %w", err)
-		}
+	if ve.store == nil {
+		return errors.New("vector storage is not initialized")
+	}
+	if err := ve.store.dataFile.Sync(); err != nil {
+		return fmt.Errorf("sync data file: %w", err)
 	}
 	return nil
 }
@@ -667,12 +629,12 @@ func (ve *VectorEngineImpl) replayWAL() error {
 }
 
 func (ve *VectorEngineImpl) appendToDataFile(id int64, vector []float32) error {
-	active := ve.activeSegmentLocked()
-	if active == nil {
-		return errors.New("no active vector segment")
+	store := ve.store
+	if store == nil {
+		return errors.New("vector storage is not initialized")
 	}
 
-	pos, err := active.dataFile.Seek(0, io.SeekEnd)
+	pos, err := store.dataFile.Seek(0, io.SeekEnd)
 	if err != nil {
 		return err
 	}
@@ -681,11 +643,11 @@ func (ve *VectorEngineImpl) appendToDataFile(id int64, vector []float32) error {
 	for i, v := range vector {
 		binary.LittleEndian.PutUint32(buf[8+i*4:], math.Float32bits(v))
 	}
-	if _, err := active.dataFile.Write(buf); err != nil {
+	if _, err := store.dataFile.Write(buf); err != nil {
 		return err
 	}
-	active.fileOffsets[id] = pos
-	delete(active.deletedIDs, id)
+	store.fileOffsets[id] = pos
+	delete(store.deletedIDs, id)
 	return nil
 }
 
@@ -739,8 +701,8 @@ func (ve *VectorEngineImpl) flushData(force bool) {
 	// the raw file writes. Release before fsync so searches are not blocked
 	// for the full duration of the (potentially slow) syscall.
 	ve.lock.Lock()
-	active := ve.activeSegmentLocked()
-	if active == nil {
+	store := ve.store
+	if store == nil {
 		ve.lock.Unlock()
 		return
 	}
@@ -748,16 +710,12 @@ func (ve *VectorEngineImpl) flushData(force bool) {
 		if err := ve.appendToDataFile(it.id, it.vec); err != nil {
 			log.Printf("appendToDataFile failed for id=%d: %v", it.id, err)
 		} else {
-			delete(active.pendingUpsertIDs, it.id)
+			delete(store.pendingUpsertIDs, it.id)
 		}
-	}
-	if info, err := active.dataFile.Stat(); err == nil {
-		active.meta.SizeBytes = info.Size()
-		ve.updateSegmentMetaLocked(active.meta)
 	}
 	ve.lock.Unlock()
 
-	if err := active.dataFile.Sync(); err != nil {
+	if err := store.dataFile.Sync(); err != nil {
 		log.Printf("data file sync failed: %v", err)
 	}
 }
@@ -779,30 +737,6 @@ func bytesToFloat32Array(buf []byte) ([]float32, error) {
 		vec[i] = math.Float32frombits(binary.LittleEndian.Uint32(buf[i*4:]))
 	}
 	return vec, nil
-}
-
-func (ve *VectorEngineImpl) activeSegmentLocked() *vectorSegment {
-	for _, segment := range ve.segments {
-		if segment.meta.ID == ve.manifest.ActiveSegmentID {
-			return segment
-		}
-	}
-	return nil
-}
-
-func (ve *VectorEngineImpl) updateSegmentMetaLocked(meta SegmentMeta) {
-	for idx := range ve.segments {
-		if ve.segments[idx].meta.ID == meta.ID {
-			ve.segments[idx].meta = meta
-			break
-		}
-	}
-	for idx := range ve.manifest.Segments {
-		if ve.manifest.Segments[idx].ID == meta.ID {
-			ve.manifest.Segments[idx] = meta
-			break
-		}
-	}
 }
 
 func buildVectorIndexFromDataFile(dataPath string, dimension int, indexDesc string, metric int) (faiss.Index, error) {
@@ -903,7 +837,11 @@ func scanVectorDataFile(dataPath string, dimension int) (map[int64]int64, map[in
 		}
 		id := int64(binary.LittleEndian.Uint64(buf[0:8]))
 		offsets[id] = offset
-		deletedIDs[id] = len(buf) >= 12 && binary.LittleEndian.Uint32(buf[8:12]) == tombstoneMarker
+		if len(buf) >= 12 && binary.LittleEndian.Uint32(buf[8:12]) == tombstoneMarker {
+			deletedIDs[id] = true
+		} else {
+			delete(deletedIDs, id)
+		}
 		offset += int64(recordSize)
 	}
 	return offsets, deletedIDs, nil

--- a/internal/storage/vector_storage.go
+++ b/internal/storage/vector_storage.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/DataIntelligenceCrew/go-faiss"
@@ -28,6 +29,7 @@ var ErrDeletionNotSupported = errors.New("vector deletion not supported for HNSW
 
 type VectorEngineImpl struct {
 	wal           *wal.WAL
+	walMu         sync.Mutex
 	maxVectorSize int
 
 	indexType string
@@ -47,11 +49,9 @@ type VectorEngineImpl struct {
 
 	lock sync.RWMutex
 
-	persistMu  sync.Mutex
-	persistBuf []struct {
-		id  int64
-		vec []float32
-	}
+	batchMu sync.Mutex
+	batch   map[int64]vectorBatchEntry
+	pending atomic.Bool
 }
 
 var _ VectorEngine = (*VectorEngineImpl)(nil)
@@ -61,9 +61,11 @@ type vectorStore struct {
 	index       faiss.Index
 	fileOffsets map[int64]int64
 	deletedIDs  map[int64]bool
-	// pendingUpsertIDs tracks IDs added to FAISS but not yet flushed to disk, so
-	// repeated inserts can replace the pending index entry.
-	pendingUpsertIDs map[int64]struct{}
+}
+
+type vectorBatchEntry struct {
+	vector  []float32
+	deleted bool
 }
 
 // NewVectorEngine builds/loads the ID-mapped FAISS index and opens data + WAL files.
@@ -86,6 +88,7 @@ func NewVectorEngineWithSettings(dataPath, indexPath, walPath string, maxVectorS
 		maxVectorSize:    maxVectorSize,
 		indexType:        indexDesc,
 		metric:           metric,
+		batch:            make(map[int64]vectorBatchEntry),
 		layout:           NewSegmentLayout(filepath.Dir(dataPath), "vector", ".db", ".faiss"),
 		primaryDataPath:  dataPath,
 		primaryIndexPath: indexPath,
@@ -253,11 +256,10 @@ func (ve *VectorEngineImpl) loadStore() error {
 	}
 	ve.manifest.Segments[0] = meta
 	ve.store = &vectorStore{
-		dataFile:         dataFile,
-		index:            index,
-		fileOffsets:      offsets,
-		deletedIDs:       deletedIDs,
-		pendingUpsertIDs: make(map[int64]struct{}),
+		dataFile:    dataFile,
+		index:       index,
+		fileOffsets: offsets,
+		deletedIDs:  deletedIDs,
 	}
 	return WriteSegmentManifest(ve.layout, ve.manifest)
 }
@@ -266,55 +268,33 @@ func (ve *VectorEngineImpl) InsertVector(id int64, vector []float32) error {
 	if len(vector) != ve.maxVectorSize {
 		return fmt.Errorf("vector length mismatch: expected %d", ve.maxVectorSize)
 	}
+	ve.maintenanceMu.RLock()
+	defer ve.maintenanceMu.RUnlock()
+	if ve.maintenanceClosed {
+		return errors.New("vector engine is closed")
+	}
 
-	// 1) WAL first (if enabled)
+	entry := vectorBatchEntry{vector: append([]float32(nil), vector...)}
 	if ve.wal != nil {
+		ve.walMu.Lock()
 		key := make([]byte, 8)
 		binary.LittleEndian.PutUint64(key, uint64(id))
 		if err := ve.wal.WriteEntry(string(key), string(float32ArrayToBytes(vector))); err != nil {
+			ve.walMu.Unlock()
 			return err
 		}
+		ve.batchMu.Lock()
+		ve.batch[id] = entry
+		ve.pending.Store(true)
+		ve.batchMu.Unlock()
+		ve.walMu.Unlock()
+	} else {
+		ve.batchMu.Lock()
+		ve.batch[id] = entry
+		ve.pending.Store(true)
+		ve.batchMu.Unlock()
 	}
-
-	// 2) Ingest (train if needed, add to FAISS, enqueue persistence), then mark committed.
-	if err := ve.insertAfterWAL(id, vector); err != nil {
-		return err
-	}
-
-	if ve.wal != nil {
-		return ve.wal.MarkCommitted()
-	}
-	return nil
-}
-
-// insertAfterWAL performs the ingest without writing to WAL (used by InsertVector and WAL replay).
-func (ve *VectorEngineImpl) insertAfterWAL(id int64, vector []float32) error {
-	ve.lock.Lock()
-	defer ve.lock.Unlock()
-
-	store := ve.store
-	if store == nil {
-		return errors.New("vector storage is not initialized")
-	}
-
-	replace := false
-	if _, ok := store.pendingUpsertIDs[id]; ok {
-		replace = true
-	} else if _, ok := store.fileOffsets[id]; ok && !store.deletedIDs[id] {
-		replace = true
-	}
-	if replace {
-		sel, _ := faiss.NewIDSelectorBatch([]int64{id})
-		_, _ = store.index.RemoveIDs(sel)
-		sel.Delete()
-	}
-
-	if err := store.index.AddWithIDs(vector, []int64{id}); err != nil {
-		return err
-	}
-	delete(store.deletedIDs, id)
-	store.pendingUpsertIDs[id] = struct{}{}
-	ve.enqueuePersist(id, vector)
+	maintenance.MarkVectorFlushDirty(ve)
 	return nil
 }
 
@@ -325,6 +305,7 @@ func (ve *VectorEngineImpl) SearchTopK(query []float32, k int) ([]int64, []float
 	if k <= 0 {
 		return []int64{}, []float32{}, nil
 	}
+	pending := ve.snapshotBatch()
 	ve.lock.RLock()
 	defer ve.lock.RUnlock()
 
@@ -336,6 +317,12 @@ func (ve *VectorEngineImpl) SearchTopK(query []float32, k int) ([]int64, []float
 	searchK := int64(k)
 	var dists []float32
 	var labels []int64
+	pendingLive := 0
+	for _, entry := range pending {
+		if !entry.deleted {
+			pendingLive++
+		}
+	}
 	for {
 		var err error
 		dists, labels, err = store.index.Search(query, searchK)
@@ -347,12 +334,15 @@ func (ve *VectorEngineImpl) SearchTopK(query []float32, k int) ([]int64, []float
 			if label < 0 || store.deletedIDs[label] {
 				continue
 			}
+			if _, staged := pending[label]; staged {
+				continue
+			}
 			if _, exists := store.fileOffsets[label]; exists {
 				valid++
 			}
 		}
 		total := store.index.Ntotal()
-		if valid >= k || searchK >= total {
+		if valid+pendingLive >= k || searchK >= total {
 			break
 		}
 		// Expand only when stale or unflushed entries were filtered. The normal
@@ -361,6 +351,43 @@ func (ve *VectorEngineImpl) SearchTopK(query []float32, k int) ([]int64, []float
 		if searchK > total {
 			searchK = total
 		}
+	}
+
+	if len(pending) > 0 {
+		type pair struct {
+			id       int64
+			distance float32
+		}
+		candidates := make([]pair, 0, len(labels)+pendingLive)
+		for i, label := range labels {
+			if label < 0 || store.deletedIDs[label] {
+				continue
+			}
+			if _, staged := pending[label]; staged {
+				continue
+			}
+			if _, exists := store.fileOffsets[label]; exists {
+				candidates = append(candidates, pair{id: label, distance: dists[i]})
+			}
+		}
+		for id, entry := range pending {
+			if !entry.deleted {
+				candidates = append(candidates, pair{id: id, distance: vectorDistance(ve.metric, query, entry.vector)})
+			}
+		}
+		sort.Slice(candidates, func(i, j int) bool {
+			return betterDistanceForMetric(ve.metric, candidates[i].distance, candidates[j].distance)
+		})
+		if len(candidates) > k {
+			candidates = candidates[:k]
+		}
+		ids := make([]int64, len(candidates))
+		filteredDists := make([]float32, len(candidates))
+		for i, candidate := range candidates {
+			ids[i] = candidate.id
+			filteredDists[i] = candidate.distance
+		}
+		return ids, filteredDists, nil
 	}
 
 	ids := make([]int64, 0, k)
@@ -386,6 +413,7 @@ func (ve *VectorEngineImpl) RangeSearch(query []float32, radius float32) ([]int6
 		return nil, nil, errors.New("invalid query size")
 	}
 
+	pending := ve.snapshotBatch()
 	ve.lock.RLock()
 	defer ve.lock.RUnlock()
 	store := ve.store
@@ -413,12 +441,24 @@ func (ve *VectorEngineImpl) RangeSearch(query []float32, radius float32) ([]int6
 		if store.deletedIDs[labels[i]] {
 			continue
 		}
+		if _, staged := pending[labels[i]]; staged {
+			continue
+		}
 		if _, exists := store.fileOffsets[labels[i]]; !exists {
 			continue
 		}
 		ps = append(ps, pair{id: labels[i], dst: dists[i]})
 	}
 	res.Delete()
+	for id, entry := range pending {
+		if entry.deleted {
+			continue
+		}
+		distance := vectorDistance(ve.metric, query, entry.vector)
+		if distanceWithinRadius(ve.metric, distance, radius) {
+			ps = append(ps, pair{id: id, dst: distance})
+		}
+	}
 
 	sort.Slice(ps, func(i, j int) bool {
 		return betterDistanceForMetric(ve.metric, ps[i].dst, ps[j].dst)
@@ -433,6 +473,18 @@ func (ve *VectorEngineImpl) RangeSearch(query []float32, radius float32) ([]int6
 }
 
 func (ve *VectorEngineImpl) GetVectorByID(id int64) ([]float32, error) {
+	if ve.pending.Load() {
+		ve.batchMu.Lock()
+		entry, exists := ve.batch[id]
+		ve.batchMu.Unlock()
+		if exists {
+			if entry.deleted {
+				return nil, fmt.Errorf("ID %d not found", id)
+			}
+			return append([]float32(nil), entry.vector...), nil
+		}
+	}
+
 	ve.lock.RLock()
 	defer ve.lock.RUnlock()
 	store := ve.store
@@ -459,88 +511,33 @@ func (ve *VectorEngineImpl) RemoveVector(id int64) error {
 	if strings.HasPrefix(ve.indexType, "HNSW") {
 		return ErrDeletionNotSupported
 	}
-
-	// 1) Persist tombstone in the same data file (like key_value_storage Delete: no extra file).
-	if err := ve.appendTombstoneToDataFile(id); err != nil {
-		return err
+	ve.maintenanceMu.RLock()
+	defer ve.maintenanceMu.RUnlock()
+	if ve.maintenanceClosed {
+		return errors.New("vector engine is closed")
 	}
 
-	// 2) WAL - log the deletion (if enabled) for crash recovery
+	entry := vectorBatchEntry{deleted: true}
 	if ve.wal != nil {
+		ve.walMu.Lock()
 		key := make([]byte, 8)
 		binary.LittleEndian.PutUint64(key, uint64(id))
 		if err := ve.wal.WriteDelete(string(key)); err != nil {
+			ve.walMu.Unlock()
 			return err
 		}
+		ve.batchMu.Lock()
+		ve.batch[id] = entry
+		ve.pending.Store(true)
+		ve.batchMu.Unlock()
+		ve.walMu.Unlock()
+	} else {
+		ve.batchMu.Lock()
+		ve.batch[id] = entry
+		ve.pending.Store(true)
+		ve.batchMu.Unlock()
 	}
-
-	// 3) Remove from FAISS index and pendingAdd; fileOffsets[id] already points to tombstone
-	if err := ve.removeAfterWAL(id); err != nil {
-		return err
-	}
-
-	if ve.wal != nil {
-		return ve.wal.MarkCommitted()
-	}
-	return nil
-}
-
-// removeAfterWAL performs the removal without writing to WAL (used by RemoveVector and WAL replay).
-func (ve *VectorEngineImpl) removeAfterWAL(id int64) error {
-	ve.lock.Lock()
-	defer ve.lock.Unlock()
-
-	store := ve.store
-	if store == nil {
-		return errors.New("vector storage is not initialized")
-	}
-
-	sel, err := faiss.NewIDSelectorBatch([]int64{id})
-	if err != nil {
-		return fmt.Errorf("create ID selector: %w", err)
-	}
-	defer sel.Delete()
-
-	_, err = store.index.RemoveIDs(sel)
-	if err != nil {
-		log.Printf("warning: RemoveIDs failed for index type %s: %v", ve.indexType, err)
-	}
-	store.deletedIDs[id] = true
-	delete(store.pendingUpsertIDs, id)
-
-	return nil
-}
-
-// appendTombstoneToDataFile appends a tombstone record for id to the data file (same format as
-// normal records; first float32 of payload = tombstoneMarker) and updates fileOffsets[id].
-// Same pattern as key_value_storage.Delete: persist delete on disk in the main file.
-func (ve *VectorEngineImpl) appendTombstoneToDataFile(id int64) error {
-	ve.lock.Lock()
-	defer ve.lock.Unlock()
-
-	store := ve.store
-	if store == nil {
-		return errors.New("vector storage is not initialized")
-	}
-
-	pos, err := store.dataFile.Seek(0, io.SeekEnd)
-	if err != nil {
-		return err
-	}
-	recordSize := 8 + 4*ve.maxVectorSize
-	buf := make([]byte, recordSize)
-	binary.LittleEndian.PutUint64(buf[0:8], uint64(id))
-	binary.LittleEndian.PutUint32(buf[8:12], tombstoneMarker)
-	// rest is zero; same size as a normal vector record
-	if _, err := store.dataFile.Write(buf); err != nil {
-		return err
-	}
-	if err := store.dataFile.Sync(); err != nil {
-		return err
-	}
-	store.fileOffsets[id] = pos
-	store.deletedIDs[id] = true
-	delete(store.pendingUpsertIDs, id)
+	maintenance.MarkVectorFlushDirty(ve)
 	return nil
 }
 
@@ -552,8 +549,9 @@ func (ve *VectorEngineImpl) Close() error {
 		maintenance.UnregisterVectorCheckpoint(ve)
 		ve.maintenanceMu.Unlock()
 
-		// Final flush of any pending data-file writes
-		ve.flushData(true)
+		if err := ve.FlushBatch(); err != nil {
+			log.Printf("final vector batch flush failed: %v", err)
+		}
 
 		if ve.wal != nil {
 			_ = ve.wal.Close()
@@ -605,12 +603,9 @@ func (ve *VectorEngineImpl) replayWAL() error {
 		}
 		id := int64(binary.LittleEndian.Uint64(keyBytes))
 
-		// Check if this is a deletion (empty value)
 		if entry.Flag == wal.EntryDeleted {
-			// IMPORTANT: do not write to WAL here again — just remove.
-			if err := ve.removeAfterWAL(id); err != nil {
-				return fmt.Errorf("replay remove id=%d: %w", id, err)
-			}
+			ve.batch[id] = vectorBatchEntry{deleted: true}
+			ve.pending.Store(true)
 			continue
 		}
 
@@ -619,46 +614,10 @@ func (ve *VectorEngineImpl) replayWAL() error {
 			return fmt.Errorf("WAL decode: %w", err)
 		}
 
-		if err := ve.insertAfterWAL(id, vec); err != nil {
-			return fmt.Errorf("replay insert id=%d: %w", id, err)
-		}
+		ve.batch[id] = vectorBatchEntry{vector: vec}
+		ve.pending.Store(true)
 	}
-
-	ve.wal.Clear()
-	return nil
-}
-
-func (ve *VectorEngineImpl) appendToDataFile(id int64, vector []float32) error {
-	store := ve.store
-	if store == nil {
-		return errors.New("vector storage is not initialized")
-	}
-
-	pos, err := store.dataFile.Seek(0, io.SeekEnd)
-	if err != nil {
-		return err
-	}
-	buf := make([]byte, 8+len(vector)*4)
-	binary.LittleEndian.PutUint64(buf[0:8], uint64(id))
-	for i, v := range vector {
-		binary.LittleEndian.PutUint32(buf[8+i*4:], math.Float32bits(v))
-	}
-	if _, err := store.dataFile.Write(buf); err != nil {
-		return err
-	}
-	store.fileOffsets[id] = pos
-	delete(store.deletedIDs, id)
-	return nil
-}
-
-func (ve *VectorEngineImpl) enqueuePersist(id int64, vec []float32) {
-	ve.persistMu.Lock()
-	ve.persistBuf = append(ve.persistBuf, struct {
-		id  int64
-		vec []float32
-	}{id: id, vec: vec})
-	ve.persistMu.Unlock()
-	maintenance.MarkVectorFlushDirty(ve)
+	return ve.FlushBatch()
 }
 
 // MaintenanceFlush participates in the shared vector flush loop.
@@ -668,7 +627,9 @@ func (ve *VectorEngineImpl) MaintenanceFlush() {
 	if ve.maintenanceClosed {
 		return
 	}
-	ve.flushData(false)
+	if err := ve.FlushBatch(); err != nil {
+		log.Printf("vector batch flush failed: %v", err)
+	}
 }
 
 // MaintenanceCheckpoint participates in the shared vector checkpoint loop.
@@ -683,41 +644,180 @@ func (ve *VectorEngineImpl) MaintenanceCheckpoint() {
 	}
 }
 
-func (ve *VectorEngineImpl) flushData(force bool) {
-	ve.persistMu.Lock()
-	buf := ve.persistBuf
-	if !force && len(buf) == 0 {
-		ve.persistMu.Unlock()
-		return
-	}
-	ve.persistBuf = nil
-	ve.persistMu.Unlock()
-
-	if len(buf) == 0 {
-		return
+func (ve *VectorEngineImpl) FlushBatch() error {
+	if ve.wal != nil {
+		ve.walMu.Lock()
+		defer ve.walMu.Unlock()
 	}
 
-	// Hold the write lock only for the in-memory fileOffsets updates and
-	// the raw file writes. Release before fsync so searches are not blocked
-	// for the full duration of the (potentially slow) syscall.
-	ve.lock.Lock()
-	store := ve.store
-	if store == nil {
-		ve.lock.Unlock()
-		return
+	ve.batchMu.Lock()
+	batch := ve.batch
+	ve.batch = make(map[int64]vectorBatchEntry)
+	ve.pending.Store(false)
+	ve.batchMu.Unlock()
+
+	if len(batch) == 0 {
+		if ve.wal != nil {
+			return ve.wal.Clear()
+		}
+		return nil
 	}
-	for _, it := range buf {
-		if err := ve.appendToDataFile(it.id, it.vec); err != nil {
-			log.Printf("appendToDataFile failed for id=%d: %v", it.id, err)
-		} else {
-			delete(store.pendingUpsertIDs, it.id)
+
+	if err := ve.flushBatch(batch); err != nil {
+		ve.batchMu.Lock()
+		for id, entry := range batch {
+			if _, newer := ve.batch[id]; !newer {
+				ve.batch[id] = entry
+			}
+		}
+		ve.pending.Store(len(ve.batch) > 0)
+		ve.batchMu.Unlock()
+		maintenance.MarkVectorFlushDirty(ve)
+		return err
+	}
+
+	if ve.wal != nil {
+		if err := ve.wal.Clear(); err != nil {
+			maintenance.MarkVectorFlushDirty(ve)
+			return err
 		}
 	}
-	ve.lock.Unlock()
+	return nil
+}
+
+func (ve *VectorEngineImpl) flushBatch(batch map[int64]vectorBatchEntry) error {
+	ve.lock.Lock()
+	defer ve.lock.Unlock()
+
+	store := ve.store
+	if store == nil {
+		return errors.New("vector storage is not initialized")
+	}
+
+	type appliedEntry struct {
+		id      int64
+		offset  int64
+		deleted bool
+	}
+	applied := make([]appliedEntry, 0, len(batch))
+	ids := make([]int64, 0, len(batch))
+	vectors := make([]float32, 0, len(batch)*ve.maxVectorSize)
+	removeIDs := make([]int64, 0, len(batch))
+	rebuildIndex := false
+
+	for id, entry := range batch {
+		offset, err := appendVectorBatchRecord(store.dataFile, id, entry, ve.maxVectorSize)
+		if err != nil {
+			return fmt.Errorf("append vector batch record %d: %w", id, err)
+		}
+		applied = append(applied, appliedEntry{id: id, offset: offset, deleted: entry.deleted})
+
+		if _, exists := store.fileOffsets[id]; exists && !store.deletedIDs[id] {
+			removeIDs = append(removeIDs, id)
+			if strings.HasPrefix(ve.indexType, "HNSW") {
+				rebuildIndex = true
+			}
+		}
+		if !entry.deleted {
+			ids = append(ids, id)
+			vectors = append(vectors, entry.vector...)
+		}
+	}
 
 	if err := store.dataFile.Sync(); err != nil {
-		log.Printf("data file sync failed: %v", err)
+		return fmt.Errorf("sync vector data batch: %w", err)
 	}
+
+	if rebuildIndex {
+		return ve.rebuildStoreIndexLocked()
+	}
+
+	if len(removeIDs) > 0 {
+		selector, err := faiss.NewIDSelectorBatch(removeIDs)
+		if err != nil {
+			return fmt.Errorf("create batch ID selector: %w", err)
+		}
+		_, removeErr := store.index.RemoveIDs(selector)
+		selector.Delete()
+		if removeErr != nil {
+			if err := ve.rebuildStoreIndexLocked(); err != nil {
+				return fmt.Errorf("remove batch IDs: %v; rebuild index: %w", removeErr, err)
+			}
+			return nil
+		}
+	}
+
+	if len(ids) > 0 {
+		if err := store.index.AddWithIDs(vectors, ids); err != nil {
+			if rebuildErr := ve.rebuildStoreIndexLocked(); rebuildErr != nil {
+				return fmt.Errorf("add vector batch: %v; rebuild index: %w", err, rebuildErr)
+			}
+			return nil
+		}
+	}
+
+	for _, entry := range applied {
+		store.fileOffsets[entry.id] = entry.offset
+		if entry.deleted {
+			store.deletedIDs[entry.id] = true
+		} else {
+			delete(store.deletedIDs, entry.id)
+		}
+	}
+	return nil
+}
+
+func (ve *VectorEngineImpl) rebuildStoreIndexLocked() error {
+	index, err := buildVectorIndexFromDataFile(ve.primaryDataPath, ve.maxVectorSize, ve.activeIndexDesc(), ve.metric)
+	if err != nil {
+		return fmt.Errorf("rebuild vector index after batch update: %w", err)
+	}
+	offsets, deletedIDs, err := scanVectorDataFile(ve.primaryDataPath, ve.maxVectorSize)
+	if err != nil {
+		index.Delete()
+		return fmt.Errorf("rescan vector data after batch update: %w", err)
+	}
+	ve.store.index.Delete()
+	ve.store.index = index
+	ve.store.fileOffsets = offsets
+	ve.store.deletedIDs = deletedIDs
+	return nil
+}
+
+func appendVectorBatchRecord(file *os.File, id int64, entry vectorBatchEntry, dimension int) (int64, error) {
+	offset, err := file.Seek(0, io.SeekEnd)
+	if err != nil {
+		return 0, err
+	}
+	buf := make([]byte, 8+4*dimension)
+	binary.LittleEndian.PutUint64(buf[:8], uint64(id))
+	if entry.deleted {
+		binary.LittleEndian.PutUint32(buf[8:12], tombstoneMarker)
+	} else {
+		for i, value := range entry.vector {
+			binary.LittleEndian.PutUint32(buf[8+i*4:], math.Float32bits(value))
+		}
+	}
+	if _, err := file.Write(buf); err != nil {
+		return 0, err
+	}
+	return offset, nil
+}
+
+func (ve *VectorEngineImpl) snapshotBatch() map[int64]vectorBatchEntry {
+	if !ve.pending.Load() {
+		return nil
+	}
+	ve.batchMu.Lock()
+	defer ve.batchMu.Unlock()
+	if len(ve.batch) == 0 {
+		return nil
+	}
+	batch := make(map[int64]vectorBatchEntry, len(ve.batch))
+	for id, entry := range ve.batch {
+		batch[id] = entry
+	}
+	return batch
 }
 
 func float32ArrayToBytes(arr []float32) []byte {
@@ -916,4 +1016,26 @@ func betterDistanceForMetric(metric int, left, right float32) bool {
 		return left > right
 	}
 	return left < right
+}
+
+func vectorDistance(metric int, left, right []float32) float32 {
+	var distance float32
+	if metric == faiss.MetricInnerProduct {
+		for i := range left {
+			distance += left[i] * right[i]
+		}
+		return distance
+	}
+	for i := range left {
+		delta := left[i] - right[i]
+		distance += delta * delta
+	}
+	return distance
+}
+
+func distanceWithinRadius(metric int, distance, radius float32) bool {
+	if metric == faiss.MetricInnerProduct {
+		return distance > radius
+	}
+	return distance < radius
 }

--- a/internal/storage/vector_storage_batch_test.go
+++ b/internal/storage/vector_storage_batch_test.go
@@ -1,0 +1,132 @@
+package storage
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/DataIntelligenceCrew/go-faiss"
+)
+
+func TestVectorFlushBatchAddsQueuedVectors(t *testing.T) {
+	dir := t.TempDir()
+	ve, err := NewVectorEngine(
+		filepath.Join(dir, "vector_data.db"),
+		filepath.Join(dir, "vector_index.faiss"),
+		filepath.Join(dir, "vector_wal.db"),
+		4, "HNSW32,Flat", faiss.MetricL2, false,
+	)
+	if err != nil {
+		t.Fatalf("NewVectorEngine failed: %v", err)
+	}
+	defer ve.Close()
+
+	const count = 256
+	ve.batchMu.Lock()
+	for id := int64(1); id <= count; id++ {
+		ve.batch[id] = vectorBatchEntry{vector: []float32{float32(id), 1, 2, 3}}
+	}
+	ve.pending.Store(true)
+	ve.batchMu.Unlock()
+
+	if got := ve.store.index.Ntotal(); got != 0 {
+		t.Fatalf("FAISS index contains %d vectors before batch flush", got)
+	}
+	ids, _, err := ve.SearchTopK([]float32{count, 1, 2, 3}, 1)
+	if err != nil || len(ids) != 1 || ids[0] != count {
+		t.Fatalf("SearchTopK should include staged vector, ids=%v err=%v", ids, err)
+	}
+	if err := ve.FlushBatch(); err != nil {
+		t.Fatalf("FlushBatch failed: %v", err)
+	}
+	if got := ve.store.index.Ntotal(); got != count {
+		t.Fatalf("FAISS index contains %d vectors after batch flush, want %d", got, count)
+	}
+	if _, err := ve.GetVectorByID(count); err != nil {
+		t.Fatalf("GetVectorByID after batch flush failed: %v", err)
+	}
+}
+
+func TestVectorBatchIsLastWriteWinsAndCopiesInput(t *testing.T) {
+	dir := t.TempDir()
+	ve, err := NewVectorEngine(
+		filepath.Join(dir, "vector_data.db"),
+		filepath.Join(dir, "vector_index.faiss"),
+		filepath.Join(dir, "vector_wal.db"),
+		4, "Flat", faiss.MetricL2, false,
+	)
+	if err != nil {
+		t.Fatalf("NewVectorEngine failed: %v", err)
+	}
+	defer ve.Close()
+
+	first := []float32{1, 0, 0, 0}
+	latest := []float32{0, 1, 0, 0}
+	if err := ve.InsertVector(7, first); err != nil {
+		t.Fatalf("first InsertVector failed: %v", err)
+	}
+	if err := ve.InsertVector(7, latest); err != nil {
+		t.Fatalf("second InsertVector failed: %v", err)
+	}
+	latest[0] = 99
+	if got, err := ve.GetVectorByID(7); err != nil || !reflect.DeepEqual(got, []float32{0, 1, 0, 0}) {
+		t.Fatalf("GetVectorByID before flush = %v, err=%v", got, err)
+	}
+
+	if err := ve.FlushBatch(); err != nil {
+		t.Fatalf("FlushBatch failed: %v", err)
+	}
+	got, err := ve.GetVectorByID(7)
+	if err != nil {
+		t.Fatalf("GetVectorByID failed: %v", err)
+	}
+	if want := []float32{0, 1, 0, 0}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("GetVectorByID = %v, want copied latest vector %v", got, want)
+	}
+	if got := ve.store.index.Ntotal(); got != 1 {
+		t.Fatalf("FAISS index contains %d entries for one batched ID", got)
+	}
+}
+
+func TestVectorBatchWALClearsOnlyAfterFlush(t *testing.T) {
+	dir := t.TempDir()
+	walPath := filepath.Join(dir, "vector_wal.db")
+	ve, err := NewVectorEngine(
+		filepath.Join(dir, "vector_data.db"),
+		filepath.Join(dir, "vector_index.faiss"),
+		walPath,
+		4, "Flat", faiss.MetricL2, true,
+	)
+	if err != nil {
+		t.Fatalf("NewVectorEngine failed: %v", err)
+	}
+	defer ve.Close()
+
+	vector := []float32{1, 2, 3, 4}
+	key := make([]byte, 8)
+	binary.LittleEndian.PutUint64(key, 1)
+	if err := ve.wal.WriteEntry(string(key), string(float32ArrayToBytes(vector))); err != nil {
+		t.Fatalf("write WAL entry: %v", err)
+	}
+	ve.batch[1] = vectorBatchEntry{vector: vector}
+	info, err := os.Stat(walPath)
+	if err != nil {
+		t.Fatalf("stat WAL before flush: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Fatal("WAL was cleared before vector batch became durable")
+	}
+
+	if err := ve.FlushBatch(); err != nil {
+		t.Fatalf("FlushBatch failed: %v", err)
+	}
+	info, err = os.Stat(walPath)
+	if err != nil {
+		t.Fatalf("stat WAL after flush: %v", err)
+	}
+	if info.Size() != 0 {
+		t.Fatalf("WAL size after durable batch flush = %d, want 0", info.Size())
+	}
+}

--- a/internal/storage/vector_storage_checkpoint_parallel_test.go
+++ b/internal/storage/vector_storage_checkpoint_parallel_test.go
@@ -36,7 +36,9 @@ func TestVectorEngineCheckpointParallelLoad(t *testing.T) {
 		}
 		seedVectors = append(seedVectors, sample{id: id, vec: vec})
 	}
-	ve.flushData(true)
+	if err := ve.FlushBatch(); err != nil {
+		t.Fatalf("FlushBatch failed: %v", err)
+	}
 
 	errCh := make(chan error, 16)
 	reportErr := func(err error) {
@@ -118,7 +120,9 @@ func TestVectorEngineCheckpointParallelLoad(t *testing.T) {
 		}
 	}
 
-	ve.flushData(true)
+	if err := ve.FlushBatch(); err != nil {
+		t.Fatalf("FlushBatch failed: %v", err)
+	}
 	if err := ve.checkpoint(); err != nil {
 		t.Fatalf("final checkpoint failed: %v", err)
 	}

--- a/internal/storage/vector_storage_index_benchmark_test.go
+++ b/internal/storage/vector_storage_index_benchmark_test.go
@@ -54,6 +54,9 @@ func BenchmarkVectorEngineInsert(b *testing.B) {
 					b.Fatalf("insert(%s): %v", indexType, err)
 				}
 			}
+			if err := e.FlushBatch(); err != nil {
+				b.Fatalf("FlushBatch(%s): %v", indexType, err)
+			}
 		})
 	}
 }
@@ -74,7 +77,9 @@ func seedBenchVectorEngine(b *testing.B, indexType string) (*VectorEngineImpl, [
 			queries = append(queries, vec)
 		}
 	}
-	e.flushData(true)
+	if err := e.FlushBatch(); err != nil {
+		b.Fatalf("FlushBatch failed: %v", err)
+	}
 	return e, queries
 }
 

--- a/internal/storage/vector_storage_index_benchmark_test.go
+++ b/internal/storage/vector_storage_index_benchmark_test.go
@@ -10,19 +10,14 @@ import (
 // supported index types. They cover the two hot-path operations: insert and
 // top-k search.
 //
-// A very large segment-rollover threshold is used so the whole dataset stays in
-// a single hot segment for the duration of the benchmark; this keeps results
-// deterministic (no background segment sealing / index rebuilds mid-run). The
-// hot segment uses the configured index for Flat/HNSW, while training indexes
-// (IVF/PQ) ingest through a Flat IDMap hot segment, so their hot-path numbers
-// reflect that behavior.
+// Training indexes (IVF/PQ) ingest through a Flat IDMap until they have enough
+// vectors to train, so their hot-path numbers reflect that behavior.
 
 const (
-	benchVecDim        = 64
-	benchVecDataset    = 10000
-	benchVecK          = 10
-	benchVecPool       = 4096
-	benchVecNoRollover = int64(1) << 40 // effectively disables segment rollover
+	benchVecDim     = 64
+	benchVecDataset = 10000
+	benchVecK       = 10
+	benchVecPool    = 4096
 )
 
 var benchVectorIndexTypes = []string{"Flat", "HNSW32", "HNSW64", "IVF32", "PQ8"}
@@ -34,8 +29,7 @@ func newBenchVectorEngine(b *testing.B, indexType string) *VectorEngineImpl {
 		dir+"/vec_data.db",
 		dir+"/vec_index.faiss",
 		dir+"/vec_wal.db",
-		benchVecDim, indexType, faiss.MetricL2, false,
-		SpaceSettings{SegmentRolloverBytes: benchVecNoRollover},
+		benchVecDim, indexType, faiss.MetricL2, false, SpaceSettings{},
 	)
 	if err != nil {
 		b.Fatalf("NewVectorEngineWithSettings(%s): %v", indexType, err)

--- a/internal/storage/vector_storage_ivf_flat_test.go
+++ b/internal/storage/vector_storage_ivf_flat_test.go
@@ -375,7 +375,4 @@ func TestVectorEngineTrainingIndex_NoSegmentRollover(t *testing.T) {
 	if len(ve.manifest.Segments) != 1 {
 		t.Fatalf("expected single vector segment for IVF, got %d segments", len(ve.manifest.Segments))
 	}
-	if ve.vectorSegmentationEnabled {
-		t.Fatal("IVF index must disable vector segmentation (vectorSegmentationEnabled=false)")
-	}
 }

--- a/internal/storage/vector_storage_multi_client_benchmark_test.go
+++ b/internal/storage/vector_storage_multi_client_benchmark_test.go
@@ -1,7 +1,6 @@
 package storage
 
 import (
-	"encoding/binary"
 	"fmt"
 	"sort"
 	"sync"
@@ -13,43 +12,15 @@ import (
 )
 
 type insertPhaseSample struct {
-	total      time.Duration
-	walWrite   time.Duration
-	indexWrite time.Duration
-	walCommit  time.Duration
+	total time.Duration
 }
 
 func benchmarkInsertWithBreakdown(ve *VectorEngineImpl, id int64, vector []float32) (insertPhaseSample, error) {
 	var sample insertPhaseSample
 	start := time.Now()
 
-	if len(vector) != ve.maxVectorSize {
-		return sample, fmt.Errorf("vector length mismatch: expected %d", ve.maxVectorSize)
-	}
-
-	if ve.wal != nil {
-		key := make([]byte, 8)
-		binary.LittleEndian.PutUint64(key, uint64(id))
-
-		walStart := time.Now()
-		if err := ve.wal.WriteEntry(string(key), string(float32ArrayToBytes(vector))); err != nil {
-			return sample, err
-		}
-		sample.walWrite = time.Since(walStart)
-	}
-
-	indexStart := time.Now()
-	if err := ve.insertAfterWAL(id, vector); err != nil {
+	if err := ve.InsertVector(id, vector); err != nil {
 		return sample, err
-	}
-	sample.indexWrite = time.Since(indexStart)
-
-	if ve.wal != nil {
-		commitStart := time.Now()
-		if err := ve.wal.MarkCommitted(); err != nil {
-			return sample, err
-		}
-		sample.walCommit = time.Since(commitStart)
 	}
 
 	sample.total = time.Since(start)
@@ -100,7 +71,9 @@ func runVectorEngineMultiClientInsertBenchmark(t *testing.T, enableWAL bool) {
 		}
 		seedVectors = append(seedVectors, seedSample{id: id, vec: vec})
 	}
-	ve.flushData(true)
+	if err := ve.FlushBatch(); err != nil {
+		t.Fatalf("FlushBatch failed: %v", err)
+	}
 
 	done := make(chan struct{})
 	resultsCh := make(chan insertPhaseSample, insertWorkers*insertsPerWorker)
@@ -227,20 +200,14 @@ func runVectorEngineMultiClientInsertBenchmark(t *testing.T, enableWAL bool) {
 	}
 
 	var (
-		insertCount        int
-		totalInsertTime    time.Duration
-		totalWALWriteTime  time.Duration
-		totalIndexTime     time.Duration
-		totalWALCommitTime time.Duration
-		latencies          []time.Duration
+		insertCount     int
+		totalInsertTime time.Duration
+		latencies       []time.Duration
 	)
 
 	for sample := range resultsCh {
 		insertCount++
 		totalInsertTime += sample.total
-		totalWALWriteTime += sample.walWrite
-		totalIndexTime += sample.indexWrite
-		totalWALCommitTime += sample.walCommit
 		latencies = append(latencies, sample.total)
 	}
 
@@ -252,11 +219,6 @@ func runVectorEngineMultiClientInsertBenchmark(t *testing.T, enableWAL bool) {
 	p50 := latencies[len(latencies)/2]
 	p95 := latencies[(len(latencies)*95)/100]
 	avgInsert := totalInsertTime / time.Duration(insertCount)
-	avgWALWrite := totalWALWriteTime / time.Duration(insertCount)
-	avgIndex := totalIndexTime / time.Duration(insertCount)
-	avgWALCommit := totalWALCommitTime / time.Duration(insertCount)
-	avgExplicitSync := (totalWALWriteTime + totalWALCommitTime) / time.Duration(insertCount)
-	syncShare := 100 * float64((totalWALWriteTime + totalWALCommitTime).Nanoseconds()) / float64(totalInsertTime.Nanoseconds())
 
 	mode := "WAL enabled"
 	if !enableWAL {
@@ -276,9 +238,4 @@ func runVectorEngineMultiClientInsertBenchmark(t *testing.T, enableWAL bool) {
 	fmt.Printf("Avg insert latency: %v\n", avgInsert)
 	fmt.Printf("P50 insert latency: %v\n", p50)
 	fmt.Printf("P95 insert latency: %v\n", p95)
-	fmt.Printf("Avg WAL write+sync time: %v\n", avgWALWrite)
-	fmt.Printf("Avg index mutation/enqueue time: %v\n", avgIndex)
-	fmt.Printf("Avg WAL commit+sync time: %v\n", avgWALCommit)
-	fmt.Printf("Avg explicit disk-sync time on insert path: %v\n", avgExplicitSync)
-	fmt.Printf("Explicit disk-sync share of total insert latency: %.2f%%\n", syncShare)
 }


### PR DESCRIPTION
## Description

Removes segmented storage from all FAISS-backed vector indexes. Flat, HNSW, IVF, and PQ indexes now use a single data file.

Also:
- Removes unused rollover, merge, and background indexing code.
- Migrates legacy multi-segment FAISS data to the single-file layout on startup.
- Keeps segmentation for key-value and filterable Flat vector engines.
- Updates relevant documentation and tests.

## Type of change

- [x] Breaking change
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] `go test ./internal/storage`
- [x] `go test ./internal/spaces ./internal/queryengine`
- [x] `git diff --check`

Tests cover:
- No rollover for Flat, HNSW, and IVF indexes.
- Legacy segmented-layout migration.
- FAISS segment-setting rejection.
- Continued segment-setting support for filterable Flat vectors.

`go test ./...` passes for regular packages. E2E and benchmark packages require a server running on port `4444`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented hard-to-understand areas
- [x] I have made corresponding documentation changes
- [x] My changes generate no new warnings
- [x] I have added tests proving the change is effective
- [x] New and existing unit tests pass locally

## Additional Notes

Existing FAISS spaces with multiple segments are automatically compacted into the primary vector data file when opened.