### PR TITLE
Fixed PQ and IVF vector index training

### DIFF
--- a/docs/VECTOR_ENGINE.md
+++ b/docs/VECTOR_ENGINE.md
@@ -94,15 +94,18 @@ CREATE-SPACE fast_embeddings --engine vector --dimension 128 --disable-wal
 - `--enable-wal`: Enable Write-Ahead Logging for enhanced durability (default: disabled for vector spaces)
 - `--disable-wal`: Disable Write-Ahead Logging for maximum performance (default for vector spaces)
 
-### Minimum Vector Requirements
+### Automatic Training
 
-Different index types have different minimum vector requirements before search operations become available:
+Search is available immediately for every index type. IVF/PQ spaces initially
+use a Flat index, then train the configured index in the background after
+10,000 vectors have been flushed. New writes remain searchable while training
+is in progress, and the trained index replaces Flat atomically.
 
-- **Flat**: No minimum required (search available immediately)
-- **HNSW{n}**: No minimum required (search available immediately)
-- **IVF{n}**: Minimum n vectors required (n = number of clusters)
-- **PQ{n}**: Minimum 256 vectors required (for training)
-- **Composite indices**: Follow the higher requirement of their components
+The underlying FAISS minimums are:
+
+- **IVF{n}**: n vectors (n = number of clusters)
+- **PQ{n}**: 256 vectors
+- **Composite indices**: The higher requirement of their components
 
 **Examples:**
 ```bash
@@ -112,21 +115,15 @@ USE hnsw_space
 INSERT-VECTOR 1 1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0
 SEARCH-TOPK 1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0 5  # Works immediately
 
-# IVF32 - search available after 32 vectors
+# IVF32 - search available immediately; background promotion after 10,000 vectors
 CREATE-SPACE ivf_space --engine vector --dimension 128 --index-type IVF32
 USE ivf_space
-# Need to insert at least 32 vectors before search works
 INSERT-VECTOR 1 1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0
-# ... insert 31 more vectors ...
-INSERT-VECTOR 32 1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0
-SEARCH-TOPK 1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0 5  # Now works
+SEARCH-TOPK 1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0 5  # Works immediately
 
-# PQ8 - search available after 256 vectors
+# PQ8 behaves the same way
 CREATE-SPACE pq_space --engine vector --dimension 128 --index-type PQ8
 USE pq_space
-# Need to insert at least 256 vectors before search works
-# ... insert 256 vectors ...
-SEARCH-TOPK 1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0 5  # Now works
 ```
 
 ### Supported Index Types

--- a/docs/VECTOR_ENGINE.md
+++ b/docs/VECTOR_ENGINE.md
@@ -58,15 +58,15 @@ CREATE-SPACE embeddings --engine vector --dimension 128
 CREATE-SPACE image_vectors --engine vector --dimension 512 --index-type HNSW32 --metric L2
 
 # Create with custom parameters
-CREATE-SPACE text_embeddings --engine vector --dimension 768 --index-type IVF32 --metric InnerProduct
+CREATE-SPACE text_embeddings --engine vector --dimension 768 --index-type IVF32,Flat --metric InnerProduct
 
 # Create with different HNSW configurations
 CREATE-SPACE fast_search --engine vector --dimension 128 --index-type HNSW64 --metric L2
 CREATE-SPACE ultra_fast --engine vector --dimension 128 --index-type HNSW256 --metric L2
 
 # Create with different IVF configurations
-CREATE-SPACE large_dataset --engine vector --dimension 128 --index-type IVF64 --metric L2
-CREATE-SPACE huge_dataset --engine vector --dimension 128 --index-type IVF256 --metric L2
+CREATE-SPACE large_dataset --engine vector --dimension 128 --index-type IVF64,Flat --metric L2
+CREATE-SPACE huge_dataset --engine vector --dimension 128 --index-type IVF256,Flat --metric L2
 
 # Create with different PQ configurations
 CREATE-SPACE memory_efficient --engine vector --dimension 128 --index-type PQ8 --metric L2
@@ -115,8 +115,8 @@ USE hnsw_space
 INSERT-VECTOR 1 1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0
 SEARCH-TOPK 1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0 5  # Works immediately
 
-# IVF32 - search available immediately; background promotion after 10,000 vectors
-CREATE-SPACE ivf_space --engine vector --dimension 128 --index-type IVF32
+# IVF32,Flat - search available immediately; background promotion after 10,000 vectors
+CREATE-SPACE ivf_space --engine vector --dimension 128 --index-type IVF32,Flat
 USE ivf_space
 INSERT-VECTOR 1 1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0
 SEARCH-TOPK 1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0 5  # Works immediately
