### PR TITLE
[SDB-20] Added logging levels

### DIFF
--- a/cmd/server/management.go
+++ b/cmd/server/management.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/shibudb.org/shibudb-server/internal/auth"
+	"github.com/shibudb.org/shibudb-server/internal/logger"
 	"github.com/shibudb.org/shibudb-server/internal/spaces"
 	"github.com/shibudb.org/shibudb-server/internal/storage"
 )
@@ -47,6 +48,7 @@ func NewManagementServer(connManager *ConnectionManager, spaceManager *spaces.Sp
 	mux.HandleFunc("/limit/increase", ms.increaseLimitHandler)
 	mux.HandleFunc("/limit/decrease", ms.decreaseLimitHandler)
 	mux.HandleFunc("/spaces/settings", ms.spaceSettingsHandler)
+	mux.HandleFunc("/loglevel", ms.logLevelHandler)
 	mux.Handle("/debug/pprof/", authorized(pprof.Index))
 	mux.Handle("/debug/pprof/cmdline", authorized(pprof.Cmdline))
 	mux.Handle("/debug/pprof/profile", authorized(pprof.Profile))
@@ -63,7 +65,7 @@ func NewManagementServer(connManager *ConnectionManager, spaceManager *spaces.Sp
 
 // Start starts the management server
 func (ms *ManagementServer) Start() error {
-	fmt.Printf("Management server started on port %s\n", ms.port)
+	logger.Infof("management", "Management server started on port %s", ms.port)
 	return ms.server.ListenAndServe()
 }
 
@@ -315,6 +317,60 @@ func (ms *ManagementServer) spaceSettingsHandler(w http.ResponseWriter, r *http.
 		"max_segments_before_merge": meta.MaxSegmentsBeforeMerge,
 		"message":                   fmt.Sprintf("Updated space settings for %s", request.Space),
 	})
+}
+
+// logLevelHandler handles GET (current level) and PUT (update level) requests
+func (ms *ManagementServer) logLevelHandler(w http.ResponseWriter, r *http.Request) {
+	if !ms.authorizeRequest(w, r) {
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+
+	switch r.Method {
+	case http.MethodGet:
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"level": strings.ToLower(logger.GetLevel().String()),
+		})
+
+	case http.MethodPut:
+		var request struct {
+			Level string `json:"level"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			http.Error(w, "Invalid JSON", http.StatusBadRequest)
+			return
+		}
+
+		level, err := logger.ParseLevel(request.Level)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"status": "failed",
+				"error":  err.Error(),
+			})
+			return
+		}
+
+		oldLevel := logger.GetLevel()
+		// Log before applying so the change is recorded under the level that
+		// was active when the admin issued it.
+		logger.Infof("management", "Log level changed from %s to %s", oldLevel, level)
+		logger.SetLevel(level)
+
+		if err := SaveLogLevel(ms.connManager.dataDir, level); err != nil {
+			logger.Warnf("management", "Failed to persist log level: %v", err)
+		}
+
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"status":    "success",
+			"old_level": strings.ToLower(oldLevel.String()),
+			"new_level": strings.ToLower(level.String()),
+			"message":   fmt.Sprintf("Log level updated from %s to %s", oldLevel, level),
+		})
+
+	default:
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
 }
 
 func (ms *ManagementServer) authorizeRequest(w http.ResponseWriter, r *http.Request) bool {

--- a/cmd/server/persistence.go
+++ b/cmd/server/persistence.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/shibudb.org/shibudb-server/internal/logger"
 )
 
 // ConnectionConfig stores persistent connection settings
@@ -35,7 +37,7 @@ func SaveConnectionLimit(dataDir string, limit int32) error {
 		return fmt.Errorf("failed to write config file: %v", err)
 	}
 
-	fmt.Printf("Connection limit saved to: %s\n", cfgFile)
+	logger.Infof("server", "Connection limit saved to: %s", cfgFile)
 	return nil
 }
 
@@ -60,6 +62,55 @@ func LoadConnectionLimit(dataDir string) (int32, error) {
 	return config.MaxConnections, nil
 }
 
+// LogLevelConfig stores the persisted log level.
+type LogLevelConfig struct {
+	Level       string `json:"level"`
+	LastUpdated string `json:"last_updated"`
+}
+
+// SaveLogLevel persists the log level to disk under dataDir.
+func SaveLogLevel(dataDir string, level logger.Level) error {
+	if err := os.MkdirAll(dataDir, 0755); err != nil {
+		return fmt.Errorf("failed to create config directory: %v", err)
+	}
+
+	cfgFile := filepath.Join(dataDir, "log_level.json")
+	config := LogLevelConfig{
+		Level:       level.String(),
+		LastUpdated: fmt.Sprintf("%d", time.Now().Unix()),
+	}
+
+	data, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal log level config: %v", err)
+	}
+
+	if err := os.WriteFile(cfgFile, data, 0644); err != nil {
+		return fmt.Errorf("failed to write log level config: %v", err)
+	}
+	return nil
+}
+
+// LoadLogLevel loads the persisted log level from dataDir. If log_level.json
+// is missing, it returns an error for which os.IsNotExist(err) is true.
+func LoadLogLevel(dataDir string) (logger.Level, error) {
+	cfgFile := filepath.Join(dataDir, "log_level.json")
+	data, err := os.ReadFile(cfgFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return logger.LevelInfo, err
+		}
+		return logger.LevelInfo, fmt.Errorf("failed to read log level config: %v", err)
+	}
+
+	var config LogLevelConfig
+	if err := json.Unmarshal(data, &config); err != nil {
+		return logger.LevelInfo, fmt.Errorf("failed to parse log level config: %v", err)
+	}
+
+	return logger.ParseLevel(config.Level)
+}
+
 // GetPersistentLimit returns the limit to use, preferring the persisted value over defaultLimit.
 func GetPersistentLimit(dataDir string, defaultLimit int32) int32 {
 	persistedLimit, err := LoadConnectionLimit(dataDir)
@@ -67,13 +118,12 @@ func GetPersistentLimit(dataDir string, defaultLimit int32) int32 {
 		if os.IsNotExist(err) {
 			return defaultLimit
 		}
-		fmt.Printf("Warning: Failed to load persisted limit: %v\n", err)
-		fmt.Printf("Using default limit: %d\n", defaultLimit)
+		logger.Warnf("server", "Failed to load persisted limit: %v; using default limit: %d", err, defaultLimit)
 		return defaultLimit
 	}
 
 	if persistedLimit > 0 {
-		fmt.Printf("Loaded persisted connection limit: %d\n", persistedLimit)
+		logger.Infof("server", "Loaded persisted connection limit: %d", persistedLimit)
 		return persistedLimit
 	}
 

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/shibudb.org/shibudb-server/internal/auth"
+	"github.com/shibudb.org/shibudb-server/internal/logger"
 	"github.com/shibudb.org/shibudb-server/internal/models"
 	"github.com/shibudb.org/shibudb-server/internal/queryengine"
 	"github.com/shibudb.org/shibudb-server/internal/spaces"
@@ -94,11 +95,11 @@ func (cm *ConnectionManager) updateLimit(newLimit int32) {
 	// Replace old semaphore
 	cm.semaphore = newSemaphore
 
-	fmt.Printf("Connection limit updated: %d -> %d (active: %d)\n", oldLimit, newLimit, active)
+	logger.Infof("server", "Connection limit updated: %d -> %d (active: %d)", oldLimit, newLimit, active)
 
 	// Save the new limit persistently
 	if err := SaveConnectionLimit(cm.dataDir, newLimit); err != nil {
-		fmt.Printf("Warning: Failed to save connection limit: %v\n", err)
+		logger.Warnf("server", "Failed to save connection limit: %v", err)
 	}
 }
 
@@ -254,10 +255,25 @@ func StartServer(port string, authFilePath string, maxConnections int32, dataFol
 	if port == managementPort {
 		panic(fmt.Sprintf("client port and management port must differ (both are %s)", port))
 	}
+
+	// Start the buffered logging goroutine (flushes to stdout every 100ms;
+	// `shibudb start` redirects stdout to shibudb.log).
+	logger.Init(os.Stdout)
+	defer logger.Shutdown()
+
+	// Restore the persisted log level, if any. Log before applying so the
+	// message is visible even when the persisted level filters INFO.
+	if level, err := LoadLogLevel(dataFolderPath); err == nil {
+		logger.Infof("server", "Using persisted log level: %s", level)
+		logger.SetLevel(level)
+	} else if !os.IsNotExist(err) {
+		logger.Warnf("server", "Failed to load persisted log level: %v", err)
+	}
+
 	spaceRestoreStartedAt := time.Now()
-	fmt.Printf("Loading spaces and indexes from %s before opening network listeners...\n", dataFolderPath)
+	logger.Infof("server", "Loading spaces and indexes from %s before opening network listeners...", dataFolderPath)
 	spaceManager := spaces.NewSpaceManager(dataFolderPath)
-	fmt.Printf("Finished loading spaces in %s. Opening management and client listeners...\n", formatStartupDuration(time.Since(spaceRestoreStartedAt)))
+	logger.Infof("server", "Finished loading spaces in %s. Opening management and client listeners...", formatStartupDuration(time.Since(spaceRestoreStartedAt)))
 	defer spaceManager.CloseAll()
 
 	authManager, err := auth.NewAuthManager(authFilePath)
@@ -273,14 +289,14 @@ func StartServer(port string, authFilePath string, maxConnections int32, dataFol
 	persistentLimit := GetPersistentLimit(dataFolderPath, maxConnections)
 	actualLimit := maxConnections
 	if persistentLimit != maxConnections {
-		fmt.Printf("Using persisted connection limit: %d (instead of %d)\n", persistentLimit, maxConnections)
+		logger.Infof("server", "Using persisted connection limit: %d (instead of %d)", persistentLimit, maxConnections)
 		actualLimit = persistentLimit
 	}
 
 	// No connection_limit.json yet: persist the limit we are using (from CLI/default or from file above).
 	if _, loadErr := LoadConnectionLimit(dataFolderPath); loadErr != nil && os.IsNotExist(loadErr) {
 		if saveErr := SaveConnectionLimit(dataFolderPath, actualLimit); saveErr != nil {
-			fmt.Printf("Warning: Failed to save connection limit: %v\n", saveErr)
+			logger.Warnf("server", "Failed to save connection limit: %v", saveErr)
 		}
 	}
 
@@ -296,9 +312,9 @@ func StartServer(port string, authFilePath string, maxConnections int32, dataFol
 
 	managementServer := NewManagementServer(connManager, spaceManager, tokenManager, managementPort)
 	go func() {
-		fmt.Printf("Starting management server on port %s...\n", managementPort)
+		logger.Infof("management", "Starting management server on port %s...", managementPort)
 		if err := managementServer.Start(); err != nil {
-			fmt.Printf("Management server error: %v\n", err)
+			logger.Errorf("management", "Management server error: %v", err)
 		}
 	}()
 
@@ -311,26 +327,31 @@ func StartServer(port string, authFilePath string, maxConnections int32, dataFol
 	}
 	defer listener.Close()
 
+	// Flush buffered startup logs, then emit the readiness line directly to
+	// stdout (bypassing level filtering): `shibudb start` scans the log file
+	// for this exact line to detect that the server is ready, so it must be
+	// written regardless of the configured log level.
+	logger.Flush()
 	fmt.Printf("ShibuDB server started on port %s (max connections: %d)\n", port, actualLimit)
-	fmt.Printf("Management server started on port %s\n", managementPort)
-	fmt.Printf("Runtime limit updates: SIGUSR1 (increase by 100), SIGUSR2 (decrease by 100)\n")
-	fmt.Printf("HTTP management: GET/PUT http://localhost:%s/limit (Authorization: Bearer <token> required)\n", managementPort)
+
+	logger.Infof("server", "Runtime limit updates: SIGUSR1 (increase by 100), SIGUSR2 (decrease by 100)")
+	logger.Infof("server", "HTTP management: GET/PUT http://localhost:%s/limit (Authorization: Bearer <token> required)", managementPort)
 
 	// Show persistence status if different from default
 	if actualLimit != maxConnections {
-		fmt.Printf("Using persisted connection limit: %d (saved from previous session)\n", actualLimit)
+		logger.Infof("server", "Using persisted connection limit: %d (saved from previous session)", actualLimit)
 	}
 
 	for {
 		conn, err := listener.Accept()
 		if err != nil {
-			fmt.Printf("Failed to accept client: %v\n", err)
+			logger.Errorf("server", "Failed to accept client: %v", err)
 			continue
 		}
 
 		// Check connection limit
 		if !connManager.TryAcquire(conn) {
-			fmt.Printf("Connection limit reached (%d/%d). Rejecting connection from %s\n",
+			logger.Warnf("server", "Connection limit reached (%d/%d). Rejecting connection from %s",
 				connManager.GetActiveConnections(), connManager.GetMaxConnections(), conn.RemoteAddr())
 
 			// Send rejection message to client
@@ -344,7 +365,7 @@ func StartServer(port string, authFilePath string, maxConnections int32, dataFol
 			continue
 		}
 
-		fmt.Printf("New connection from %s (active: %d/%d)\n",
+		logger.Debugf("server", "New connection from %s (active: %d/%d)",
 			conn.RemoteAddr(), connManager.GetActiveConnections(), connManager.GetMaxConnections())
 
 		go handleConnectionWithManager(conn, spaceManager, authManager, connManager)
@@ -364,21 +385,21 @@ func handleSignals(cm *ConnectionManager) {
 		case syscall.SIGUSR1:
 			// Increase limit by 100
 			newLimit = currentLimit + 100
-			fmt.Printf("Received SIGUSR1: Increasing connection limit from %d to %d\n", currentLimit, newLimit)
+			logger.Infof("server", "Received SIGUSR1: Increasing connection limit from %d to %d", currentLimit, newLimit)
 		case syscall.SIGUSR2:
 			// Decrease limit by 100, but not below current active connections
 			active := cm.GetActiveConnections()
 			newLimit = currentLimit - 100
 			if newLimit < active {
 				newLimit = active
-				fmt.Printf("Received SIGUSR2: Cannot decrease below active connections (%d), keeping limit at %d\n", active, currentLimit)
+				logger.Warnf("server", "Received SIGUSR2: Cannot decrease below active connections (%d), keeping limit at %d", active, currentLimit)
 				continue
 			}
-			fmt.Printf("Received SIGUSR2: Decreasing connection limit from %d to %d\n", currentLimit, newLimit)
+			logger.Infof("server", "Received SIGUSR2: Decreasing connection limit from %d to %d", currentLimit, newLimit)
 		}
 
 		if err := cm.UpdateLimit(newLimit); err != nil {
-			fmt.Printf("Failed to update connection limit: %v\n", err)
+			logger.Errorf("server", "Failed to update connection limit: %v", err)
 		}
 	}
 }
@@ -395,9 +416,9 @@ func monitorConnections(cm *ConnectionManager) {
 		usage := stats["usage_percentage"].(float64)
 
 		if usage > 80 {
-			fmt.Printf("WARNING: High connection usage: %d/%d (%.1f%%)\n", active, max, usage)
+			logger.Warnf("server", "High connection usage: %d/%d (%.1f%%)", active, max, usage)
 		} else {
-			fmt.Printf("Connection status: %d/%d (%.1f%%)\n", active, max, usage)
+			logger.Debugf("server", "Connection status: %d/%d (%.1f%%)", active, max, usage)
 		}
 	}
 }
@@ -413,7 +434,7 @@ func handleConnectionWithManager(conn net.Conn, spaceManager *spaces.SpaceManage
 	defer func() {
 		conn.Close()
 		connManager.Release(conn)
-		fmt.Printf("Connection closed from %s (active: %d/%d)\n",
+		logger.Debugf("server", "Connection closed from %s (active: %d/%d)",
 			conn.RemoteAddr(), connManager.GetActiveConnections(), connManager.GetMaxConnections())
 	}()
 

--- a/docs/ADMINISTRATION.md
+++ b/docs/ADMINISTRATION.md
@@ -38,6 +38,7 @@ ShibuDb stores runtime files under a single data directory root:
     users.json
     management_tokens.json
     connection_limit.json
+    log_level.json
     <space>/
       space.meta.json
       data.db / wal.db / index.dat                 (key-value)
@@ -50,6 +51,7 @@ ShibuDb stores runtime files under a single data directory root:
 
 Notes:
 - `connection_limit.json` is used to persist the last saved connection limit across restarts.
+- `log_level.json` is used to persist the server log level across restarts.
 - Each space has its own directory under `lib/`.
 
 ## Management API (connection limits + space settings)
@@ -92,6 +94,15 @@ curl -X PUT http://localhost:5444/limit \
   -H "Authorization: Bearer <token>" \
   -H "Content-Type: application/json" \
   -d '{"limit": 2000}'
+
+# Get current log level
+curl http://localhost:5444/loglevel -H "Authorization: Bearer <token>"
+
+# Set log level (debug, info, warn, error)
+curl -X PUT http://localhost:5444/loglevel \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"level": "warn"}'
 ```
 
 ### CLI management (recommended)
@@ -105,7 +116,36 @@ shibudb manager --username <admin> --password <pass> limit 2000
 shibudb manager --username <admin> --password <pass> increase 500
 shibudb manager --username <admin> --password <pass> decrease 200
 shibudb manager --username <admin> --password <pass> health
+shibudb manager --username <admin> --password <pass> log-level        # show current level
+shibudb manager --username <admin> --password <pass> log-level warn   # set level
 ```
+
+## Logging
+
+The server writes structured, leveled log lines to `<data-dir>/log/shibudb.log`
+(when started via `shibudb start`; `shibudb run` logs to the terminal). Log
+calls are buffered in memory and flushed to the log file every 100ms by a
+background goroutine.
+
+Line format:
+
+```text
+2026-08-09T18:30:19.508+05:30 [INFO ] [server] ShibuDB server started on port 4444
+```
+
+Levels: `debug`, `info`, `warn`, `error`. Setting a level enables it and
+everything above it — `info` enables info/warn/error, `warn` enables
+warn/error, `error` enables only errors, and `debug` enables everything
+(including per-query and per-connection logs).
+
+The level can be changed at runtime without a restart:
+
+```bash
+shibudb manager --username <admin> --password <pass> log-level warn
+```
+
+The level is persisted to `<data-dir>/lib/log_level.json` and restored on the
+next server start. The default level is `info`.
 
 ### Space settings updates
 

--- a/internal/auth/manager.go
+++ b/internal/auth/manager.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sync"
 
+	"github.com/shibudb.org/shibudb-server/internal/logger"
 	"github.com/shibudb.org/shibudb-server/internal/models"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -176,7 +177,7 @@ func (a *AuthManager) HasRole(user models.User, space string, required string) b
 }
 
 func (a *AuthManager) CreateUser(username, password, role string, perms map[string]string) error {
-	fmt.Println("Creating user", username, role, perms)
+	logger.Infof("auth", "Creating user %s (role: %s, permissions: %v)", username, role, perms)
 	a.lock.Lock()
 	defer a.lock.Unlock()
 
@@ -200,7 +201,7 @@ func (a *AuthManager) CreateUser(username, password, role string, perms map[stri
 }
 
 func (a *AuthManager) UpdateUserPassword(username string, password string) error {
-	fmt.Println("Updating user password", username)
+	logger.Infof("auth", "Updating user password: %s", username)
 	a.lock.Lock()
 	defer a.lock.Unlock()
 
@@ -226,7 +227,7 @@ func (a *AuthManager) UpdateUserPassword(username string, password string) error
 }
 
 func (a *AuthManager) UpdateUserRole(username string, role string) error {
-	fmt.Println("Updating user role", username, role)
+	logger.Infof("auth", "Updating user role: %s -> %s", username, role)
 	a.lock.Lock()
 	defer a.lock.Unlock()
 
@@ -247,7 +248,7 @@ func (a *AuthManager) UpdateUserRole(username string, role string) error {
 }
 
 func (a *AuthManager) UpdateUserPermissions(username string, perms map[string]string) error {
-	fmt.Println("Updating user permissions", username)
+	logger.Infof("auth", "Updating user permissions: %s", username)
 	a.lock.Lock()
 	defer a.lock.Unlock()
 
@@ -268,7 +269,7 @@ func (a *AuthManager) UpdateUserPermissions(username string, perms map[string]st
 }
 
 func (a *AuthManager) DeleteUser(username string) error {
-	fmt.Println("Deleting user", username)
+	logger.Infof("auth", "Deleting user: %s", username)
 	a.lock.Lock()
 	defer a.lock.Unlock()
 

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,264 @@
+// Package logger provides leveled, buffered, asynchronous logging for the
+// ShibuDB server. Log calls append formatted lines to an in-memory buffer;
+// a background goroutine (started on server start via Init) flushes the
+// buffer to the output every 100ms. The active level can be changed at
+// runtime (e.g. from `shibudb manager log-level`).
+package logger
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Level represents a log severity level. Setting a level enables it and
+// everything above it: DEBUG enables all logs, ERROR enables only errors.
+type Level int32
+
+const (
+	LevelDebug Level = iota
+	LevelInfo
+	LevelWarn
+	LevelError
+)
+
+func (l Level) String() string {
+	switch l {
+	case LevelDebug:
+		return "DEBUG"
+	case LevelInfo:
+		return "INFO"
+	case LevelWarn:
+		return "WARN"
+	case LevelError:
+		return "ERROR"
+	default:
+		return fmt.Sprintf("LEVEL(%d)", int32(l))
+	}
+}
+
+// ParseLevel converts a case-insensitive level name into a Level.
+func ParseLevel(s string) (Level, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "debug":
+		return LevelDebug, nil
+	case "info":
+		return LevelInfo, nil
+	case "warn", "warning":
+		return LevelWarn, nil
+	case "error":
+		return LevelError, nil
+	default:
+		return LevelInfo, fmt.Errorf("unknown log level %q (valid: debug, info, warn, error)", s)
+	}
+}
+
+const (
+	// flushInterval is how often the background goroutine flushes the buffer.
+	flushInterval = 100 * time.Millisecond
+	// maxBufferBytes forces an immediate flush if pending logs grow beyond
+	// this size between ticks, so a burst of logging cannot grow memory
+	// unboundedly.
+	maxBufferBytes = 256 * 1024
+)
+
+// Logger is a leveled logger that buffers formatted lines in memory and
+// flushes them to out on a fixed interval once Start is called. Before
+// Start (e.g. in tests or CLI paths), writes are synchronous.
+type Logger struct {
+	level atomic.Int32
+
+	mu      sync.Mutex
+	out     io.Writer
+	buf     []byte
+	started bool
+	stopCh  chan struct{}
+	doneCh  chan struct{}
+}
+
+// New creates a Logger writing to out at LevelInfo, in synchronous mode.
+// Call Start to enable buffered asynchronous flushing.
+func New(out io.Writer) *Logger {
+	l := &Logger{out: out}
+	l.level.Store(int32(LevelInfo))
+	return l
+}
+
+// SetLevel changes the minimum enabled level at runtime.
+func (l *Logger) SetLevel(level Level) {
+	l.level.Store(int32(level))
+}
+
+// GetLevel returns the current minimum enabled level.
+func (l *Logger) GetLevel() Level {
+	return Level(l.level.Load())
+}
+
+// SetOutput replaces the destination writer.
+func (l *Logger) SetOutput(out io.Writer) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.out = out
+}
+
+// Start launches the background flush goroutine. It is a no-op if the
+// logger is already started.
+func (l *Logger) Start() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.started {
+		return
+	}
+	l.started = true
+	l.stopCh = make(chan struct{})
+	l.doneCh = make(chan struct{})
+	go l.flushLoop(l.stopCh, l.doneCh)
+}
+
+// Stop terminates the background goroutine and flushes any pending lines.
+// The logger falls back to synchronous mode afterwards.
+func (l *Logger) Stop() {
+	l.mu.Lock()
+	if !l.started {
+		l.mu.Unlock()
+		return
+	}
+	l.started = false
+	stopCh, doneCh := l.stopCh, l.doneCh
+	l.mu.Unlock()
+
+	close(stopCh)
+	<-doneCh
+	l.Flush()
+}
+
+func (l *Logger) flushLoop(stopCh, doneCh chan struct{}) {
+	defer close(doneCh)
+	ticker := time.NewTicker(flushInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			l.Flush()
+		case <-stopCh:
+			return
+		}
+	}
+}
+
+// Flush writes all buffered lines to the output.
+func (l *Logger) Flush() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.flushLocked()
+}
+
+func (l *Logger) flushLocked() {
+	if len(l.buf) == 0 {
+		return
+	}
+	_, _ = l.out.Write(l.buf)
+	l.buf = l.buf[:0]
+}
+
+func (l *Logger) logf(level Level, component, format string, args ...interface{}) {
+	if level < l.GetLevel() {
+		return
+	}
+	ts := time.Now().Format("2006-01-02T15:04:05.000Z07:00")
+	line := fmt.Sprintf("%s [%-5s] [%s] %s\n", ts, level, component, fmt.Sprintf(format, args...))
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if !l.started {
+		_, _ = l.out.Write([]byte(line))
+		return
+	}
+	l.buf = append(l.buf, line...)
+	if len(l.buf) >= maxBufferBytes {
+		l.flushLocked()
+	}
+}
+
+// Debugf logs at DEBUG level.
+func (l *Logger) Debugf(component, format string, args ...interface{}) {
+	l.logf(LevelDebug, component, format, args...)
+}
+
+// Infof logs at INFO level.
+func (l *Logger) Infof(component, format string, args ...interface{}) {
+	l.logf(LevelInfo, component, format, args...)
+}
+
+// Warnf logs at WARN level.
+func (l *Logger) Warnf(component, format string, args ...interface{}) {
+	l.logf(LevelWarn, component, format, args...)
+}
+
+// Errorf logs at ERROR level.
+func (l *Logger) Errorf(component, format string, args ...interface{}) {
+	l.logf(LevelError, component, format, args...)
+}
+
+// std is the process-wide logger used by the package-level functions.
+// It writes synchronously to stdout until Init is called.
+var std = New(os.Stdout)
+
+// Init points the global logger at out and starts the background flush
+// goroutine. Call this once on server start.
+func Init(out io.Writer) {
+	std.SetOutput(out)
+	std.Start()
+}
+
+// Shutdown stops the background goroutine and flushes pending logs.
+func Shutdown() {
+	std.Stop()
+}
+
+// SetLevel changes the global logger's minimum enabled level.
+func SetLevel(level Level) {
+	std.SetLevel(level)
+}
+
+// GetLevel returns the global logger's minimum enabled level.
+func GetLevel() Level {
+	return std.GetLevel()
+}
+
+// Flush writes any buffered lines of the global logger to its output.
+func Flush() {
+	std.Flush()
+}
+
+// Debugf logs at DEBUG level to the global logger.
+func Debugf(component, format string, args ...interface{}) {
+	std.Debugf(component, format, args...)
+}
+
+// Infof logs at INFO level to the global logger.
+func Infof(component, format string, args ...interface{}) {
+	std.Infof(component, format, args...)
+}
+
+// Warnf logs at WARN level to the global logger.
+func Warnf(component, format string, args ...interface{}) {
+	std.Warnf(component, format, args...)
+}
+
+// Errorf logs at ERROR level to the global logger.
+func Errorf(component, format string, args ...interface{}) {
+	std.Errorf(component, format, args...)
+}
+
+// Fatalf logs at ERROR level, flushes all pending logs, and exits the
+// process with status 1.
+func Fatalf(component, format string, args ...interface{}) {
+	std.Errorf(component, format, args...)
+	std.Flush()
+	os.Exit(1)
+}

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -1,0 +1,111 @@
+package logger
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// syncBuffer is a goroutine-safe bytes.Buffer for capturing log output.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func TestLevelFiltering(t *testing.T) {
+	var out syncBuffer
+	l := New(&out)
+
+	l.SetLevel(LevelWarn)
+	l.Debugf("test", "debug message")
+	l.Infof("test", "info message")
+	l.Warnf("test", "warn message")
+	l.Errorf("test", "error message")
+
+	got := out.String()
+	if strings.Contains(got, "debug message") || strings.Contains(got, "info message") {
+		t.Fatalf("expected debug/info to be filtered at WARN level, got:\n%s", got)
+	}
+	if !strings.Contains(got, "warn message") || !strings.Contains(got, "error message") {
+		t.Fatalf("expected warn/error to be logged at WARN level, got:\n%s", got)
+	}
+}
+
+func TestAsyncFlush(t *testing.T) {
+	var out syncBuffer
+	l := New(&out)
+	l.Start()
+	defer l.Stop()
+
+	l.Infof("test", "buffered message %d", 42)
+
+	// Nothing should be written synchronously in async mode.
+	if got := out.String(); got != "" {
+		t.Fatalf("expected empty output before flush tick, got: %q", got)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.Contains(out.String(), "buffered message 42") {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("message was not flushed within deadline, output: %q", out.String())
+}
+
+func TestStopFlushesPending(t *testing.T) {
+	var out syncBuffer
+	l := New(&out)
+	l.Start()
+	l.Infof("test", "pending message")
+	l.Stop()
+
+	if !strings.Contains(out.String(), "pending message") {
+		t.Fatalf("expected Stop to flush pending logs, got: %q", out.String())
+	}
+}
+
+func TestLineFormat(t *testing.T) {
+	var out syncBuffer
+	l := New(&out)
+	l.Infof("server", "hello %s", "world")
+
+	got := out.String()
+	if !strings.Contains(got, "[INFO ]") || !strings.Contains(got, "[server]") || !strings.Contains(got, "hello world") {
+		t.Fatalf("unexpected line format: %q", got)
+	}
+}
+
+func TestParseLevel(t *testing.T) {
+	cases := map[string]Level{
+		"debug":   LevelDebug,
+		"INFO":    LevelInfo,
+		"Warn":    LevelWarn,
+		"warning": LevelWarn,
+		"error":   LevelError,
+	}
+	for in, want := range cases {
+		got, err := ParseLevel(in)
+		if err != nil || got != want {
+			t.Fatalf("ParseLevel(%q) = %v, %v; want %v", in, got, err, want)
+		}
+	}
+	if _, err := ParseLevel("bogus"); err == nil {
+		t.Fatal("expected error for invalid level")
+	}
+}

--- a/internal/maintenance/scheduler.go
+++ b/internal/maintenance/scheduler.go
@@ -2,11 +2,12 @@ package maintenance
 
 import (
 	"container/heap"
-	"log"
 	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/shibudb.org/shibudb-server/internal/logger"
 )
 
 // Job is a recurring maintenance operation registered with a Scheduler.
@@ -214,7 +215,7 @@ var (
 func Default() *Scheduler {
 	defaultOnce.Do(func() {
 		defaultSched = New()
-		log.Printf("[maintenance] scheduler started with %d workers", runtime.NumCPU())
+		logger.Infof("maintenance", "scheduler started with %d workers", runtime.NumCPU())
 	})
 	return defaultSched
 }

--- a/internal/queryengine/query_engine.go
+++ b/internal/queryengine/query_engine.go
@@ -4,10 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/shibudb.org/shibudb-server/internal/auth"
+	"github.com/shibudb.org/shibudb-server/internal/logger"
 	"github.com/shibudb.org/shibudb-server/internal/models"
 	"github.com/shibudb.org/shibudb-server/internal/spaces"
 	"github.com/shibudb.org/shibudb-server/internal/storage"
@@ -36,6 +36,14 @@ func NewQueryEngine(spaceManager *spaces.SpaceManager, authManager AuthManagerIf
 	}
 }
 
+// usernameOf returns just the username for logging, never credentials.
+func usernameOf(u *models.User) string {
+	if u == nil {
+		return "<nil>"
+	}
+	return u.Username
+}
+
 func getUserResponse(u *models.User) string {
 	if u == nil {
 		return "User: <nil>"
@@ -56,7 +64,7 @@ func getUserResponse(u *models.User) string {
 }
 
 func (qe *QueryEngine) Execute(query models.Query) (string, error) {
-	log.Println("Query:", query.Type)
+	logger.Debugf("query", "Executing query: %s", query.Type)
 
 	switch query.Type {
 	case models.TypeGetUser:
@@ -99,7 +107,7 @@ func (qe *QueryEngine) Execute(query models.Query) (string, error) {
 		}
 		return string(data), nil
 	case models.TypeCreateUser:
-		log.Println("Creating user:", query)
+		logger.Infof("query", "Creating user: %s", usernameOf(query.NewUser))
 		if query.User == "" {
 			return "", errors.New("unauthenticated")
 		}
@@ -116,7 +124,7 @@ func (qe *QueryEngine) Execute(query models.Query) (string, error) {
 		}
 		return "USER_CREATED", nil
 	case models.TypeUpdateUserPassword:
-		log.Println("Updating user password:", query.NewUser)
+		logger.Infof("query", "Updating user password: %s", usernameOf(query.NewUser))
 		if query.User == "" {
 			return "", errors.New("unauthenticated")
 		}
@@ -133,7 +141,7 @@ func (qe *QueryEngine) Execute(query models.Query) (string, error) {
 		}
 		return "USER_PASSWORD_UPDATED", nil
 	case models.TypeUpdateUserRole:
-		log.Println("Updating user role:", query.NewUser)
+		logger.Infof("query", "Updating user role: %s", usernameOf(query.NewUser))
 		if query.User == "" {
 			return "", errors.New("unauthenticated")
 		}
@@ -150,7 +158,7 @@ func (qe *QueryEngine) Execute(query models.Query) (string, error) {
 		}
 		return "USER_ROLE_UPDATED", nil
 	case models.TypeUpdateUserPermissions:
-		log.Println("Updating user permissions:", query.NewUser)
+		logger.Infof("query", "Updating user permissions: %s", usernameOf(query.NewUser))
 		if query.User == "" {
 			return "", errors.New("unauthenticated")
 		}
@@ -167,7 +175,7 @@ func (qe *QueryEngine) Execute(query models.Query) (string, error) {
 		}
 		return "USER_ROLE_UPDATED", nil
 	case models.TypeDeleteUser:
-		log.Println("Deleting user:", query.DeleteUser)
+		logger.Infof("query", "Deleting user: %s", usernameOf(query.DeleteUser))
 		if query.User == "" {
 			return "", errors.New("unauthenticated")
 		}

--- a/internal/spaces/space_manager.go
+++ b/internal/spaces/space_manager.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/shibudb.org/shibudb-server/internal/logger"
 	"github.com/shibudb.org/shibudb-server/internal/storage"
 
 	"github.com/DataIntelligenceCrew/go-faiss"
@@ -165,7 +166,7 @@ func NewSpaceManager(basePath string) *SpaceManager {
 		return rewriteManifest(manager.manifestFilePath, spaces)
 	}
 	if err := manager.loadSpaceMetas(); err != nil {
-		fmt.Printf("Warning: failed to load space metadata: %v\n", err)
+		logger.Warnf("spaces", "failed to load space metadata: %v", err)
 	}
 	return manager
 }
@@ -189,7 +190,7 @@ func (sm *SpaceManager) loadCurrentSpaceCatalog() (bool, error) {
 
 	manifestSpaces, manifestExists, manifestErr := sm.readManifestSpaces()
 	if manifestErr != nil {
-		fmt.Printf("Warning: failed to read %s: %v\n", sm.manifestFilePath, manifestErr)
+		logger.Warnf("spaces", "failed to read %s: %v", sm.manifestFilePath, manifestErr)
 	}
 
 	if !manifestExists && len(discovered) == 0 {
@@ -200,7 +201,7 @@ func (sm *SpaceManager) loadCurrentSpaceCatalog() (bool, error) {
 	startedAt := time.Now()
 	lastLogAt := startedAt
 	if len(names) > 0 {
-		fmt.Printf("Restoring %d spaces from %s before accepting client connections...\n", len(names), sm.baseDir)
+		logger.Infof("spaces", "Restoring %d spaces from %s before accepting client connections...", len(names), sm.baseDir)
 	}
 
 	validSpaces := make(map[string]struct{}, len(discovered))
@@ -208,13 +209,13 @@ func (sm *SpaceManager) loadCurrentSpaceCatalog() (bool, error) {
 	for idx, name := range names {
 		meta, err := sm.readSpaceMetaFile(filepath.Join(sm.baseDir, name, spaceMetaFileName))
 		if err != nil {
-			fmt.Printf("Warning: skipping space %q due to invalid metadata: %v\n", name, err)
+			logger.Warnf("spaces", "skipping space %q due to invalid metadata: %v", name, err)
 			failures++
 			maybeLogSpaceRestoreProgress(idx+1, len(names), len(validSpaces), failures, startedAt, &lastLogAt, name)
 			continue
 		}
 		if err := sm.loadSpace(meta); err != nil {
-			fmt.Printf("❌ Failed to open space '%s': %v\n", meta.Name, err)
+			logger.Errorf("spaces", "Failed to open space '%s': %v", meta.Name, err)
 			failures++
 			maybeLogSpaceRestoreProgress(idx+1, len(names), len(validSpaces), failures, startedAt, &lastLogAt, meta.Name)
 			continue
@@ -224,8 +225,8 @@ func (sm *SpaceManager) loadCurrentSpaceCatalog() (bool, error) {
 	}
 
 	if len(names) > 0 {
-		fmt.Printf(
-			"Finished restoring spaces: loaded %d/%d (failed: %d, elapsed: %s)\n",
+		logger.Infof("spaces",
+			"Finished restoring spaces: loaded %d/%d (failed: %d, elapsed: %s)",
 			len(validSpaces),
 			len(names),
 			failures,
@@ -235,7 +236,7 @@ func (sm *SpaceManager) loadCurrentSpaceCatalog() (bool, error) {
 
 	if manifestErr != nil || !manifestExists || !sameSpaceSet(manifestSpaces, validSpaces) {
 		if err := sm.rewriteManifest(sortedSpaceNames(validSpaces)); err != nil {
-			fmt.Printf("Warning: failed to reconcile %s: %v\n", sm.manifestFilePath, err)
+			logger.Warnf("spaces", "failed to reconcile %s: %v", sm.manifestFilePath, err)
 		}
 	}
 
@@ -260,7 +261,7 @@ func (sm *SpaceManager) loadLegacyMetadataJSON() error {
 	for _, meta := range metas {
 		meta = normalizeSpaceMeta(meta)
 		if err := sm.loadSpace(meta); err != nil {
-			fmt.Printf("❌ Failed to open legacy space '%s': %v\n", meta.Name, err)
+			logger.Errorf("spaces", "Failed to open legacy space '%s': %v", meta.Name, err)
 			continue
 		}
 		normalized = append(normalized, meta)
@@ -271,7 +272,7 @@ func (sm *SpaceManager) loadLegacyMetadataJSON() error {
 	}
 
 	if err := sm.migrateLegacyMetadata(normalized); err != nil {
-		fmt.Printf("Warning: failed to migrate legacy metadata.json to current layout: %v\n", err)
+		logger.Warnf("spaces", "failed to migrate legacy metadata.json to current layout: %v", err)
 	}
 	return nil
 }
@@ -757,8 +758,8 @@ func maybeLogSpaceRestoreProgress(processed, total, loaded, failures int, starte
 	}
 
 	*lastLogAt = time.Now()
-	fmt.Printf(
-		"Space restore progress: %d/%d processed, %d loaded, %d failed (elapsed: %s, last: %s)\n",
+	logger.Infof("spaces",
+		"Space restore progress: %d/%d processed, %d loaded, %d failed (elapsed: %s, last: %s)",
 		processed,
 		total,
 		loaded,

--- a/internal/storage/flat_meta_vector_storage.go
+++ b/internal/storage/flat_meta_vector_storage.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"math"
 	"os"
 	"path/filepath"
@@ -17,6 +16,7 @@ import (
 	"github.com/DataIntelligenceCrew/go-faiss"
 	"github.com/RoaringBitmap/roaring/roaring64"
 	"github.com/google/btree"
+	"github.com/shibudb.org/shibudb-server/internal/logger"
 	"github.com/shibudb.org/shibudb-server/internal/maintenance"
 	"github.com/shibudb.org/shibudb-server/internal/wal"
 )
@@ -808,7 +808,7 @@ func (e *FlatMetaVectorEngine) flushData(force bool) {
 	dataFile := active.dataFile
 	for _, item := range buf {
 		if err := appendFlatMetaRecord(dataFile, item); err != nil {
-			log.Printf("flat-meta append failed for id=%d: %v", item.id, err)
+			logger.Errorf("storage", "flat-meta append failed for id=%d: %v", item.id, err)
 		}
 	}
 	if info, err := dataFile.Stat(); err == nil {
@@ -819,10 +819,10 @@ func (e *FlatMetaVectorEngine) flushData(force bool) {
 	e.lock.Unlock()
 
 	if err := dataFile.Sync(); err != nil {
-		log.Printf("flat-meta data file sync failed: %v", err)
+		logger.Errorf("storage", "flat-meta data file sync failed: %v", err)
 	}
 	if rotateErr != nil {
-		log.Printf("flat-meta hot segment rotation failed: %v", rotateErr)
+		logger.Errorf("storage", "flat-meta hot segment rotation failed: %v", rotateErr)
 	}
 }
 
@@ -1004,7 +1004,7 @@ func (e *FlatMetaVectorEngine) tryMergeOldestColdSegments() bool {
 
 	mergedMeta, mergedFile, err := e.mergeSegments(newID, firstDesc, secondDesc)
 	if err != nil {
-		log.Printf("merge flat-meta segments %d and %d failed: %v", first.meta.ID, second.meta.ID, err)
+		logger.Errorf("storage", "merge flat-meta segments %d and %d failed: %v", first.meta.ID, second.meta.ID, err)
 		e.lock.Lock()
 		if segment := e.segmentByIDLocked(first.meta.ID); segment != nil {
 			segment.meta.State = SegmentStateCold

--- a/internal/storage/key_value_storage.go
+++ b/internal/storage/key_value_storage.go
@@ -5,13 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"sync"
 	"time"
 
 	kvindex "github.com/shibudb.org/shibudb-server/internal/index"
+	"github.com/shibudb.org/shibudb-server/internal/logger"
 	"github.com/shibudb.org/shibudb-server/internal/maintenance"
 	"github.com/shibudb.org/shibudb-server/internal/wal"
 )
@@ -215,22 +215,22 @@ func (db *ShibuDB) replayWAL() {
 	}
 	entries, err := db.wal.Replay()
 	if err != nil {
-		log.Printf("WAL replay failed: %v", err)
+		logger.Errorf("storage", "WAL replay failed: %v", err)
 		return
 	}
 	for _, entry := range entries {
 		if entry.Flag == wal.EntryDeleted {
 			if err := db.Delete(entry.Key); err != nil && !errors.Is(err, errKeyDeleted) && !errors.Is(err, errKeyNotFound) {
-				log.Printf("WAL replay delete failed for %q: %v", entry.Key, err)
+				logger.Errorf("storage", "WAL replay delete failed for %q: %v", entry.Key, err)
 			}
 			continue
 		}
 		if err := db.PutBatch(entry.Key, entry.Value); err != nil {
-			log.Printf("WAL replay put failed for %q: %v", entry.Key, err)
+			logger.Errorf("storage", "WAL replay put failed for %q: %v", entry.Key, err)
 		}
 	}
 	if err := db.FlushBatch(); err != nil {
-		log.Printf("WAL replay flush failed: %v", err)
+		logger.Errorf("storage", "WAL replay flush failed: %v", err)
 	}
 	_ = db.wal.Clear()
 }
@@ -479,7 +479,7 @@ func (db *ShibuDB) MaintenanceFlush() {
 		return
 	}
 	if err := db.FlushBatch(); err != nil {
-		log.Printf("FlushBatch failed: %v", err)
+		logger.Errorf("storage", "FlushBatch failed: %v", err)
 	}
 }
 
@@ -536,7 +536,7 @@ func (db *ShibuDB) tryMergeOldestColdSegments() bool {
 
 	mergedMeta, mergedIndex, mergedFile, err := db.mergeSegments(newID, firstDesc, secondDesc)
 	if err != nil {
-		log.Printf("merge key-value segments %d and %d failed: %v", first.meta.ID, second.meta.ID, err)
+		logger.Errorf("storage", "merge key-value segments %d and %d failed: %v", first.meta.ID, second.meta.ID, err)
 		db.lock.Lock()
 		if segment := db.segmentByIDLocked(first.meta.ID); segment != nil {
 			segment.meta.State = SegmentStateCold

--- a/internal/storage/vector_storage.go
+++ b/internal/storage/vector_storage.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"math"
 	"os"
 	"path/filepath"
@@ -16,6 +15,7 @@ import (
 	"time"
 
 	"github.com/DataIntelligenceCrew/go-faiss"
+	"github.com/shibudb.org/shibudb-server/internal/logger"
 	"github.com/shibudb.org/shibudb-server/internal/maintenance"
 	"github.com/shibudb.org/shibudb-server/internal/wal"
 )
@@ -195,7 +195,7 @@ func (ve *VectorEngineImpl) compactLegacySegmentedLayoutIfNeeded() error {
 	if len(ve.manifest.Segments) <= 1 {
 		return nil
 	}
-	log.Printf("storage: merging %d legacy vector segments into single-file layout for FAISS index %q",
+	logger.Infof("storage", "merging %d legacy vector segments into single-file layout for FAISS index %q",
 		len(ve.manifest.Segments), ve.indexType)
 
 	paths := make([]string, 0, len(ve.manifest.Segments))
@@ -583,7 +583,7 @@ func (ve *VectorEngineImpl) Close() error {
 			ve.promotionWG.Wait()
 		}
 		if err := ve.FlushBatch(); err != nil {
-			log.Printf("final vector batch flush failed: %v", err)
+			logger.Errorf("storage", "final vector batch flush failed: %v", err)
 		}
 
 		if ve.wal != nil {
@@ -661,7 +661,7 @@ func (ve *VectorEngineImpl) MaintenanceFlush() {
 		return
 	}
 	if err := ve.FlushBatch(); err != nil {
-		log.Printf("vector batch flush failed: %v", err)
+		logger.Errorf("storage", "vector batch flush failed: %v", err)
 	}
 }
 
@@ -673,7 +673,7 @@ func (ve *VectorEngineImpl) MaintenanceCheckpoint() {
 		return
 	}
 	if err := ve.checkpoint(); err != nil {
-		log.Printf("checkpoint failed: %v", err)
+		logger.Errorf("storage", "checkpoint failed: %v", err)
 	}
 }
 
@@ -882,7 +882,7 @@ func (ve *VectorEngineImpl) indexPromotionWorker() {
 		}
 
 		if err := ve.promoteConfiguredIndex(); err != nil {
-			log.Printf("promote FAISS index %q failed: %v", ve.indexType, err)
+			logger.Errorf("storage", "promote FAISS index %q failed: %v", ve.indexType, err)
 		}
 	}
 }
@@ -933,7 +933,7 @@ func (ve *VectorEngineImpl) promoteConfiguredIndex() error {
 	ve.store.index = index
 	ve.store.configured = true
 	oldIndex.Delete()
-	log.Printf("promoted FAISS index to %q with %d live vectors", ve.indexType, liveVectors)
+	logger.Infof("storage", "promoted FAISS index to %q with %d live vectors", ve.indexType, liveVectors)
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/shibudb.org/shibudb-server/internal/auth"
 	"github.com/shibudb.org/shibudb-server/internal/cliinput"
 	"github.com/shibudb.org/shibudb-server/internal/cliparse"
+	"github.com/shibudb.org/shibudb-server/internal/logger"
 	"github.com/shibudb.org/shibudb-server/internal/models"
 	"github.com/shibudb.org/shibudb-server/internal/spaces"
 )
@@ -1575,6 +1576,16 @@ func handleManagerCommand(managementPort string, args []string, authCfg managerA
 		checkManagerHealth(baseURL, tempToken)
 	case "reset":
 		resetManagerLimit(baseURL, tempToken)
+	case "log-level":
+		if len(args) < 2 {
+			getManagerLogLevel(baseURL, tempToken)
+			return
+		}
+		if _, err := logger.ParseLevel(args[1]); err != nil {
+			fmt.Printf("Error: %v\n", err)
+			return
+		}
+		setManagerLogLevel(baseURL, tempToken, args[1])
 	default:
 		fmt.Printf("Error: Unknown command: %s\n", command)
 		printManagerUsage()
@@ -1714,6 +1725,7 @@ func printManagerUsage() {
   decrease [amount]         Decrease connection limit by amount (default: 100)
   health                    Check server health
   reset                     Reset connection limit to configured default
+  log-level [level]         Show or set the server log level (debug, info, warn, error)
   generate-token            Generate a new management bearer token
   list-tokens               List stored management tokens
   delete-token <token_id>   Delete a management token by id
@@ -1730,6 +1742,8 @@ Examples:
   shibudb manager --username admin --password admin decrease 200
   shibudb manager --username admin --password admin reset
   shibudb manager --username admin --password admin stats
+  shibudb manager --username admin --password admin log-level warn
+  shibudb manager --username admin --password admin log-level
   shibudb manager --username admin --password admin generate-token
   shibudb manager --username admin --password admin list-tokens
   shibudb manager --username admin --password admin delete-token <token_id>
@@ -1947,6 +1961,52 @@ func decreaseManagerLimit(baseURL, bearerToken string, amount int32) {
 		fmt.Printf("Success: %s\n", result["message"])
 		fmt.Printf("Old Limit: %d, New Limit: %d\n",
 			int(result["old_limit"].(float64)), int(result["new_limit"].(float64)))
+	} else {
+		fmt.Printf("Error: %s\n", result["error"])
+	}
+}
+
+func getManagerLogLevel(baseURL, bearerToken string) {
+	resp, err := makeManagerRequest("GET", baseURL+"/loglevel", nil, bearerToken)
+	if err != nil {
+		fmt.Printf("Error: Failed to connect to management server: %v\n", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	var result map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		fmt.Printf("Error: Failed to parse response: %v\n", err)
+		return
+	}
+
+	if resp.StatusCode == http.StatusOK {
+		fmt.Printf("Current Log Level: %s\n", result["level"])
+	} else {
+		fmt.Printf("Error: %s\n", result["error"])
+	}
+}
+
+func setManagerLogLevel(baseURL, bearerToken, level string) {
+	body := map[string]interface{}{
+		"level": level,
+	}
+
+	resp, err := makeManagerRequest("PUT", baseURL+"/loglevel", body, bearerToken)
+	if err != nil {
+		fmt.Printf("Error: Failed to connect to management server: %v\n", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	var result map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		fmt.Printf("Error: Failed to parse response: %v\n", err)
+		return
+	}
+
+	if resp.StatusCode == http.StatusOK {
+		fmt.Printf("Success: %s\n", result["message"])
 	} else {
 		fmt.Printf("Error: %s\n", result["error"])
 	}


### PR DESCRIPTION
## Description

This PR replaces the ad-hoc `fmt.Printf` / `log.Printf` statements scattered across the server with a structured, leveled, buffered logging system.

**Motivation:** All server output was previously unstructured print statements captured in `shibudb.log` only via stdout redirection — no timestamps on most lines, no severity levels, no way to reduce log noise on a busy server, and every log call was a synchronous write.

**What's included:**

- **New `internal/logger` package** — log calls append formatted lines (`2026-08-09T18:30:19.508+05:30 [INFO ] [component] message`) to an in-memory buffer; a background goroutine started on server start flushes the buffer to the log output every 100ms (with a forced flush if the buffer exceeds 256KB during a burst, and a final flush on shutdown/fatal).
- **Log levels** — `debug`, `info`, `warn`, `error`. Setting a level enables it and everything above it: `info` enables info/warn/error, `warn` enables warn/error, `error` enables only errors, `debug` enables everything (per-query and per-connection logs).
- **Runtime level control from `shibudb manager`** — new `GET`/`PUT /loglevel` endpoints on the management HTTP API and a `shibudb manager log-level [level]` CLI command. The level can be changed anytime without a restart.
- **Persistence** — the level is saved to `<data-dir>/lib/log_level.json` (same pattern as `connection_limit.json`) and restored on the next server start.
- **Migrated ~50 call sites** across `cmd/server`, `internal/spaces`, `internal/storage`, `internal/queryengine`, `internal/auth`, and `internal/maintenance` to leveled logger calls. Flush/WAL/checkpoint failures are ERROR; connection-limit rejections and high-usage alerts are WARN; startup, user-admin, and index-promotion events are INFO; noisy per-query, per-connection, and periodic status lines are DEBUG.
- **Security fix along the way** — user-admin logging previously printed whole request/user structs including plaintext passwords; migrated calls log only usernames.

**Notes:**

- The readiness line `ShibuDB server started on port ...` intentionally bypasses level filtering, because `shibudb start` scans the log file for it to detect startup readiness.
- CLI output in `main.go` and protocol responses to clients (`fmt.Fprintf(conn, ...)`) are unchanged.

Fixes # (SDB-20)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] Unit tests for the new logger package (`internal/logger/logger_test.go`): level filtering, async 100ms flush, flush-on-stop, line format, level parsing — `go test ./internal/logger/`
- [x] Full existing test suites pass locally: `go test ./internal/storage/ ./internal/spaces/ ./cmd/server/ ./internal/queryengine/ ./internal/auth/ ./internal/maintenance/`
- [x] End-to-end manual verification:
  1. `shibudb run --data-dir <tmp> --port 14444 --management-port 15444` — startup logs appear in the new structured format and the readiness line still prints.
  2. `shibudb manager --username admin --password <pass> log-level` — shows `info` (default).
  3. `shibudb manager ... log-level warn` — succeeds; subsequent INFO lines are filtered from the log; `lib/log_level.json` is written.
  4. `shibudb manager ... log-level bogus` — rejected with a clear error listing valid levels.
  5. Restart the server — `Using persisted log level: WARN` is logged and the level is applied.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`docs/ADMINISTRATION.md`: new Logging section, `/loglevel` endpoints, `log-level` CLI command, data directory layout)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules (N/A — no dependent modules)

## Additional Notes

- `shibudb stop` currently hard-kills the server (SIGKILL), so up to 100ms of buffered logs can be lost on stop. A graceful-shutdown path would eliminate this and is a candidate for a follow-up.
- The logger writes to the server process's stdout; `shibudb start` already redirects stdout to `<data-dir>/log/shibudb.log`, so file output and startup-readiness detection keep working unchanged, and `shibudb run` still logs to the terminal for development.