@@ -136,7 +136,7 @@ ShibuDb supports various FAISS index types with hardcoded configurations and com
 |------------|-------------|----------|--------|-------|---------------------|--------|
 | `Flat` | Exact search | Small datasets, high accuracy | High | Slow | 0 | Yes |
 | `HNSW{n}` | Hierarchical Navigable Small World | Fast similarity search | Medium | Fast | 0 | **No** |
-| `IVF{n}` | Inverted file index | Large datasets | Low | Medium | n | Yes |
+| `IVF{n},Flat` | Inverted file index with Flat storage | Large datasets | Low | Medium | n | Yes |
 | `PQ{n}` | Product quantization | Very large datasets | Very Low | Fast | 256 | Yes |
 
 *"Delete" column: whether `DELETE-VECTOR` is supported for that index type.*
@@ -148,8 +148,8 @@ ShibuDb supports various FAISS index types with hardcoded configurations and com
 - **Minimum vectors required**: 0 (search enabled immediately)
 - **Use case**: Fast approximate similarity search with configurable neighbor count
 
-**IVF Indices**: `IVF{n}` where n is a power of 2 from 2 to 256
-- Examples: `IVF2`, `IVF4`, `IVF8`, `IVF16`, `IVF32`, `IVF64`, `IVF128`, `IVF256`
+**IVF Indices**: `IVF{n},Flat` where n is a power of 2 from 2 to 256
+- Examples: `IVF2,Flat`, `IVF4,Flat`, `IVF8,Flat`, `IVF16,Flat`, `IVF32,Flat`, `IVF64,Flat`, `IVF128,Flat`, `IVF256,Flat`
 - **Minimum vectors required**: n (number of clusters)
 - **Use case**: Large dataset indexing with configurable cluster count
 
@@ -304,8 +304,8 @@ CREATE-SPACE hnsw256 --engine vector --dimension 128 --index-type HNSW256 # 256 
 **Best for**: Large datasets, balanced performance
 
 ```bash
-# Create IVF index (32 clusters)
-CREATE-SPACE large_dataset --engine vector --dimension 128 --index-type IVF32 --metric L2
+# Create IVF index (32 clusters with Flat storage)
+CREATE-SPACE large_dataset --engine vector --dimension 128 --index-type IVF32,Flat --metric L2
 USE large_dataset
 
 # Insert many vectors
@@ -320,14 +320,14 @@ SEARCH-TOPK 1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0 10
 **Available IVF Variants:**
 ```bash
 # Different cluster configurations (power of 2 from 2 to 256)
-CREATE-SPACE ivf2 --engine vector --dimension 128 --index-type IVF2   # 2 clusters
-CREATE-SPACE ivf4 --engine vector --dimension 128 --index-type IVF4   # 4 clusters
-CREATE-SPACE ivf8 --engine vector --dimension 128 --index-type IVF8   # 8 clusters
-CREATE-SPACE ivf16 --engine vector --dimension 128 --index-type IVF16 # 16 clusters
-CREATE-SPACE ivf32 --engine vector --dimension 128 --index-type IVF32 # 32 clusters
-CREATE-SPACE ivf64 --engine vector --dimension 128 --index-type IVF64 # 64 clusters
-CREATE-SPACE ivf128 --engine vector --dimension 128 --index-type IVF128 # 128 clusters
-CREATE-SPACE ivf256 --engine vector --dimension 128 --index-type IVF256 # 256 clusters
+CREATE-SPACE ivf2 --engine vector --dimension 128 --index-type IVF2,Flat     # 2 clusters
+CREATE-SPACE ivf4 --engine vector --dimension 128 --index-type IVF4,Flat     # 4 clusters
+CREATE-SPACE ivf8 --engine vector --dimension 128 --index-type IVF8,Flat     # 8 clusters
+CREATE-SPACE ivf16 --engine vector --dimension 128 --index-type IVF16,Flat   # 16 clusters
+CREATE-SPACE ivf32 --engine vector --dimension 128 --index-type IVF32,Flat   # 32 clusters
+CREATE-SPACE ivf64 --engine vector --dimension 128 --index-type IVF64,Flat   # 64 clusters
+CREATE-SPACE ivf128 --engine vector --dimension 128 --index-type IVF128,Flat # 128 clusters
+CREATE-SPACE ivf256 --engine vector --dimension 128 --index-type IVF256,Flat # 256 clusters
 ```
 
 **Characteristics:**
@@ -764,10 +764,10 @@ CREATE-SPACE medium_exact --engine vector --dimension 128 --index-type HNSW32,Fl
 #### Large Datasets (1M - 10M vectors)
 ```bash
 # Use IVF for balanced performance
-CREATE-SPACE large_dataset --engine vector --dimension 128 --index-type IVF32
+CREATE-SPACE large_dataset --engine vector --dimension 128 --index-type IVF32,Flat
 
 # For larger datasets, use more clusters
-CREATE-SPACE large_many_clusters --engine vector --dimension 128 --index-type IVF64
+CREATE-SPACE large_many_clusters --engine vector --dimension 128 --index-type IVF64,Flat
 
 # For high accuracy with exact refinement
 CREATE-SPACE large_accurate --engine vector --dimension 128 --index-type IVF32,Flat
@@ -796,9 +796,9 @@ CREATE-SPACE huge_fast --engine vector --dimension 128 --index-type HNSW128,PQ32
 - `HNSW128-HNSW256`: Higher accuracy, slower, good for precision-critical applications
 
 **IVF Variants:**
-- `IVF2-IVF16`: Good for smaller large datasets (1M-5M vectors)
-- `IVF32-IVF64`: Good for medium large datasets (5M-20M vectors)
-- `IVF128-IVF256`: Good for very large datasets (20M+ vectors)
+- `IVF2,Flat` through `IVF16,Flat`: Good for smaller large datasets (1M-5M vectors)
+- `IVF32,Flat` through `IVF64,Flat`: Good for medium large datasets (5M-20M vectors)
+- `IVF128,Flat` through `IVF256,Flat`: Good for very large datasets (20M+ vectors)
 
 **PQ Variants:**
 - `PQ2-PQ8`: Very memory efficient, lower accuracy
@@ -827,9 +827,9 @@ CREATE-SPACE hnsw_medium --engine vector --dimension 128 --index-type HNSW32
 CREATE-SPACE hnsw_large --engine vector --dimension 128 --index-type HNSW64
 
 # IVF: Lower memory usage (varies by cluster count)
-CREATE-SPACE ivf_small --engine vector --dimension 128 --index-type IVF16
-CREATE-SPACE ivf_medium --engine vector --dimension 128 --index-type IVF32
-CREATE-SPACE ivf_large --engine vector --dimension 128 --index-type IVF64
+CREATE-SPACE ivf_small --engine vector --dimension 128 --index-type IVF16,Flat
+CREATE-SPACE ivf_medium --engine vector --dimension 128 --index-type IVF32,Flat
+CREATE-SPACE ivf_large --engine vector --dimension 128 --index-type IVF64,Flat
 
 # PQ: Lowest memory usage (varies by quantization bits)
 CREATE-SPACE pq_small --engine vector --dimension 128 --index-type PQ4
@@ -977,7 +977,7 @@ SEARCH-TOPK 0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8 5
 ```bash
 # Create image embedding space with different configurations
 # For small image collection (balanced)
-CREATE-SPACE image_embeddings_balanced --engine vector --dimension 512 --index-type IVF32 --metric L2
+CREATE-SPACE image_embeddings_balanced --engine vector --dimension 512 --index-type IVF32,Flat --metric L2
 
 # For large image collection (high accuracy)
 CREATE-SPACE image_embeddings_accurate --engine vector --dimension 512 --index-type IVF64,Flat --metric L2
@@ -1056,7 +1056,7 @@ SEARCH-TOPK 0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8 10
 
 ```bash
 # Create face embedding space
-CREATE-SPACE face_embeddings --engine vector --dimension 128 --index-type IVF32 --metric L2
+CREATE-SPACE face_embeddings --engine vector --dimension 128 --index-type IVF32,Flat --metric L2
 USE face_embeddings
 
 # Store face embeddings
@@ -1106,13 +1106,13 @@ INSERT-VECTOR user@123 1.0,2.0,3.0,4.0,5.0
 
 **Problem**: `DELETE-VECTOR` was used on a space that uses an HNSW index (e.g. `HNSW32`, `HNSW64,Flat`).
 
-**Solution**: HNSW indices do not support removing vectors. Either use a different index type that supports deletion (Flat, IVF, PQ), or avoid deleting vectors in that space.
+**Solution**: HNSW indices do not support removing vectors. Either use a different index type that supports deletion (Flat, IVF with Flat/PQ storage, or PQ), or avoid deleting vectors in that space.
 
 ```bash
-# If you need deletion, use Flat or IVF instead of HNSW
+# If you need deletion, use Flat or IVF with Flat storage instead of HNSW
 CREATE-SPACE my_vectors --engine vector --dimension 128 --index-type Flat
 # or
-CREATE-SPACE my_vectors --engine vector --dimension 128 --index-type IVF32
+CREATE-SPACE my_vectors --engine vector --dimension 128 --index-type IVF32,Flat
 ```
 
 #### 4. "Operation not supported: not a vector space" Error

--- a/internal/spaces/space_manager.go
+++ b/internal/spaces/space_manager.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -47,7 +48,7 @@ func isAllowedIndexType(indexType string) bool {
 			return false
 		}
 
-		// e.g. HNSW32, IVF32, PQ4, Flat
+		// e.g. HNSW32, IVF32, PQ4, Flat (standalone IVF is rejected below)
 		var base string
 		num := -1
 
@@ -89,8 +90,20 @@ func isAllowedIndexType(indexType string) bool {
 		if base == "Flat" && num != -1 {
 			return false
 		}
+		if len(parts) == 1 && base == "IVF" {
+			return false
+		}
 	}
 	return true
+}
+
+func isStandaloneIVFIndex(indexType string) bool {
+	indexType = strings.TrimSpace(indexType)
+	if !strings.HasPrefix(indexType, "IVF") || strings.Contains(indexType, ",") {
+		return false
+	}
+	_, err := strconv.Atoi(strings.TrimPrefix(indexType, "IVF"))
+	return err == nil
 }
 
 func isAllowedMetric(metric string) bool {
@@ -517,10 +530,16 @@ func (sm *SpaceManager) CreateSpaceWithSettingsAndMetadata(space, engineType str
 
 	if engineType == "vector" {
 		if !isAllowedIndexType(meta.IndexType) {
+			if isStandaloneIVFIndex(meta.IndexType) {
+				return nil, fmt.Errorf("index type %q is invalid; use %q", meta.IndexType, meta.IndexType+",Flat")
+			}
 			return nil, fmt.Errorf("index type '%s' is not allowed", meta.IndexType)
 		}
 		if !isAllowedMetric(metric) {
 			return nil, fmt.Errorf("metric '%s' is not allowed", metric)
+		}
+		if err := storage.ValidateVectorIndexConfig(meta.Dimension, meta.IndexType, getFAISSMetric(meta.Metric)); err != nil {
+			return nil, err
 		}
 		if len(meta.IndexedMetadataFields) > 0 {
 			if meta.IndexType != "Flat" {

--- a/internal/spaces/space_manager_test.go
+++ b/internal/spaces/space_manager_test.go
@@ -39,15 +39,15 @@ func TestIsAllowedIndexType(t *testing.T) {
 		{"HNSW3", "HNSW3", false},              // Not power of 2
 		{"HNSW7", "HNSW7", false},              // Not power of 2
 
-		// IVF variants (powers of 2 from 2 to 256)
-		{"IVF2", "IVF2", true},
-		{"IVF4", "IVF4", true},
-		{"IVF8", "IVF8", true},
-		{"IVF16", "IVF16", true},
-		{"IVF32", "IVF32", true},
-		{"IVF64", "IVF64", true},
-		{"IVF128", "IVF128", true},
-		{"IVF256", "IVF256", true},
+		// Standalone IVF is not a valid FAISS factory descriptor; it requires storage.
+		{"IVF2", "IVF2", false},
+		{"IVF4", "IVF4", false},
+		{"IVF8", "IVF8", false},
+		{"IVF16", "IVF16", false},
+		{"IVF32", "IVF32", false},
+		{"IVF64", "IVF64", false},
+		{"IVF128", "IVF128", false},
+		{"IVF256", "IVF256", false},
 		{"IVF without number", "IVF", false}, // IVF requires number suffix
 		{"IVF512", "IVF512", false},          // Out of range
 		{"IVF1", "IVF1", false},              // Out of range
@@ -103,6 +103,19 @@ func TestIsAllowedIndexType(t *testing.T) {
 				t.Errorf("isAllowedIndexType(%q) = %v, want %v", tt.indexType, result, tt.expected)
 			}
 		})
+	}
+}
+
+func TestSpaceManagerRejectsStandaloneIVFIndex(t *testing.T) {
+	sm := NewSpaceManager(t.TempDir())
+
+	if _, err := sm.CreateSpace("invalid_ivf", "vector", 8, "IVF128", "L2"); err == nil {
+		t.Fatal("CreateSpace with standalone IVF index succeeded, want an error")
+	} else if !strings.Contains(err.Error(), `use "IVF128,Flat"`) {
+		t.Fatalf("CreateSpace error = %q, want IVF128,Flat guidance", err)
+	}
+	if _, err := os.Stat(filepath.Join(sm.baseDir, "invalid_ivf")); !os.IsNotExist(err) {
+		t.Fatalf("invalid space directory was created, stat error = %v", err)
 	}
 }
 

--- a/internal/storage/rebuild.go
+++ b/internal/storage/rebuild.go
@@ -312,7 +312,7 @@ func readVectorRecordAt(file *os.File, offset int64, dimension int) (int64, []fl
 }
 
 func requiredTrainCountForIndex(indexDesc string) int {
-	if indexDesc == "Flat" || strings.HasPrefix(indexDesc, "HNSW") {
+	if indexDesc == "Flat" || (strings.HasPrefix(indexDesc, "HNSW") && !strings.Contains(indexDesc, "PQ")) {
 		return 0
 	}
 

--- a/internal/storage/vector_storage.go
+++ b/internal/storage/vector_storage.go
@@ -24,6 +24,8 @@ import (
 // Quiet NaN 0x7FC00000 — reserved; vectors with NaN in first dimension are not supported.
 const tombstoneMarker = uint32(0x7FC00000)
 
+const indexPromotionDebounce = 250 * time.Millisecond
+
 // ErrDeletionNotSupported is returned by RemoveVector when the index type (e.g. HNSW) does not support vector deletion.
 var ErrDeletionNotSupported = errors.New("vector deletion not supported for HNSW index type")
 
@@ -52,6 +54,10 @@ type VectorEngineImpl struct {
 	batchMu sync.Mutex
 	batch   map[int64]vectorBatchEntry
 	pending atomic.Bool
+
+	promotionWake chan struct{}
+	promotionStop chan struct{}
+	promotionWG   sync.WaitGroup
 }
 
 var _ VectorEngine = (*VectorEngineImpl)(nil)
@@ -61,6 +67,7 @@ type vectorStore struct {
 	index       faiss.Index
 	fileOffsets map[int64]int64
 	deletedIDs  map[int64]bool
+	configured  bool
 }
 
 type vectorBatchEntry struct {
@@ -92,6 +99,8 @@ func NewVectorEngineWithSettings(dataPath, indexPath, walPath string, maxVectorS
 		layout:           NewSegmentLayout(filepath.Dir(dataPath), "vector", ".db", ".faiss"),
 		primaryDataPath:  dataPath,
 		primaryIndexPath: indexPath,
+		promotionWake:    make(chan struct{}, 1),
+		promotionStop:    make(chan struct{}),
 	}
 
 	manifest, err := e.loadOrCreateManifest()
@@ -121,6 +130,10 @@ func NewVectorEngineWithSettings(dataPath, indexPath, walPath string, maxVectorS
 		if err := e.replayWAL(); err != nil {
 			return nil, fmt.Errorf("WAL replay failed: %w", err)
 		}
+	}
+	if e.requiresIndexTraining() {
+		e.startIndexPromotionWorker()
+		e.scheduleIndexPromotion()
 	}
 
 	return e, nil
@@ -245,7 +258,7 @@ func (ve *VectorEngineImpl) loadStore() error {
 		return err
 	}
 
-	index, err := buildVectorIndexFromDataFile(desc.DataPath, ve.maxVectorSize, ve.activeIndexDesc(), ve.metric)
+	index, err := buildVectorIndexFromDataFile(desc.DataPath, ve.maxVectorSize, ve.initialIndexDesc(), ve.metric)
 	if err != nil {
 		_ = dataFile.Close()
 		return err
@@ -549,6 +562,10 @@ func (ve *VectorEngineImpl) Close() error {
 		maintenance.UnregisterVectorCheckpoint(ve)
 		ve.maintenanceMu.Unlock()
 
+		if ve.requiresIndexTraining() {
+			close(ve.promotionStop)
+			ve.promotionWG.Wait()
+		}
 		if err := ve.FlushBatch(); err != nil {
 			log.Printf("final vector batch flush failed: %v", err)
 		}
@@ -682,6 +699,7 @@ func (ve *VectorEngineImpl) FlushBatch() error {
 			return err
 		}
 	}
+	ve.scheduleIndexPromotion()
 	return nil
 }
 
@@ -768,7 +786,11 @@ func (ve *VectorEngineImpl) flushBatch(batch map[int64]vectorBatchEntry) error {
 }
 
 func (ve *VectorEngineImpl) rebuildStoreIndexLocked() error {
-	index, err := buildVectorIndexFromDataFile(ve.primaryDataPath, ve.maxVectorSize, ve.activeIndexDesc(), ve.metric)
+	indexDesc := ve.initialIndexDesc()
+	if ve.store.configured {
+		indexDesc = ve.indexType
+	}
+	index, err := buildVectorIndexFromDataFile(ve.primaryDataPath, ve.maxVectorSize, indexDesc, ve.metric)
 	if err != nil {
 		return fmt.Errorf("rebuild vector index after batch update: %w", err)
 	}
@@ -782,6 +804,125 @@ func (ve *VectorEngineImpl) rebuildStoreIndexLocked() error {
 	ve.store.fileOffsets = offsets
 	ve.store.deletedIDs = deletedIDs
 	return nil
+}
+
+func (ve *VectorEngineImpl) requiresIndexTraining() bool {
+	return requiredTrainCountForIndex(ve.indexType) > 0
+}
+
+func (ve *VectorEngineImpl) startIndexPromotionWorker() {
+	ve.promotionWG.Add(1)
+	go ve.indexPromotionWorker()
+}
+
+func (ve *VectorEngineImpl) scheduleIndexPromotion() {
+	if !ve.requiresIndexTraining() {
+		return
+	}
+	ve.lock.RLock()
+	configured := ve.store != nil && ve.store.configured
+	ve.lock.RUnlock()
+	if configured {
+		return
+	}
+	select {
+	case ve.promotionWake <- struct{}{}:
+	default:
+	}
+}
+
+func (ve *VectorEngineImpl) indexPromotionWorker() {
+	defer ve.promotionWG.Done()
+	for {
+		select {
+		case <-ve.promotionStop:
+			return
+		case <-ve.promotionWake:
+		}
+
+		timer := time.NewTimer(indexPromotionDebounce)
+		debouncing := true
+		for debouncing {
+			select {
+			case <-ve.promotionStop:
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				return
+			case <-ve.promotionWake:
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				timer.Reset(indexPromotionDebounce)
+			case <-timer.C:
+				debouncing = false
+			}
+		}
+
+		if err := ve.promoteConfiguredIndex(); err != nil {
+			log.Printf("promote FAISS index %q failed: %v", ve.indexType, err)
+		}
+	}
+}
+
+func (ve *VectorEngineImpl) promoteConfiguredIndex() error {
+	ve.lock.RLock()
+	if ve.store == nil || ve.store.configured {
+		ve.lock.RUnlock()
+		return nil
+	}
+	liveVectors := len(ve.store.fileOffsets) - len(ve.store.deletedIDs)
+	info, err := ve.store.dataFile.Stat()
+	ve.lock.RUnlock()
+	if err != nil {
+		return fmt.Errorf("stat vector data before index promotion: %w", err)
+	}
+	if liveVectors < ve.indexPromotionThreshold() {
+		return nil
+	}
+	snapshotSize := info.Size()
+
+	index, err := buildVectorIndexFromDataFile(ve.primaryDataPath, ve.maxVectorSize, ve.indexType, ve.metric)
+	if err != nil {
+		return err
+	}
+
+	ve.lock.Lock()
+	defer ve.lock.Unlock()
+	if ve.store == nil || ve.store.configured {
+		index.Delete()
+		return nil
+	}
+	currentInfo, err := ve.store.dataFile.Stat()
+	if err != nil {
+		index.Delete()
+		return fmt.Errorf("stat vector data after index promotion: %w", err)
+	}
+	if currentInfo.Size() != snapshotSize {
+		index.Delete()
+		select {
+		case ve.promotionWake <- struct{}{}:
+		default:
+		}
+		return nil
+	}
+
+	oldIndex := ve.store.index
+	ve.store.index = index
+	ve.store.configured = true
+	oldIndex.Delete()
+	log.Printf("promoted FAISS index to %q with %d live vectors", ve.indexType, liveVectors)
+	return nil
+}
+
+func (ve *VectorEngineImpl) indexPromotionThreshold() int {
+	return trainingSampleCount(requiredTrainCountForIndex(ve.indexType), vectorRebuildTrainSample)
 }
 
 func appendVectorBatchRecord(file *os.File, id int64, entry vectorBatchEntry, dimension int) (int64, error) {
@@ -1004,7 +1145,7 @@ func writeMergedVectorDataFile(dataPath string, records map[int64][]byte) error 
 	return os.Rename(tmpPath, dataPath)
 }
 
-func (ve *VectorEngineImpl) activeIndexDesc() string {
+func (ve *VectorEngineImpl) initialIndexDesc() string {
 	if requiredTrainCountForIndex(ve.indexType) > 0 {
 		return "Flat"
 	}

--- a/internal/storage/vector_storage.go
+++ b/internal/storage/vector_storage.go
@@ -81,6 +81,10 @@ func NewVectorEngine(dataPath, indexPath, walPath string, maxVectorSize int, ind
 }
 
 func NewVectorEngineWithSettings(dataPath, indexPath, walPath string, maxVectorSize int, indexDesc string, metric int, enableWAL bool, _ SpaceSettings) (*VectorEngineImpl, error) {
+	if err := ValidateVectorIndexConfig(maxVectorSize, indexDesc, metric); err != nil {
+		return nil, err
+	}
+
 	var w *wal.WAL
 	var err error
 	if enableWAL {
@@ -137,6 +141,18 @@ func NewVectorEngineWithSettings(dataPath, indexPath, walPath string, maxVectorS
 	}
 
 	return e, nil
+}
+
+// ValidateVectorIndexConfig asks FAISS to parse the configured index before any
+// files are created. Training-based indexes otherwise use a Flat fallback and
+// could hide an invalid descriptor until background promotion.
+func ValidateVectorIndexConfig(dimension int, indexDesc string, metric int) error {
+	index, err := faiss.IndexFactory(dimension, "IDMap,"+indexDesc, metric)
+	if err != nil {
+		return fmt.Errorf("invalid FAISS index type %q: %w", indexDesc, err)
+	}
+	index.Delete()
+	return nil
 }
 
 func (ve *VectorEngineImpl) UpdateSpaceSettings(_ SpaceSettings) error {

--- a/internal/storage/vector_storage_index_benchmark_test.go
+++ b/internal/storage/vector_storage_index_benchmark_test.go
@@ -20,7 +20,7 @@ const (
 	benchVecPool    = 4096
 )
 
-var benchVectorIndexTypes = []string{"Flat", "HNSW32", "HNSW64", "IVF32", "PQ8"}
+var benchVectorIndexTypes = []string{"Flat", "HNSW32", "HNSW64", "IVF32,Flat", "PQ8"}
 
 func newBenchVectorEngine(b *testing.B, indexType string) *VectorEngineImpl {
 	b.Helper()

--- a/internal/storage/vector_storage_training_promotion_test.go
+++ b/internal/storage/vector_storage_training_promotion_test.go
@@ -1,0 +1,149 @@
+package storage
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/DataIntelligenceCrew/go-faiss"
+)
+
+func TestVectorTrainingIndexesPromoteFromFlat(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		indexDesc string
+	}{
+		{name: "IVF", indexDesc: "IVF32,Flat"},
+		{name: "PQ", indexDesc: "PQ4"},
+		{name: "IVF_PQ", indexDesc: "IVF32,PQ4"},
+		{name: "HNSW_PQ", indexDesc: "HNSW32,PQ4"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			ve, err := NewVectorEngine(
+				filepath.Join(dir, "vector_data.db"),
+				filepath.Join(dir, "vector_index.faiss"),
+				filepath.Join(dir, "vector_wal.db"),
+				8, test.indexDesc, faiss.MetricL2, false,
+			)
+			if err != nil {
+				t.Fatalf("NewVectorEngine failed: %v", err)
+			}
+			defer ve.Close()
+
+			count := ve.indexPromotionThreshold()
+			var query []float32
+			for id := 1; id <= count; id++ {
+				vector := deterministicTrainingVector(id, 8)
+				if id == count {
+					query = vector
+				}
+				if err := ve.InsertVector(int64(id), vector); err != nil {
+					t.Fatalf("InsertVector %d failed: %v", id, err)
+				}
+			}
+			if err := ve.FlushBatch(); err != nil {
+				t.Fatalf("FlushBatch failed: %v", err)
+			}
+			if err := ve.promoteConfiguredIndex(); err != nil {
+				t.Fatalf("promoteConfiguredIndex failed: %v", err)
+			}
+
+			ve.lock.RLock()
+			configured := ve.store.configured
+			trained := ve.store.index.IsTrained()
+			total := ve.store.index.Ntotal()
+			ve.lock.RUnlock()
+			if !configured {
+				t.Fatalf("%s index remained on Flat fallback", test.indexDesc)
+			}
+			if !trained {
+				t.Fatalf("%s index is not trained", test.indexDesc)
+			}
+			if total != int64(count) {
+				t.Fatalf("%s index contains %d vectors, want %d", test.indexDesc, total, count)
+			}
+
+			ids, _, err := ve.SearchTopK(query, 10)
+			if err != nil || len(ids) == 0 {
+				t.Fatalf("SearchTopK after promotion returned ids=%v err=%v", ids, err)
+			}
+		})
+	}
+}
+
+func TestVectorTrainingIndexPromotesInBackground(t *testing.T) {
+	dir := t.TempDir()
+	ve, err := NewVectorEngine(
+		filepath.Join(dir, "vector_data.db"),
+		filepath.Join(dir, "vector_index.faiss"),
+		filepath.Join(dir, "vector_wal.db"),
+		8, "IVF32,Flat", faiss.MetricL2, false,
+	)
+	if err != nil {
+		t.Fatalf("NewVectorEngine failed: %v", err)
+	}
+	defer ve.Close()
+
+	for id := 1; id <= ve.indexPromotionThreshold(); id++ {
+		if err := ve.InsertVector(int64(id), deterministicTrainingVector(id, 8)); err != nil {
+			t.Fatalf("InsertVector %d failed: %v", id, err)
+		}
+	}
+	if err := ve.FlushBatch(); err != nil {
+		t.Fatalf("FlushBatch failed: %v", err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		ve.lock.RLock()
+		configured := ve.store.configured
+		ve.lock.RUnlock()
+		if configured {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("IVF index was not promoted in the background")
+}
+
+func TestVectorTrainingIndexStaysFlatBelowThreshold(t *testing.T) {
+	dir := t.TempDir()
+	ve, err := NewVectorEngine(
+		filepath.Join(dir, "vector_data.db"),
+		filepath.Join(dir, "vector_index.faiss"),
+		filepath.Join(dir, "vector_wal.db"),
+		8, "IVF32,Flat", faiss.MetricL2, false,
+	)
+	if err != nil {
+		t.Fatalf("NewVectorEngine failed: %v", err)
+	}
+	defer ve.Close()
+
+	for id := 1; id <= 16; id++ {
+		if err := ve.InsertVector(int64(id), deterministicTrainingVector(id, 8)); err != nil {
+			t.Fatalf("InsertVector %d failed: %v", id, err)
+		}
+	}
+	if err := ve.FlushBatch(); err != nil {
+		t.Fatalf("FlushBatch failed: %v", err)
+	}
+	if err := ve.promoteConfiguredIndex(); err != nil {
+		t.Fatalf("promoteConfiguredIndex failed: %v", err)
+	}
+
+	ve.lock.RLock()
+	configured := ve.store.configured
+	ve.lock.RUnlock()
+	if configured {
+		t.Fatal("IVF index promoted before reaching its training threshold")
+	}
+}
+
+func deterministicTrainingVector(id, dimension int) []float32 {
+	vector := make([]float32, dimension)
+	for i := range vector {
+		vector[i] = float32((id*(i+3))%97) / 97
+	}
+	return vector
+}

--- a/internal/storage/vector_storage_training_promotion_test.go
+++ b/internal/storage/vector_storage_training_promotion_test.go
@@ -2,11 +2,25 @@ package storage
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/DataIntelligenceCrew/go-faiss"
 )
+
+func TestValidateVectorIndexConfigRejectsStandaloneIVF(t *testing.T) {
+	err := ValidateVectorIndexConfig(8, "IVF128", faiss.MetricL2)
+	if err == nil {
+		t.Fatal("ValidateVectorIndexConfig accepted standalone IVF128")
+	}
+	if !strings.Contains(err.Error(), `invalid FAISS index type "IVF128"`) {
+		t.Fatalf("unexpected validation error: %v", err)
+	}
+	if err := ValidateVectorIndexConfig(8, "IVF128,Flat", faiss.MetricL2); err != nil {
+		t.Fatalf("ValidateVectorIndexConfig rejected IVF128,Flat: %v", err)
+	}
+}
 
 func TestVectorTrainingIndexesPromoteFromFlat(t *testing.T) {
 	for _, test := range []struct {

--- a/main.go
+++ b/main.go
@@ -518,7 +518,7 @@ Space management
   create-space <name> [flags]     Create a space. Flags:
                                     --engine key-value|vector   (default: key-value)
                                     --dimension N               (required for vector spaces)
-                                    --index-type TYPE           (vector; e.g. Flat, HNSW32, IVF32, PQ8; default Flat)
+                                    --index-type TYPE           (vector; e.g. Flat, HNSW32, IVF32,Flat, PQ8; default Flat)
                                     --metric METRIC             (vector; L2, InnerProduct, L1, Linf, Lp,
                                                                  Canberra, BrayCurtis, JensenShannon; default L2)
                                     --enable-wal | --disable-wal (default: disabled)


### PR DESCRIPTION
## Description

Fixes a bug where training-based FAISS indexes—IVF, PQ, IVF+PQ, and HNSW+PQ—continued using the temporary Flat fallback and never activated their configured index.

This change:

- Keeps searches available through Flat while vectors are being collected.
- Trains the configured index asynchronously after 10,000 vectors are flushed.
- Waits for a short ingest-quiet period before training.
- Atomically replaces Flat with the trained index without search downtime.
- Discards and retries stale training results when the data file changes during training.
- Correctly detects that HNSW+PQ composite indexes require training.
- Preserves batched inserts and search visibility during index training.
- Documents the new automatic training lifecycle.

Fixes #<issue-number>

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?

The following tests were run locally:

```bash
go test ./internal/storage -count=1
go test -race ./internal/storage -run 'TestVectorTrainingIndex' -count=1
go test ./internal/queryengine ./internal/spaces -count=1
git diff --check
```

Test coverage includes:

- IVF promotion from Flat to the configured index.
- PQ promotion from Flat to the configured index.
- IVF+PQ composite promotion.
- HNSW+PQ composite promotion.
- Automatic background promotion.
- Remaining on Flat below the training threshold.
- Searching successfully after promotion.
- Concurrent promotion behavior under the race detector.
- Existing storage, query-engine, and space-manager behavior.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] No dependent downstream changes are required

## Additional Notes

Search remains available throughout the complete lifecycle:

1. Training-based indexes initially use Flat.
2. Inserts continue through the existing buffered batch-flush path.
3. After 10,000 flushed vectors and a short quiet period, the configured index is trained in the background.
4. Searches continue using Flat while training runs.
5. The trained index is installed atomically.
6. If the data file changes during training, the stale result is discarded and training is retried.