### PR TITLE
[sdb-35] Added turboquant support in flat meta vectors

### DIFF
--- a/.github/workflows/linux-package-install.yml
+++ b/.github/workflows/linux-package-install.yml
@@ -141,7 +141,7 @@ jobs:
           set -eu
 
           install_go() {
-            go_version="1.23.7"
+            go_version="1.24.0"
             case "$(uname -m)" in
               x86_64) go_arch="amd64" ;;
               aarch64) go_arch="arm64" ;;
@@ -278,7 +278,7 @@ jobs:
           set -eu
 
           install_go() {
-            go_version="1.23.7"
+            go_version="1.24.0"
             case "$(uname -m)" in
               x86_64) go_arch="amd64" ;;
               aarch64) go_arch="arm64" ;;
@@ -446,7 +446,7 @@ jobs:
               set -euo pipefail
 
               install_go() {
-                go_version="1.23.7"
+                go_version="1.24.0"
                 case "$(uname -m)" in
                   x86_64) go_arch="amd64" ;;
                   aarch64) go_arch="arm64" ;;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go-version: [1.23.x]
+        go-version: [1.24.x]
 
     steps:
     - name: Checkout code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ This project and everyone participating in it is governed by our Code of Conduct
 
 ### Prerequisites
 
-- Go 1.23.0 or later
+- Go 1.24.0 or later
 - Git
 - Make (required for build scripts)
 
@@ -40,7 +40,7 @@ Clone the canonical repository locally:
 
 ```bash
 # Install dependencies and verify the toolchain
-install go version 1.23.0 or above
+install go version 1.24.0 or above
 ```
 
 ### 2. Run Tests

--- a/E2ETests/vector_flat_metadata_e2e_test.go
+++ b/E2ETests/vector_flat_metadata_e2e_test.go
@@ -336,6 +336,44 @@ func TestVectorFlatMetadataErrorsE2E(t *testing.T) {
 			t.Fatalf("expected ERROR creating non-Flat space with metadata fields, got: %s", strings.TrimSpace(resp))
 		}
 	})
+
+	t.Run("compression on non-flat-meta vector spaces is rejected", func(t *testing.T) {
+		cases := []struct {
+			space     string
+			indexType string
+			fields    []storage.MetadataFieldSpec
+			want      string
+		}{
+			{"vec_flat_comp_nometa_e2e", "Flat", nil, "indexed metadata fields"},
+			{"vec_hnsw_comp_e2e", "HNSW32", nil, `got index type "HNSW32"`},
+			{"vec_ivf_comp_e2e", "IVF32,Flat", nil, `got index type "IVF32,Flat"`},
+			{"vec_pq_comp_e2e", "PQ8", nil, `got index type "PQ8"`},
+		}
+		for _, tc := range cases {
+			CleanSpace(tc.space, conn, reader)
+			createQ := models.Query{
+				Type:                  models.TypeCreateSpace,
+				Space:                 tc.space,
+				EngineType:            "vector",
+				Dimension:             8,
+				IndexType:             tc.indexType,
+				Metric:                "L2",
+				IndexedMetadataFields: tc.fields,
+				Compression:           storage.VectorCompressionTurboQuant4Bits,
+			}
+			resp := sendQueryAndGetResponse(createQ, conn, reader)
+			if !strings.Contains(resp, "ERROR") {
+				t.Fatalf("%s: expected ERROR, got: %s", tc.space, strings.TrimSpace(resp))
+			}
+			if !strings.Contains(resp, "compression is only supported for Flat spaces declared with indexed metadata fields") {
+				t.Fatalf("%s: missing compression restriction in %s", tc.space, strings.TrimSpace(resp))
+			}
+			if !strings.Contains(resp, tc.want) {
+				t.Fatalf("%s: want %q in %s", tc.space, tc.want, strings.TrimSpace(resp))
+			}
+			CleanSpace(tc.space, conn, reader)
+		}
+	})
 }
 
 func TestVectorFlatMetadataTurboQuantE2E(t *testing.T) {

--- a/E2ETests/vector_flat_metadata_e2e_test.go
+++ b/E2ETests/vector_flat_metadata_e2e_test.go
@@ -337,3 +337,39 @@ func TestVectorFlatMetadataErrorsE2E(t *testing.T) {
 		}
 	})
 }
+
+func TestVectorFlatMetadataTurboQuantE2E(t *testing.T) {
+	conn, reader := dialAndLogin(t)
+	defer conn.Close()
+
+	space := "vec_flat_meta_tq4_e2e"
+	CleanSpace(space, conn, reader)
+	defer CleanSpace(space, conn, reader)
+
+	createQ := models.Query{
+		Type:                  models.TypeCreateSpace,
+		Space:                 space,
+		EngineType:            "vector",
+		Dimension:             8,
+		IndexType:             "Flat",
+		Metric:                "L2",
+		EnableWAL:             true,
+		IndexedMetadataFields: []storage.MetadataFieldSpec{{Name: "user_id", Type: storage.MetadataTypeString}},
+		Compression:           storage.VectorCompressionTurboQuant4Bits,
+	}
+	if !CreateSpaceWithSettings(createQ, conn, reader) {
+		t.Fatalf("failed to create TurboQuant Flat space %q", space)
+	}
+
+	insertVectorWithMeta(space, "1", "1,0,0,0,0,0,0,0", map[string]any{"user_id": "alice"}, conn, reader)
+	insertVectorWithMeta(space, "2", "0,1,0,0,0,0,0,0", map[string]any{"user_id": "bob"}, conn, reader)
+	time.Sleep(300 * time.Millisecond)
+
+	resp := searchTopKFiltered(space, "1,0,0,0,0,0,0,0", 1, nil, conn, reader)
+	assertExactIDs(t, "nearest", resp, 1)
+
+	filter := &storage.MetadataFilter{Op: storage.FilterOpEq, Field: "user_id", Value: "alice"}
+	resp = searchTopKFiltered(space, "1,0,0,0,0,0,0,0", 10, filter, conn, reader)
+	assertExactIDs(t, "user_id=alice", resp, 1)
+	assertMissingIDs(t, "user_id=alice", resp, 2)
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ShibuDb
 
-[![Go Version](https://img.shields.io/badge/Go-1.23.0-blue.svg)](https://golang.org)
+[![Go Version](https://img.shields.io/badge/Go-1.24.0-blue.svg)](https://golang.org)
 [![License](https://img.shields.io/badge/License-AGPL%203.0-green.svg)](LICENSE)
 [![Platforms](https://img.shields.io/badge/Platforms-Linux%20%7C%20macOS-blue.svg)](https://github.com/shibudb-org/shibudb-server)
 
@@ -88,7 +88,7 @@ ShibuDb follows a modular architecture with clear separation of concerns:
 
 ### Prerequisites
 
-- Go 1.23.0 or later
+- Go 1.24.0 or later
 - FAISS libraries (included in resources/)
 
 ### Build and Test
@@ -124,7 +124,7 @@ make connect-local-client
 **Available CLI Commands:**
 - `help` or `?` - Show the full interactive command reference
 - `USE <space>` - Switch to a specific space
-- `create-space <name> [--engine key-value|vector] [--dimension N] [--index-type TYPE] [--metric METRIC] [--metadata-fields name:type,...]` - Create a new space
+- `create-space <name> [--engine key-value|vector] [--dimension N] [--index-type TYPE] [--metric METRIC] [--metadata-fields name:type,...] [--compression TurboQuant2Bits|TurboQuant3Bits|TurboQuant4Bits]` - Create a new space
 - `put <key> <value>` - Store a key-value pair
 - `get <key>` - Retrieve a value by key
 - `delete <key>` - Delete a key-value pair
@@ -191,6 +191,7 @@ search to matching vectors (e.g. per-tenant data) for better recall and speed.
 Notes:
 - `--metadata-fields`, `--meta`, and `--where` are only available on vector spaces created with `--index-type Flat`.
 - The `--metadata-fields` and `--meta` lists must not contain spaces (they are comma-separated).
+- `--compression TurboQuant2Bits`, `TurboQuant3Bits`, or `TurboQuant4Bits` is optional on those same Flat+metadata spaces. It stores quantized vectors in memory and on disk (approximately 16× / 10× / 8× smaller than float32, plus a per-vector norm). Search reconstructs approximate float32 values. 6-bit and 8-bit schemes are not available; the TurboQuant library only supports 2/3/4-bit quantization.
 
 See [Vector Engine — Metadata Filtering](docs/VECTOR_ENGINE.md#metadata-filtering) for the full grammar, internals, and error reference.
 
@@ -256,7 +257,7 @@ curl -fsSL https://raw.githubusercontent.com/shibudb-org/shibudb-server/main/scr
 
 The source installer supports Linux `amd64` and `arm64`. It installs build
 dependencies with `apt`, `dnf`, or `yum`, and downloads a temporary Go toolchain
-if Go 1.23 or later is not already available.
+if Go 1.24 or later is not already available.
 
 ## 🎯 Use Cases
 

--- a/README.md
+++ b/README.md
@@ -376,6 +376,7 @@ This project is licensed under the GNU Affero General Public License v3.0 (AGPL-
 ## 🙏 Acknowledgments
 
 - [FAISS](https://github.com/facebookresearch/faiss) - Vector similarity search
+- [TurboQuant](https://github.com/mredencom/turboquant) - Data-oblivious vector quantization (2/3/4-bit)
 - [Go B-tree](https://github.com/google/btree) - B-tree implementation
 - [Go Crypto](https://golang.org/x/crypto) - Cryptographic functions
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -65,7 +65,7 @@ EXIT, QUIT                       Disconnect and exit
 ```text
 USE <space>
 LIST-SPACES
-CREATE-SPACE <name> [--engine key-value|vector] [--dimension N] [--index-type TYPE] [--metric METRIC] [--enable-wal] [--disable-wal] [--segment-rollover-bytes N] [--max-segments-before-merge N] [--metadata-fields name:type,...]
+CREATE-SPACE <name> [--engine key-value|vector] [--dimension N] [--index-type TYPE] [--metric METRIC] [--enable-wal] [--disable-wal] [--segment-rollover-bytes N] [--max-segments-before-merge N] [--metadata-fields name:type,...] [--compression TurboQuant2Bits|TurboQuant3Bits|TurboQuant4Bits]
 DELETE-SPACE <name>
 ```
 
@@ -74,6 +74,7 @@ Notes:
 - `--index-type` for `--engine key-value` defaults to `btree` (supports `btree` or `hashmap`).
 - WAL is **disabled by default** unless `--enable-wal` is provided.
 - `--metadata-fields` declares indexed metadata fields for filtering and is **only valid with `--index-type Flat`**. Format is comma-separated `name:type` (no spaces); `type` is `string`, `int`, or `float`. See [Metadata Filtering](VECTOR_ENGINE.md#metadata-filtering).
+- `--compression` is **only valid with `--index-type Flat` and `--metadata-fields`**. Values: `TurboQuant2Bits`, `TurboQuant3Bits`, `TurboQuant4Bits`. See [TurboQuant compression](VECTOR_ENGINE.md#turboquant-compression).
 
 ### Key-value operations (require `USE <space>` on a key-value space)
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -16,7 +16,7 @@
 ### System Requirements
 
 - **Operating System**: Linux (AMD64/ARM64) or macOS (Apple Silicon)
-- **Go Version**: 1.23.0 or later (for source builds)
+- **Go Version**: 1.24.0 or later (for source builds)
 - **Memory**: Minimum 512MB RAM, recommended 2GB+
 - **Disk Space**: Minimum 1GB free space
 - **Network**: TCP port access for client connections
@@ -85,7 +85,7 @@ libraries from the ShibuDB source tree.
 
 The installer supports Linux `amd64` and `arm64`. It can install dependencies
 through `apt`, `dnf`, or `yum`, and downloads a temporary Go toolchain if Go
-1.23 or later is not already installed.
+1.24 or later is not already installed.
 
 ```bash
 # Install the latest release

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -54,7 +54,9 @@ Your query vector must have exactly `<space dimension>` values. Recreate the spa
 ## Metadata filtering (`--meta` / `--where`) errors
 
 - **“metadata filtering is only supported for Flat spaces declared with indexed metadata fields”**: the space was not created with `--index-type Flat` and `--metadata-fields`. Recreate it with both.
-- **“indexed metadata fields are only supported for the Flat index type”**: you passed `--metadata-fields` with a non-Flat `--index-type`. Use `--index-type Flat`.
+- **“compression is only supported for Flat spaces declared with indexed metadata fields”**: `--compression` is only valid with `--index-type Flat` and `--metadata-fields`.
+- **“unsupported compression …”**: valid values are `TurboQuant2Bits`, `TurboQuant3Bits`, and `TurboQuant4Bits` (6-bit and 8-bit are not implemented).
+- **“TurboQuant compression requires dimension >= 2”**: recreate the space with a larger `--dimension`.
 - **“filter field "X" is not an indexed metadata field”**: `X` was not declared in `--metadata-fields`. Only declared fields can be filtered.
 - **“range op "gt"/"lt"/... on "X" requires a number”**: a comparison/`BETWEEN` was used on a string value. Use a numeric (`int`/`float`) field, or quote string equality (`field='value'`).
 - **No results when you expect some**: a string field whose value looks numeric may have been stored/queried as a number. Quote it (e.g. `user_id='123'`). Also remember `--meta`/`--metadata-fields` must not contain spaces.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -54,7 +54,7 @@ Your query vector must have exactly `<space dimension>` values. Recreate the spa
 ## Metadata filtering (`--meta` / `--where`) errors
 
 - **“metadata filtering is only supported for Flat spaces declared with indexed metadata fields”**: the space was not created with `--index-type Flat` and `--metadata-fields`. Recreate it with both.
-- **“compression is only supported for Flat spaces declared with indexed metadata fields”**: `--compression` is only valid with `--index-type Flat` and `--metadata-fields`.
+- **“compression is only supported for Flat spaces declared with indexed metadata fields”**: `--compression` is only valid on a filterable Flat space (`--index-type Flat` and `--metadata-fields`). HNSW, IVF, PQ, and plain Flat spaces (no metadata fields) are rejected.
 - **“unsupported compression …”**: valid values are `TurboQuant2Bits`, `TurboQuant3Bits`, and `TurboQuant4Bits` (6-bit and 8-bit are not implemented).
 - **“TurboQuant compression requires dimension >= 2”**: recreate the space with a larger `--dimension`.
 - **“filter field "X" is not an indexed metadata field”**: `X` was not declared in `--metadata-fields`. Only declared fields can be filtered.

--- a/docs/VECTOR_ENGINE.md
+++ b/docs/VECTOR_ENGINE.md
@@ -757,7 +757,7 @@ SEARCH-TOPK 0.1,0.1,0.1,0.1 10 --where price>cheap
 # Declaring --metadata-fields on a non-Flat index
 # ERROR: indexed metadata fields are only supported for the Flat index type, got 'HNSW32'
 
-# Compression without metadata fields, or on a non-Flat index
+# Compression on a non-Flat index (HNSW, IVF, PQ) or a Flat space without --metadata-fields
 # ERROR: compression is only supported for Flat spaces declared with indexed metadata fields
 ```
 

--- a/docs/VECTOR_ENGINE.md
+++ b/docs/VECTOR_ENGINE.md
@@ -93,6 +93,7 @@ CREATE-SPACE fast_embeddings --engine vector --dimension 128 --disable-wal
 - `--metric METRIC`: Distance metric (default: L2)
 - `--enable-wal`: Enable Write-Ahead Logging for enhanced durability (default: disabled for vector spaces)
 - `--disable-wal`: Disable Write-Ahead Logging for maximum performance (default for vector spaces)
+- `--compression SCHEME`: TurboQuant quantization for filterable Flat spaces (`TurboQuant2Bits`, `TurboQuant3Bits`, or `TurboQuant4Bits`; see [TurboQuant compression](#turboquant-compression))
 
 ### Automatic Training
 
@@ -652,6 +653,31 @@ candidate set is reduced first.
 - `--metadata-fields` and `--meta` are comma-separated and **must not contain spaces**.
 - Only fields declared at creation are indexed; filtering on an undeclared field returns an error.
 
+### TurboQuant compression
+
+Filterable Flat spaces can store vectors with [TurboQuant](https://github.com/mredencom/turboquant) quantization instead of float32. Enable it at create time:
+
+```bash
+CREATE-SPACE products --engine vector --dimension 128 --index-type Flat --metric L2 \
+    --metadata-fields user_id:string \
+    --compression TurboQuant4Bits
+```
+
+| Scheme | Bits / dim | Typical size vs float32 | Quality |
+|---|---|---|---|
+| *(none)* | 32 | 1× | Exact |
+| `TurboQuant4Bits` | 4 | ~8× smaller | High cosine similarity (usually > 0.98) |
+| `TurboQuant3Bits` | 3 | ~10× smaller | Strong quality/size middle ground |
+| `TurboQuant2Bits` | 2 | ~16× smaller | Lower fidelity; still good for well-separated vectors |
+
+The compressed payload is a float32 L2 norm plus bit-packed indices, so the ratio approaches 32/bits as dimension grows.
+
+Search and `GET-VECTOR` reconstruct approximate float32 vectors. Ranking is therefore approximate. Compression cannot be changed after the space is created.
+
+**6-bit and 8-bit schemes are not offered.** `github.com/mredencom/turboquant` only implements 2/3/4-bit quantization. 8-bit would only be ~4× smaller than float32; 4-bit is the high-quality option, 3-bit the middle ground, and 2-bit the extra-memory option.
+
+`--compression` is rejected unless the space is `--engine vector --index-type Flat` with `--metadata-fields`, and dimension is at least 2.
+
 ### 1. Declare Indexed Fields (at space creation)
 
 ```bash
@@ -730,9 +756,12 @@ SEARCH-TOPK 0.1,0.1,0.1,0.1 10 --where price>cheap
 
 # Declaring --metadata-fields on a non-Flat index
 # ERROR: indexed metadata fields are only supported for the Flat index type, got 'HNSW32'
+
+# Compression without metadata fields, or on a non-Flat index
+# ERROR: compression is only supported for Flat spaces declared with indexed metadata fields
 ```
 
-> Wire protocol: these map to the `indexed_metadata_fields` (CREATE_SPACE), `metadata`
+> Wire protocol: these map to the `indexed_metadata_fields` and `compression` (CREATE_SPACE), `metadata`
 > (INSERT_VECTOR), and `filter` (SEARCH_TOPK / RANGE_SEARCH) fields of the JSON query. The `--where`
 > DSL is a client-side convenience that compiles to the structured `filter` AST.
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/shibudb.org/shibudb-server
 
-go 1.23.0
-
-toolchain go1.23.7
+go 1.24.0
 
 require (
 	github.com/google/btree v1.1.3
@@ -14,6 +12,7 @@ require (
 require (
 	github.com/DataIntelligenceCrew/go-faiss v0.2.0
 	github.com/RoaringBitmap/roaring v1.9.4
+	github.com/mredencom/turboquant v0.0.2
 )
 
 require (
@@ -21,4 +20,5 @@ require (
 	github.com/mattn/go-runewidth v0.0.3 // indirect
 	github.com/mschoch/smat v0.2.0 // indirect
 	github.com/stretchr/testify v1.8.1 // indirect
+	gonum.org/v1/gonum v0.17.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
 github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/mattn/go-runewidth v0.0.3 h1:a+kO+98RDGEfo6asOGMmpodZq4FNtnGP54yps8BzLR4=
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mredencom/turboquant v0.0.2 h1:n5PJcj3bu0m0Ra/yFYQTX3a5/4zlUmGkd+we6KXMNEE=
+github.com/mredencom/turboquant v0.0.2/go.mod h1:FCNOFJbKWSSMPrBHzEpz6rv+d3YcJKSTmBy0qsL9oWI=
 github.com/mschoch/smat v0.2.0 h1:8imxQsjDm8yFEAVBe7azKmKSgzSkZXDuKkSq9374khM=
 github.com/mschoch/smat v0.2.0/go.mod h1:kc9mz7DoBKqDyiRL7VZN8KvXQMWeTaVnttLRXOlotKw=
 github.com/peterh/liner v1.2.2 h1:aJ4AOodmL+JxOZZEL2u9iJf8omNRpqHc/EbrK+3mAXw=
@@ -30,6 +32,8 @@ golang.org/x/crypto v0.38.0/go.mod h1:MvrbAqul58NNYPKnOra203SB9vpuZW0e+RRZV+Ggqj
 golang.org/x/sys v0.0.0-20211117180635-dee7805ff2e1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
 golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+gonum.org/v1/gonum v0.17.0 h1:VbpOemQlsSMrYmn7T2OUvQ4dqxQXU+ouZFQsZOx50z4=
+gonum.org/v1/gonum v0.17.0/go.mod h1:El3tOrEuMpv2UdMrbNlKEh9vd86bmQ6vqIcDwxEOc1E=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/models/query.go
+++ b/internal/models/query.go
@@ -45,6 +45,7 @@ type Query struct {
 
 	// Filterable Flat vector space fields.
 	IndexedMetadataFields []storage.MetadataFieldSpec `json:"indexed_metadata_fields,omitempty"`
+	Compression           string                      `json:"compression,omitempty"`
 	Metadata              map[string]any              `json:"metadata,omitempty"`
 	Filter                *storage.MetadataFilter     `json:"filter,omitempty"`
 }

--- a/internal/queryengine/query_engine.go
+++ b/internal/queryengine/query_engine.go
@@ -231,7 +231,7 @@ func (qe *QueryEngine) Execute(query models.Query) (string, error) {
 			SegmentRolloverBytes:   query.SegmentRolloverBytes,
 			MaxSegmentsBeforeMerge: query.MaxSegmentsBeforeMerge,
 		}
-		_, err = qe.spaceManager.CreateSpaceWithSettingsAndMetadata(query.Space, query.EngineType, query.Dimension, indexType, metric, query.EnableWAL, settings, query.IndexedMetadataFields)
+		_, err = qe.spaceManager.CreateSpaceWithSettingsAndMetadata(query.Space, query.EngineType, query.Dimension, indexType, metric, query.EnableWAL, settings, query.IndexedMetadataFields, query.Compression)
 		if err != nil {
 			return "", err
 		}

--- a/internal/queryengine/query_engine_filter_test.go
+++ b/internal/queryengine/query_engine_filter_test.go
@@ -146,3 +146,71 @@ func TestQueryEngine_FilterOnPlainVectorSpaceErrors(t *testing.T) {
 		t.Fatalf("expected error filtering on a plain vector space")
 	}
 }
+
+func TestQueryEngine_TurboQuantFlatSpace(t *testing.T) {
+	dir := t.TempDir()
+	sm := spaces.NewSpaceManager(dir)
+	defer sm.CloseAll()
+	qe := NewQueryEngine(sm, &mockAuth{})
+
+	space := "tq"
+	if _, err := qe.Execute(models.Query{
+		Type:        models.TypeCreateSpace,
+		Space:       space,
+		EngineType:  "vector",
+		Dimension:   8,
+		IndexType:   "Flat",
+		Metric:      "L2",
+		User:        "admin",
+		Compression: storage.VectorCompressionTurboQuant4Bits,
+		IndexedMetadataFields: []storage.MetadataFieldSpec{
+			{Name: "user_id", Type: storage.MetadataTypeString},
+		},
+	}); err != nil {
+		t.Fatalf("create compressed space: %v", err)
+	}
+
+	if _, err := qe.Execute(models.Query{
+		Type:     models.TypeInsertVector,
+		Space:    space,
+		Key:      "1",
+		Value:    "1,0,0,0,0,0,0,0",
+		Metadata: map[string]any{"user_id": "alice"},
+	}); err != nil {
+		t.Fatalf("insert 1: %v", err)
+	}
+	if _, err := qe.Execute(models.Query{
+		Type:     models.TypeInsertVector,
+		Space:    space,
+		Key:      "2",
+		Value:    "0,1,0,0,0,0,0,0",
+		Metadata: map[string]any{"user_id": "bob"},
+	}); err != nil {
+		t.Fatalf("insert 2: %v", err)
+	}
+
+	res, err := qe.Execute(models.Query{
+		Type:      models.TypeSearchTopK,
+		Space:     space,
+		Value:     "1,0,0,0,0,0,0,0",
+		Dimension: 1,
+		Filter:    &storage.MetadataFilter{Op: storage.FilterOpEq, Field: "user_id", Value: "alice"},
+	})
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if !strings.Contains(res, `"id": 1`) {
+		t.Fatalf("expected id 1, got %s", res)
+	}
+	if strings.Contains(res, `"id": 2`) {
+		t.Fatalf("did not expect id 2, got %s", res)
+	}
+
+	if _, err := qe.Execute(models.Query{
+		Type: models.TypeCreateSpace, Space: "bad_comp", EngineType: "vector",
+		Dimension: 8, IndexType: "Flat", Metric: "L2", User: "admin",
+		Compression: storage.VectorCompressionTurboQuant4Bits,
+	}); err == nil {
+		t.Fatal("expected error creating compressed space without metadata fields")
+	}
+}

--- a/internal/queryengine/query_engine_filter_test.go
+++ b/internal/queryengine/query_engine_filter_test.go
@@ -1,6 +1,7 @@
 package queryengine
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -212,5 +213,50 @@ func TestQueryEngine_TurboQuantFlatSpace(t *testing.T) {
 		Compression: storage.VectorCompressionTurboQuant4Bits,
 	}); err == nil {
 		t.Fatal("expected error creating compressed space without metadata fields")
+	}
+}
+
+func TestQueryEngine_CompressionRejectedOnNonFlatMeta(t *testing.T) {
+	dir := t.TempDir()
+	sm := spaces.NewSpaceManager(dir)
+	defer sm.CloseAll()
+	qe := NewQueryEngine(sm, &mockAuth{})
+
+	fields := []storage.MetadataFieldSpec{{Name: "user_id", Type: storage.MetadataTypeString}}
+	cases := []struct {
+		name      string
+		indexType string
+		fields    []storage.MetadataFieldSpec
+		wantSub   string
+	}{
+		{"plain flat", "Flat", nil, "indexed metadata fields"},
+		{"hnsw32", "HNSW32", nil, `got index type "HNSW32"`},
+		{"ivf32 flat", "IVF32,Flat", nil, `got index type "IVF32,Flat"`},
+		{"pq8", "PQ8", nil, `got index type "PQ8"`},
+		{"hnsw32 with metadata", "HNSW32", fields, `got index type "HNSW32"`},
+	}
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := qe.Execute(models.Query{
+				Type:                  models.TypeCreateSpace,
+				Space:                 fmt.Sprintf("rej_%d", i),
+				EngineType:            "vector",
+				Dimension:             8,
+				IndexType:             tc.indexType,
+				Metric:                "L2",
+				User:                  "admin",
+				IndexedMetadataFields: tc.fields,
+				Compression:           storage.VectorCompressionTurboQuant4Bits,
+			})
+			if err == nil {
+				t.Fatalf("expected compression error for %s", tc.name)
+			}
+			if !strings.Contains(err.Error(), "compression is only supported for Flat spaces declared with indexed metadata fields") {
+				t.Fatalf("got %v", err)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Fatalf("got %v, want substring %q", err, tc.wantSub)
+			}
+		})
 	}
 }

--- a/internal/spaces/dump.go
+++ b/internal/spaces/dump.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"sort"
 	"time"
+
+	"github.com/shibudb.org/shibudb-server/internal/storage"
 )
 
 // DumpFormatVersion identifies the dump file format so restores can detect
@@ -447,6 +449,10 @@ func dumpFlatMetaVectorSpace(enc *json.Encoder, spacePath string, meta spaceMeta
 	}
 
 	dimension := meta.Dimension
+	quantizer, payloadSize, err := flatMetaQuantizer(meta)
+	if err != nil {
+		return 0, err
+	}
 
 	// Collect latest record per ID (last-writer-wins).
 	type flatMetaEntry struct {
@@ -457,7 +463,15 @@ func dumpFlatMetaVectorSpace(enc *json.Encoder, spacePath string, meta spaceMeta
 	latest := make(map[int64]*flatMetaEntry)
 
 	for _, path := range dataPaths {
-		if err := streamFlatMetaFile(path, dimension, func(id int64, tombstone bool, vec []float32, metaBytes []byte) error {
+		if err := streamFlatMetaFile(path, payloadSize, func(id int64, tombstone bool, payload []byte, metaBytes []byte) error {
+			var vec []float32
+			if !tombstone {
+				var err error
+				vec, err = decodeFlatMetaVectorPayload(payload, dimension, quantizer)
+				if err != nil {
+					return err
+				}
+			}
 			latest[id] = &flatMetaEntry{
 				vec:       vec,
 				metaJSON:  metaBytes,
@@ -533,8 +547,8 @@ func collectFlatMetaDataPaths(spacePath string) ([]string, error) {
 }
 
 // streamFlatMetaFile reads a flat-meta vector data file record by record.
-// Record format: [8B id LE][1B flag][4B metaLen LE][metaBytes][vecBytes if live]
-func streamFlatMetaFile(path string, dim int, fn func(id int64, tombstone bool, vec []float32, metaBytes []byte) error) error {
+// Record format: [8B id LE][1B flag][4B metaLen LE][metaBytes][payload if live].
+func streamFlatMetaFile(path string, payloadSize int, fn func(id int64, tombstone bool, payload []byte, metaBytes []byte) error) error {
 	file, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -568,17 +582,49 @@ func streamFlatMetaFile(path string, dim int, fn func(id int64, tombstone bool, 
 			continue
 		}
 
-		vecBuf := make([]byte, 4*dim)
+		vecBuf := make([]byte, payloadSize)
 		if _, err := io.ReadFull(file, vecBuf); err != nil {
 			break
 		}
-		vec := make([]float32, dim)
-		for i := 0; i < dim; i++ {
-			vec[i] = math.Float32frombits(binary.LittleEndian.Uint32(vecBuf[i*4:]))
-		}
-		if err := fn(id, false, vec, metaBuf); err != nil {
+		if err := fn(id, false, vecBuf, metaBuf); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func flatMetaQuantizer(meta spaceMeta) (*storage.VectorQuantizer, int, error) {
+	if meta.Compression == "" {
+		return nil, 4 * meta.Dimension, nil
+	}
+	q, err := storage.NewVectorQuantizer(meta.Dimension, meta.Compression)
+	if err != nil {
+		return nil, 0, err
+	}
+	return q, q.PayloadSize(), nil
+}
+
+func decodeFlatMetaVectorPayload(payload []byte, dim int, q *storage.VectorQuantizer) ([]float32, error) {
+	if q != nil {
+		return q.Dequantize(payload)
+	}
+	if len(payload) != 4*dim {
+		return nil, fmt.Errorf("vector length mismatch: expected %d bytes, got %d", 4*dim, len(payload))
+	}
+	vec := make([]float32, dim)
+	for i := 0; i < dim; i++ {
+		vec[i] = math.Float32frombits(binary.LittleEndian.Uint32(payload[i*4:]))
+	}
+	return vec, nil
+}
+
+func encodeFlatMetaVectorPayload(vec []float32, q *storage.VectorQuantizer) ([]byte, error) {
+	if q != nil {
+		return q.Quantize(vec)
+	}
+	buf := make([]byte, 4*len(vec))
+	for i, v := range vec {
+		binary.LittleEndian.PutUint32(buf[i*4:], math.Float32bits(v))
+	}
+	return buf, nil
 }

--- a/internal/spaces/dump_test.go
+++ b/internal/spaces/dump_test.go
@@ -309,6 +309,90 @@ func TestDumpRestoreFlatMetaVector(t *testing.T) {
 	}
 }
 
+func TestDumpRestoreFlatMetaTurboQuant(t *testing.T) {
+	baseDir := t.TempDir()
+	spaceName := "test_flat_meta_tq"
+	spacePath := filepath.Join(baseDir, spaceName)
+	if err := os.MkdirAll(spacePath, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	dimension := 8
+	meta := spaceMeta{
+		LayoutVersion: currentSpaceLayoutVersion,
+		Name:          spaceName,
+		EngineType:    "vector",
+		IndexType:     "Flat",
+		Metric:        "L2",
+		Dimension:     dimension,
+		Compression:   storage.VectorCompressionTurboQuant4Bits,
+		IndexedMetadataFields: []storage.MetadataFieldSpec{
+			{Name: "color", Type: "string"},
+		},
+	}
+	meta = normalizeSpaceMeta(meta)
+	metaBytes, _ := json.MarshalIndent(meta, "", "  ")
+	if err := os.WriteFile(filepath.Join(spacePath, spaceMetaFileName), append(metaBytes, '\n'), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	q, err := storage.NewVectorQuantizer(dimension, storage.VectorCompressionTurboQuant4Bits)
+	if err != nil {
+		t.Fatalf("NewVectorQuantizer: %v", err)
+	}
+	orig := []float32{1, 0, 0, 0, 0, 0, 0, 0}
+	payload, err := q.Quantize(orig)
+	if err != nil {
+		t.Fatalf("Quantize: %v", err)
+	}
+
+	dataPath := filepath.Join(spacePath, "flat_meta_data.db")
+	dataFile, err := os.Create(dataPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	header := make([]byte, 13)
+	metaJSON := []byte(`{"color":"red"}`)
+	binary.LittleEndian.PutUint64(header[0:8], 7)
+	header[8] = 0
+	binary.LittleEndian.PutUint32(header[9:13], uint32(len(metaJSON)))
+	if _, err := dataFile.Write(header); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := dataFile.Write(metaJSON); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := dataFile.Write(payload); err != nil {
+		t.Fatal(err)
+	}
+	dataFile.Close()
+
+	manifestPath := filepath.Join(baseDir, spacesManifestFileName)
+	record := manifestRecord{Version: currentSpaceLayoutVersion, Op: manifestOpCreate, Space: spaceName}
+	line, _ := json.Marshal(record)
+	if err := os.WriteFile(manifestPath, append(line, '\n'), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	stats, err := DumpAll(baseDir, &buf, "")
+	if err != nil {
+		t.Fatalf("DumpAll failed: %v", err)
+	}
+	if stats.VectorRecords != 1 {
+		t.Fatalf("expected 1 vector dumped, got %d", stats.VectorRecords)
+	}
+
+	restoreDir := t.TempDir()
+	restoreStats, err := RestoreAll(restoreDir, bytes.NewReader(buf.Bytes()), "overwrite")
+	if err != nil {
+		t.Fatalf("RestoreAll failed: %v", err)
+	}
+	if restoreStats.VectorRecords != 1 {
+		t.Fatalf("expected 1 vector restored, got %d", restoreStats.VectorRecords)
+	}
+}
+
 // TestDumpSpaceFilter tests that --space filters correctly.
 func TestDumpSpaceFilter(t *testing.T) {
 	baseDir := t.TempDir()

--- a/internal/spaces/restore.go
+++ b/internal/spaces/restore.go
@@ -298,6 +298,10 @@ func restoreVectorData(spacePath string, meta spaceMeta, data []DumpVectorRecord
 func restoreFlatMetaVectorData(spacePath string, meta spaceMeta, data []DumpVectorRecord, mode string) (int, error) {
 	dataPath := filepath.Join(spacePath, "flat_meta_data.db")
 	dimension := meta.Dimension
+	quantizer, payloadSize, err := flatMetaQuantizer(meta)
+	if err != nil {
+		return 0, err
+	}
 
 	if mode == "merge" {
 		// Read existing live records.
@@ -308,10 +312,14 @@ func restoreFlatMetaVectorData(spacePath string, meta spaceMeta, data []DumpVect
 		existing := make(map[int64]*existEntry)
 		if paths, err := collectFlatMetaDataPaths(spacePath); err == nil {
 			for _, path := range paths {
-				_ = streamFlatMetaFile(path, dimension, func(id int64, tombstone bool, vec []float32, metaBytes []byte) error {
+				_ = streamFlatMetaFile(path, payloadSize, func(id int64, tombstone bool, payload []byte, metaBytes []byte) error {
 					if tombstone {
 						existing[id] = nil
 					} else {
+						vec, err := decodeFlatMetaVectorPayload(payload, dimension, quantizer)
+						if err != nil {
+							return err
+						}
 						existing[id] = &existEntry{vec: vec, metaJSON: metaBytes}
 					}
 					return nil
@@ -374,9 +382,9 @@ func restoreFlatMetaVectorData(spacePath string, meta spaceMeta, data []DumpVect
 			return 0, err
 		}
 
-		vecBuf := make([]byte, 4*dimension)
-		for i, v := range rec.Vector {
-			binary.LittleEndian.PutUint32(vecBuf[i*4:], math.Float32bits(v))
+		vecBuf, err := encodeFlatMetaVectorPayload(rec.Vector, quantizer)
+		if err != nil {
+			return 0, err
 		}
 		if _, err := file.Write(vecBuf); err != nil {
 			return 0, err

--- a/internal/spaces/space_manager.go
+++ b/internal/spaces/space_manager.go
@@ -116,6 +116,26 @@ func isAllowedMetric(metric string) bool {
 	return false
 }
 
+func requireFlatMetaCompression(engineType, indexType string, fields []storage.MetadataFieldSpec, dim int, compression string) error {
+	if compression == "" {
+		return nil
+	}
+	if engineType != "vector" {
+		got := engineType
+		if got == "" {
+			got = "key-value"
+		}
+		return fmt.Errorf("compression is only supported for Flat spaces declared with indexed metadata fields, got engine type %q", got)
+	}
+	if indexType != "Flat" {
+		return fmt.Errorf("compression is only supported for Flat spaces declared with indexed metadata fields, got index type %q", indexType)
+	}
+	if len(fields) == 0 {
+		return errors.New("compression is only supported for Flat spaces declared with indexed metadata fields")
+	}
+	return storage.ValidateVectorCompression(dim, compression)
+}
+
 type spaceMeta struct {
 	LayoutVersion          int    `json:"layout_version,omitempty"`
 	Name                   string `json:"name"`
@@ -554,19 +574,14 @@ func (sm *SpaceManager) CreateSpaceWithSettingsAndMetadata(space, engineType str
 		if err := storage.ValidateVectorIndexConfig(meta.Dimension, meta.IndexType, getFAISSMetric(meta.Metric)); err != nil {
 			return nil, err
 		}
+		if err := requireFlatMetaCompression(engineType, meta.IndexType, meta.IndexedMetadataFields, meta.Dimension, compression); err != nil {
+			return nil, err
+		}
 		if len(meta.IndexedMetadataFields) > 0 {
 			if meta.IndexType != "Flat" {
 				return nil, fmt.Errorf("indexed metadata fields are only supported for the Flat index type, got '%s'", meta.IndexType)
 			}
 			if err := storage.ValidateFieldSpecs(meta.IndexedMetadataFields); err != nil {
-				return nil, err
-			}
-		}
-		if compression != "" {
-			if meta.IndexType != "Flat" || len(meta.IndexedMetadataFields) == 0 {
-				return nil, errors.New("compression is only supported for Flat spaces declared with indexed metadata fields")
-			}
-			if err := storage.ValidateVectorCompression(meta.Dimension, compression); err != nil {
 				return nil, err
 			}
 		}
@@ -577,13 +592,13 @@ func (sm *SpaceManager) CreateSpaceWithSettingsAndMetadata(space, engineType str
 		if len(meta.IndexedMetadataFields) > 0 {
 			return nil, errors.New("indexed metadata fields are only supported for vector spaces")
 		}
-		if compression != "" {
-			return nil, errors.New("compression is only supported for Flat spaces declared with indexed metadata fields")
+		if err := requireFlatMetaCompression(engineType, meta.IndexType, meta.IndexedMetadataFields, meta.Dimension, compression); err != nil {
+			return nil, err
 		}
 	} else if len(meta.IndexedMetadataFields) > 0 {
 		return nil, errors.New("indexed metadata fields are only supported for vector spaces")
-	} else if compression != "" {
-		return nil, errors.New("compression is only supported for Flat spaces declared with indexed metadata fields")
+	} else if err := requireFlatMetaCompression(engineType, meta.IndexType, meta.IndexedMetadataFields, meta.Dimension, compression); err != nil {
+		return nil, err
 	}
 
 	spacePath := filepath.Join(sm.baseDir, space)

--- a/internal/spaces/space_manager.go
+++ b/internal/spaces/space_manager.go
@@ -128,6 +128,8 @@ type spaceMeta struct {
 	MaxSegmentsBeforeMerge int    `json:"max_segments_before_merge,omitempty"`
 
 	IndexedMetadataFields []storage.MetadataFieldSpec `json:"indexed_metadata_fields,omitempty"`
+	// Compression is a TurboQuant scheme for filterable Flat spaces (e.g. TurboQuant4Bits).
+	Compression string `json:"compression,omitempty"`
 }
 
 type manifestRecord struct {
@@ -420,6 +422,10 @@ func normalizeSpaceMeta(meta spaceMeta) spaceMeta {
 		}
 		meta.Metric = ""
 		meta.IndexedMetadataFields = nil
+		meta.Compression = ""
+	}
+	if meta.EngineType == "vector" && (meta.IndexType != "Flat" || len(meta.IndexedMetadataFields) == 0) {
+		meta.Compression = ""
 	}
 	if meta.EngineType == "vector" && len(meta.IndexedMetadataFields) == 0 {
 		meta.SegmentRolloverBytes = 0
@@ -464,7 +470,7 @@ func (sm *SpaceManager) openSpaceEngine(meta spaceMeta) (interface{}, error) {
 		if meta.IndexType == "Flat" && len(meta.IndexedMetadataFields) > 0 {
 			dataFile := filepath.Join(spacePath, "flat_meta_data.db")
 			walFile := filepath.Join(spacePath, "flat_meta_wal.db")
-			return storage.NewFlatMetaVectorEngineWithSettings(dataFile, walFile, meta.Dimension, getFAISSMetric(meta.Metric), meta.IndexedMetadataFields, meta.EnableWAL, settings)
+			return storage.NewFlatMetaVectorEngineWithCompression(dataFile, walFile, meta.Dimension, getFAISSMetric(meta.Metric), meta.IndexedMetadataFields, meta.EnableWAL, settings, meta.Compression)
 		}
 		dataFile := filepath.Join(spacePath, "vector_data.db")
 		indexFile := filepath.Join(spacePath, "vector_index.faiss")
@@ -502,10 +508,10 @@ func (sm *SpaceManager) CreateSpaceWithWAL(space, engineType string, dimension i
 }
 
 func (sm *SpaceManager) CreateSpaceWithSettings(space, engineType string, dimension int, indexType string, metric string, enableWAL bool, settings storage.SpaceSettings) (interface{}, error) {
-	return sm.CreateSpaceWithSettingsAndMetadata(space, engineType, dimension, indexType, metric, enableWAL, settings, nil)
+	return sm.CreateSpaceWithSettingsAndMetadata(space, engineType, dimension, indexType, metric, enableWAL, settings, nil, "")
 }
 
-func (sm *SpaceManager) CreateSpaceWithSettingsAndMetadata(space, engineType string, dimension int, indexType string, metric string, enableWAL bool, settings storage.SpaceSettings, indexedMetadataFields []storage.MetadataFieldSpec) (interface{}, error) {
+func (sm *SpaceManager) CreateSpaceWithSettingsAndMetadata(space, engineType string, dimension int, indexType string, metric string, enableWAL bool, settings storage.SpaceSettings, indexedMetadataFields []storage.MetadataFieldSpec, compression string) (interface{}, error) {
 	sm.lock.Lock()
 	defer sm.lock.Unlock()
 
@@ -514,6 +520,11 @@ func (sm *SpaceManager) CreateSpaceWithSettingsAndMetadata(space, engineType str
 	}
 	if _, exists := sm.spaceMetas[space]; exists {
 		return nil, errors.New("space already exists")
+	}
+
+	compression, err := storage.NormalizeVectorCompression(compression)
+	if err != nil {
+		return nil, err
 	}
 
 	meta := normalizeSpaceMeta(spaceMeta{
@@ -526,6 +537,7 @@ func (sm *SpaceManager) CreateSpaceWithSettingsAndMetadata(space, engineType str
 		SegmentRolloverBytes:   settings.SegmentRolloverBytes,
 		MaxSegmentsBeforeMerge: settings.MaxSegmentsBeforeMerge,
 		IndexedMetadataFields:  indexedMetadataFields,
+		Compression:            compression,
 		LayoutVersion:          currentSpaceLayoutVersion,
 	})
 
@@ -550,6 +562,14 @@ func (sm *SpaceManager) CreateSpaceWithSettingsAndMetadata(space, engineType str
 				return nil, err
 			}
 		}
+		if compression != "" {
+			if meta.IndexType != "Flat" || len(meta.IndexedMetadataFields) == 0 {
+				return nil, errors.New("compression is only supported for Flat spaces declared with indexed metadata fields")
+			}
+			if err := storage.ValidateVectorCompression(meta.Dimension, compression); err != nil {
+				return nil, err
+			}
+		}
 	} else if engineType == "key-value" {
 		if meta.IndexType != "btree" && meta.IndexType != "hashmap" {
 			return nil, fmt.Errorf("index type '%s' is not allowed for key-value engines", meta.IndexType)
@@ -557,8 +577,13 @@ func (sm *SpaceManager) CreateSpaceWithSettingsAndMetadata(space, engineType str
 		if len(meta.IndexedMetadataFields) > 0 {
 			return nil, errors.New("indexed metadata fields are only supported for vector spaces")
 		}
+		if compression != "" {
+			return nil, errors.New("compression is only supported for Flat spaces declared with indexed metadata fields")
+		}
 	} else if len(meta.IndexedMetadataFields) > 0 {
 		return nil, errors.New("indexed metadata fields are only supported for vector spaces")
+	} else if compression != "" {
+		return nil, errors.New("compression is only supported for Flat spaces declared with indexed metadata fields")
 	}
 
 	spacePath := filepath.Join(sm.baseDir, space)

--- a/internal/spaces/space_manager_test.go
+++ b/internal/spaces/space_manager_test.go
@@ -584,6 +584,7 @@ func TestSpaceManager_FilterableFlatKeepsSegmentSettings(t *testing.T) {
 		"flat_meta_seg", "vector", 4, "Flat", "L2", true,
 		storage.SpaceSettings{SegmentRolloverBytes: 2048, MaxSegmentsBeforeMerge: 9},
 		[]storage.MetadataFieldSpec{{Name: "user_id", Type: storage.MetadataTypeString}},
+		"",
 	); err != nil {
 		t.Fatalf("CreateSpaceWithSettingsAndMetadata: %v", err)
 	}
@@ -594,5 +595,47 @@ func TestSpaceManager_FilterableFlatKeepsSegmentSettings(t *testing.T) {
 	if meta.SegmentRolloverBytes != 2048 || meta.MaxSegmentsBeforeMerge != 9 {
 		t.Fatalf("filterable Flat space lost segment settings, got rollover=%d merge=%d",
 			meta.SegmentRolloverBytes, meta.MaxSegmentsBeforeMerge)
+	}
+}
+
+func TestSpaceManager_TurboQuantCompression(t *testing.T) {
+	dir := t.TempDir()
+	sm := NewSpaceManager(dir)
+	defer sm.CloseAll()
+
+	fields := []storage.MetadataFieldSpec{{Name: "user_id", Type: storage.MetadataTypeString}}
+	if _, err := sm.CreateSpaceWithSettingsAndMetadata(
+		"tq4", "vector", 8, "Flat", "L2", false,
+		storage.SpaceSettings{}, fields, storage.VectorCompressionTurboQuant4Bits,
+	); err != nil {
+		t.Fatalf("create compressed space: %v", err)
+	}
+	meta, ok := sm.SpaceMeta("tq4")
+	if !ok {
+		t.Fatal("SpaceMeta missing")
+	}
+	if meta.Compression != storage.VectorCompressionTurboQuant4Bits {
+		t.Fatalf("Compression = %q, want %q", meta.Compression, storage.VectorCompressionTurboQuant4Bits)
+	}
+
+	if _, err := sm.CreateSpaceWithSettingsAndMetadata(
+		"plain_comp", "vector", 8, "Flat", "L2", false,
+		storage.SpaceSettings{}, nil, storage.VectorCompressionTurboQuant4Bits,
+	); err == nil {
+		t.Fatal("expected error: compression requires indexed metadata fields")
+	}
+
+	if _, err := sm.CreateSpaceWithSettingsAndMetadata(
+		"hnsw_comp", "vector", 8, "HNSW32", "L2", false,
+		storage.SpaceSettings{}, fields, storage.VectorCompressionTurboQuant4Bits,
+	); err == nil {
+		t.Fatal("expected error: compression requires Flat index with metadata fields")
+	}
+
+	if _, err := sm.CreateSpaceWithSettingsAndMetadata(
+		"kv_comp", "key-value", 0, "btree", "", false,
+		storage.SpaceSettings{}, nil, storage.VectorCompressionTurboQuant4Bits,
+	); err == nil {
+		t.Fatal("expected error: compression is not supported for key-value spaces")
 	}
 }

--- a/internal/spaces/space_manager_test.go
+++ b/internal/spaces/space_manager_test.go
@@ -618,24 +618,40 @@ func TestSpaceManager_TurboQuantCompression(t *testing.T) {
 		t.Fatalf("Compression = %q, want %q", meta.Compression, storage.VectorCompressionTurboQuant4Bits)
 	}
 
-	if _, err := sm.CreateSpaceWithSettingsAndMetadata(
-		"plain_comp", "vector", 8, "Flat", "L2", false,
-		storage.SpaceSettings{}, nil, storage.VectorCompressionTurboQuant4Bits,
-	); err == nil {
-		t.Fatal("expected error: compression requires indexed metadata fields")
+	comp := storage.VectorCompressionTurboQuant4Bits
+	cases := []struct {
+		name      string
+		engine    string
+		indexType string
+		fields    []storage.MetadataFieldSpec
+		wantSub   string
+	}{
+		{"faiss flat without metadata", "vector", "Flat", nil, "indexed metadata fields"},
+		{"hnsw32", "vector", "HNSW32", nil, `got index type "HNSW32"`},
+		{"hnsw32 with metadata fields", "vector", "HNSW32", fields, `got index type "HNSW32"`},
+		{"ivf32 flat", "vector", "IVF32,Flat", nil, `got index type "IVF32,Flat"`},
+		{"pq8", "vector", "PQ8", nil, `got index type "PQ8"`},
+		{"key-value btree", "key-value", "btree", nil, `got engine type "key-value"`},
 	}
-
-	if _, err := sm.CreateSpaceWithSettingsAndMetadata(
-		"hnsw_comp", "vector", 8, "HNSW32", "L2", false,
-		storage.SpaceSettings{}, fields, storage.VectorCompressionTurboQuant4Bits,
-	); err == nil {
-		t.Fatal("expected error: compression requires Flat index with metadata fields")
-	}
-
-	if _, err := sm.CreateSpaceWithSettingsAndMetadata(
-		"kv_comp", "key-value", 0, "btree", "", false,
-		storage.SpaceSettings{}, nil, storage.VectorCompressionTurboQuant4Bits,
-	); err == nil {
-		t.Fatal("expected error: compression is not supported for key-value spaces")
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			space := fmt.Sprintf("reject_comp_%d", i)
+			_, err := sm.CreateSpaceWithSettingsAndMetadata(
+				space, tc.engine, 8, tc.indexType, "L2", false,
+				storage.SpaceSettings{}, tc.fields, comp,
+			)
+			if err == nil {
+				t.Fatalf("expected error creating %s with --compression", tc.name)
+			}
+			if !strings.Contains(err.Error(), "compression is only supported for Flat spaces declared with indexed metadata fields") {
+				t.Fatalf("error %q missing compression restriction", err)
+			}
+			if tc.wantSub != "" && !strings.Contains(err.Error(), tc.wantSub) {
+				t.Fatalf("error %q, want substring %q", err, tc.wantSub)
+			}
+			if _, ok := sm.SpaceMeta(space); ok {
+				t.Fatalf("rejected space %q should not be published", space)
+			}
+		})
 	}
 }

--- a/internal/storage/flat_meta_vector_storage.go
+++ b/internal/storage/flat_meta_vector_storage.go
@@ -27,7 +27,9 @@ import (
 // an unfiltered query scans all live vectors. Vectors and indexes live in
 // memory; durability is provided by a set of append-only segment data files plus
 // the WAL, and the in-memory indexes are rebuilt by scanning the segments on
-// open.
+// open. When created with TurboQuant compression, live vectors are stored in
+// quantized form (in memory and on disk) and reconstructed for search and
+// GetVectorByID; ranking is approximate.
 //
 // Persistence uses the same segmented layout as the key-value engine: writes
 // land in the active (hot) segment, which is sealed and
@@ -48,10 +50,13 @@ type FlatMetaVectorEngine struct {
 
 	lock sync.RWMutex
 
-	settings SpaceSettings
+	settings    SpaceSettings
+	compression string
+	quantizer   *VectorQuantizer // nil when uncompressed
 
 	// In-memory state (guarded by lock).
-	vectors  map[int64][]float32
+	vectors  map[int64][]float32 // live float32 vectors when uncompressed
+	qvectors map[int64][]byte    // serialized TurboQuant payloads when compressed
 	metadata map[int64]map[string]any
 	liveIDs  *roaring64.Bitmap
 	// stringIdx: field -> value -> set of ids (equality / IN).
@@ -93,7 +98,7 @@ type flatMetaRecord struct {
 	tombstone bool
 	raw       []byte
 	meta      []byte
-	vec       []float32
+	payload   []byte // on-disk vector bytes (float32 or quantized)
 }
 
 type flatMetaNumEntry struct {
@@ -107,7 +112,7 @@ type flatMetaPersistItem struct {
 	id        int64
 	tombstone bool
 	meta      []byte
-	vec       []float32
+	payload   []byte // on-disk vector bytes (float32 or quantized)
 }
 
 const flatMetaDataFlagLive = 0
@@ -126,11 +131,34 @@ func NewFlatMetaVectorEngine(dataPath, walPath string, dim, metric int, specs []
 // NewFlatMetaVectorEngineWithSettings opens (or creates) a filterable Flat vector
 // space using the provided segment rollover/merge settings.
 func NewFlatMetaVectorEngineWithSettings(dataPath, walPath string, dim, metric int, specs []MetadataFieldSpec, enableWAL bool, settings SpaceSettings) (*FlatMetaVectorEngine, error) {
+	return NewFlatMetaVectorEngineWithCompression(dataPath, walPath, dim, metric, specs, enableWAL, settings, VectorCompressionNone)
+}
+
+// NewFlatMetaVectorEngineWithCompression opens (or creates) a filterable Flat
+// vector space, optionally storing TurboQuant-compressed vectors in memory and
+// on disk. compression is one of VectorCompressionNone, TurboQuant2Bits,
+// TurboQuant3Bits, or TurboQuant4Bits.
+func NewFlatMetaVectorEngineWithCompression(dataPath, walPath string, dim, metric int, specs []MetadataFieldSpec, enableWAL bool, settings SpaceSettings, compression string) (*FlatMetaVectorEngine, error) {
 	if dim <= 0 {
 		return nil, fmt.Errorf("invalid vector dimension %d", dim)
 	}
 	if err := ValidateFieldSpecs(specs); err != nil {
 		return nil, err
+	}
+	compression, err := NormalizeVectorCompression(compression)
+	if err != nil {
+		return nil, err
+	}
+	if err := ValidateVectorCompression(dim, compression); err != nil {
+		return nil, err
+	}
+
+	var quantizer *VectorQuantizer
+	if compression != VectorCompressionNone {
+		quantizer, err = NewVectorQuantizer(dim, compression)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	var w *wal.WAL
@@ -149,7 +177,10 @@ func NewFlatMetaVectorEngineWithSettings(dataPath, walPath string, dim, metric i
 		specTypes:       fieldSpecTypes(specs),
 		wal:             w,
 		settings:        NormalizeSpaceSettings(settings),
+		compression:     compression,
+		quantizer:       quantizer,
 		vectors:         make(map[int64][]float32),
+		qvectors:        make(map[int64][]byte),
 		metadata:        make(map[int64]map[string]any),
 		liveIDs:         roaring64.New(),
 		stringIdx:       make(map[string]map[string]*roaring64.Bitmap),
@@ -267,7 +298,7 @@ func (e *FlatMetaVectorEngine) loadSegments() error {
 func (e *FlatMetaVectorEngine) rebuildInMemoryLocked() error {
 	for _, segment := range e.segments {
 		desc := e.layout.Descriptor(segment.meta)
-		err := streamFlatMetaDataFile(desc.DataPath, e.dim, func(rec flatMetaRecord) error {
+		err := streamFlatMetaDataFile(desc.DataPath, e.vectorPayloadSize(), func(rec flatMetaRecord) error {
 			if rec.tombstone {
 				e.indexRemoveLocked(rec.id)
 				return nil
@@ -282,7 +313,11 @@ func (e *FlatMetaVectorEngine) rebuildInMemoryLocked() error {
 			if err != nil {
 				return fmt.Errorf("metadata for id %d: %w", rec.id, err)
 			}
-			e.indexInsertLocked(rec.id, rec.vec, norm)
+			vec, err := e.decodeStoredVector(rec.payload)
+			if err != nil {
+				return fmt.Errorf("decode vector for id %d: %w", rec.id, err)
+			}
+			e.indexInsertLocked(rec.id, vec, rec.payload, norm)
 			return nil
 		})
 		if err != nil {
@@ -318,7 +353,7 @@ func (e *FlatMetaVectorEngine) RangeSearch(query []float32, radius float32) ([]i
 func (e *FlatMetaVectorEngine) GetVectorByID(id int64) ([]float32, error) {
 	e.lock.RLock()
 	defer e.lock.RUnlock()
-	vec, ok := e.vectors[id]
+	vec, ok := e.liveVectorLocked(id)
 	if !ok {
 		return nil, fmt.Errorf("ID %d not found", id)
 	}
@@ -395,20 +430,28 @@ func (e *FlatMetaVectorEngine) InsertVectorWithMetadata(id int64, vector []float
 		return fmt.Errorf("encode metadata: %w", err)
 	}
 
+	payload, err := e.encodeVectorPayload(vector)
+	if err != nil {
+		return err
+	}
+
 	if e.wal != nil {
 		key := make([]byte, 8)
 		binary.LittleEndian.PutUint64(key, uint64(id))
-		if err := e.wal.WriteEntry(string(key), string(encodeFlatMetaWALValue(metaBytes, vector))); err != nil {
+		if err := e.wal.WriteEntry(string(key), string(encodeFlatMetaWALValue(metaBytes, payload))); err != nil {
 			return err
 		}
 	}
 
-	vecCopy := append([]float32(nil), vector...)
+	var vecCopy []float32
+	if e.quantizer == nil {
+		vecCopy = append([]float32(nil), vector...)
+	}
 	e.lock.Lock()
-	e.indexInsertLocked(id, vecCopy, norm)
+	e.indexInsertLocked(id, vecCopy, payload, norm)
 	e.lock.Unlock()
 
-	e.enqueuePersist(flatMetaPersistItem{id: id, meta: metaBytes, vec: vecCopy})
+	e.enqueuePersist(flatMetaPersistItem{id: id, meta: metaBytes, payload: payload})
 	if e.wal != nil {
 		return e.wal.MarkCommitted()
 	}
@@ -627,7 +670,7 @@ func (e *FlatMetaVectorEngine) scoreCandidatesLocked(query []float32, candidates
 	pairs := make([]flatMetaPair, 0, len(ids))
 	for _, u := range ids {
 		id := int64(u)
-		vec, ok := e.vectors[id]
+		vec, ok := e.liveVectorLocked(id)
 		if !ok {
 			continue
 		}
@@ -652,11 +695,17 @@ func splitPairs(pairs []flatMetaPair) ([]int64, []float32, error) {
 
 // === in-memory index maintenance (lock held) ===
 
-func (e *FlatMetaVectorEngine) indexInsertLocked(id int64, vec []float32, norm map[string]any) {
+func (e *FlatMetaVectorEngine) indexInsertLocked(id int64, vec []float32, payload []byte, norm map[string]any) {
 	if old, ok := e.metadata[id]; ok {
 		e.removeFromIndexesLocked(id, old)
 	}
-	e.vectors[id] = vec
+	if e.quantizer != nil {
+		e.qvectors[id] = payload
+		delete(e.vectors, id)
+	} else {
+		e.vectors[id] = vec
+		delete(e.qvectors, id)
+	}
 	e.metadata[id] = norm
 	e.liveIDs.Add(uint64(id))
 	e.addToIndexesLocked(id, norm)
@@ -667,8 +716,51 @@ func (e *FlatMetaVectorEngine) indexRemoveLocked(id int64) {
 		e.removeFromIndexesLocked(id, old)
 	}
 	delete(e.vectors, id)
+	delete(e.qvectors, id)
 	delete(e.metadata, id)
 	e.liveIDs.Remove(uint64(id))
+}
+
+func (e *FlatMetaVectorEngine) liveVectorLocked(id int64) ([]float32, bool) {
+	if e.quantizer != nil {
+		data, ok := e.qvectors[id]
+		if !ok {
+			return nil, false
+		}
+		vec, err := e.quantizer.Dequantize(data)
+		if err != nil {
+			logger.Errorf("storage", "flat-meta dequantize failed for id=%d: %v", id, err)
+			return nil, false
+		}
+		return vec, true
+	}
+	vec, ok := e.vectors[id]
+	return vec, ok
+}
+
+func (e *FlatMetaVectorEngine) vectorPayloadSize() int {
+	if e.quantizer != nil {
+		return e.quantizer.PayloadSize()
+	}
+	return 4 * e.dim
+}
+
+func (e *FlatMetaVectorEngine) encodeVectorPayload(vector []float32) ([]byte, error) {
+	if e.quantizer != nil {
+		return e.quantizer.Quantize(vector)
+	}
+	return encodeFloat32Vector(vector), nil
+}
+
+func (e *FlatMetaVectorEngine) decodeStoredVector(payload []byte) ([]float32, error) {
+	if e.quantizer != nil {
+		if len(payload) != e.quantizer.PayloadSize() {
+			return nil, fmt.Errorf("quantized vector length mismatch: expected %d bytes, got %d", e.quantizer.PayloadSize(), len(payload))
+		}
+		// Compressed payloads are kept as-is; float32 is reconstructed on read.
+		return nil, nil
+	}
+	return decodeFloat32Vector(payload, e.dim)
 }
 
 func (e *FlatMetaVectorEngine) addToIndexesLocked(id int64, norm map[string]any) {
@@ -827,7 +919,7 @@ func (e *FlatMetaVectorEngine) flushData(force bool) {
 }
 
 // appendFlatMetaRecord appends one record to file.
-// Layout: [id:8][flag:1][metaLen:4][meta][vector: dim*4 (live only)].
+// Layout: [id:8][flag:1][metaLen:4][meta][vector payload (live only)].
 func appendFlatMetaRecord(file *os.File, item flatMetaPersistItem) error {
 	header := make([]byte, 13)
 	binary.LittleEndian.PutUint64(header[0:8], uint64(item.id))
@@ -843,14 +935,10 @@ func appendFlatMetaRecord(file *os.File, item flatMetaPersistItem) error {
 
 	header[8] = flatMetaDataFlagLive
 	binary.LittleEndian.PutUint32(header[9:13], uint32(len(item.meta)))
-	body := make([]byte, 0, 13+len(item.meta)+4*len(item.vec))
+	body := make([]byte, 0, 13+len(item.meta)+len(item.payload))
 	body = append(body, header...)
 	body = append(body, item.meta...)
-	vecBytes := make([]byte, 4*len(item.vec))
-	for i, v := range item.vec {
-		binary.LittleEndian.PutUint32(vecBytes[i*4:], math.Float32bits(v))
-	}
-	body = append(body, vecBytes...)
+	body = append(body, item.payload...)
 	if _, err := file.Seek(0, io.SeekEnd); err != nil {
 		return err
 	}
@@ -1043,7 +1131,7 @@ func (e *FlatMetaVectorEngine) tryMergeOldestColdSegments() bool {
 // keeping the latest record per id (including tombstones). It returns the new
 // segment meta and an open handle to the merged file.
 func (e *FlatMetaVectorEngine) mergeSegments(newID int64, firstDesc, secondDesc SegmentDescriptor) (SegmentMeta, *os.File, error) {
-	latestRecords, err := collectLatestFlatMetaRecords(e.dim, firstDesc.DataPath, secondDesc.DataPath)
+	latestRecords, err := collectLatestFlatMetaRecords(e.vectorPayloadSize(), firstDesc.DataPath, secondDesc.DataPath)
 	if err != nil {
 		return SegmentMeta{}, nil, err
 	}
@@ -1069,10 +1157,10 @@ func (e *FlatMetaVectorEngine) mergeSegments(newID int64, firstDesc, secondDesc 
 	return meta, dataFile, nil
 }
 
-func collectLatestFlatMetaRecords(dim int, paths ...string) (map[int64][]byte, error) {
+func collectLatestFlatMetaRecords(payloadSize int, paths ...string) (map[int64][]byte, error) {
 	records := make(map[int64][]byte)
 	for _, path := range paths {
-		err := streamFlatMetaDataFile(path, dim, func(rec flatMetaRecord) error {
+		err := streamFlatMetaDataFile(path, payloadSize, func(rec flatMetaRecord) error {
 			records[rec.id] = append([]byte(nil), rec.raw...)
 			return nil
 		})
@@ -1138,7 +1226,7 @@ func (e *FlatMetaVectorEngine) replayWAL() error {
 			}
 			continue
 		}
-		metaBytes, vec, err := decodeFlatMetaWALValue([]byte(entry.Value), e.dim)
+		metaBytes, payload, err := decodeFlatMetaWALValue([]byte(entry.Value), e.vectorPayloadSize())
 		if err != nil {
 			return fmt.Errorf("decode WAL value for id %d: %w", id, err)
 		}
@@ -1152,10 +1240,14 @@ func (e *FlatMetaVectorEngine) replayWAL() error {
 		if err != nil {
 			return err
 		}
+		vec, err := e.decodeStoredVector(payload)
+		if err != nil {
+			return fmt.Errorf("decode WAL vector for id %d: %w", id, err)
+		}
 		e.lock.Lock()
-		e.indexInsertLocked(id, vec, norm)
+		e.indexInsertLocked(id, vec, payload, norm)
 		e.lock.Unlock()
-		e.enqueuePersist(flatMetaPersistItem{id: id, meta: metaBytes, vec: vec})
+		e.enqueuePersist(flatMetaPersistItem{id: id, meta: metaBytes, payload: payload})
 	}
 	e.flushData(true)
 	return e.wal.Clear()
@@ -1164,7 +1256,7 @@ func (e *FlatMetaVectorEngine) replayWAL() error {
 // streamFlatMetaDataFile reads an append-only data file record by record (in file
 // order) and invokes fn for each. A truncated trailing record (e.g. from a crash
 // mid-append) is treated as end-of-file. A missing file is not an error.
-func streamFlatMetaDataFile(path string, dim int, fn func(flatMetaRecord) error) error {
+func streamFlatMetaDataFile(path string, payloadSize int, fn func(flatMetaRecord) error) error {
 	file, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -1199,37 +1291,49 @@ func streamFlatMetaDataFile(path string, dim int, fn func(flatMetaRecord) error)
 			}
 			continue
 		}
-		vecBuf := make([]byte, 4*dim)
+		vecBuf := make([]byte, payloadSize)
 		if _, err := io.ReadFull(file, vecBuf); err != nil {
 			break
-		}
-		vec := make([]float32, dim)
-		for i := 0; i < dim; i++ {
-			vec[i] = math.Float32frombits(binary.LittleEndian.Uint32(vecBuf[i*4:]))
 		}
 		raw := make([]byte, 0, 13+len(metaBuf)+len(vecBuf))
 		raw = append(raw, header...)
 		raw = append(raw, metaBuf...)
 		raw = append(raw, vecBuf...)
-		if err := fn(flatMetaRecord{id: id, tombstone: false, raw: raw, meta: metaBuf, vec: vec}); err != nil {
+		if err := fn(flatMetaRecord{id: id, tombstone: false, raw: raw, meta: metaBuf, payload: vecBuf}); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func encodeFlatMetaWALValue(meta []byte, vec []float32) []byte {
-	buf := make([]byte, 4+len(meta)+4*len(vec))
-	binary.LittleEndian.PutUint32(buf[0:4], uint32(len(meta)))
-	copy(buf[4:], meta)
-	off := 4 + len(meta)
+func encodeFloat32Vector(vec []float32) []byte {
+	buf := make([]byte, 4*len(vec))
 	for i, v := range vec {
-		binary.LittleEndian.PutUint32(buf[off+i*4:], math.Float32bits(v))
+		binary.LittleEndian.PutUint32(buf[i*4:], math.Float32bits(v))
 	}
 	return buf
 }
 
-func decodeFlatMetaWALValue(b []byte, dim int) ([]byte, []float32, error) {
+func decodeFloat32Vector(b []byte, dim int) ([]float32, error) {
+	if len(b) != 4*dim {
+		return nil, fmt.Errorf("vector length mismatch: expected %d bytes, got %d", 4*dim, len(b))
+	}
+	vec := make([]float32, dim)
+	for i := 0; i < dim; i++ {
+		vec[i] = math.Float32frombits(binary.LittleEndian.Uint32(b[i*4:]))
+	}
+	return vec, nil
+}
+
+func encodeFlatMetaWALValue(meta []byte, payload []byte) []byte {
+	buf := make([]byte, 4+len(meta)+len(payload))
+	binary.LittleEndian.PutUint32(buf[0:4], uint32(len(meta)))
+	copy(buf[4:], meta)
+	copy(buf[4+len(meta):], payload)
+	return buf
+}
+
+func decodeFlatMetaWALValue(b []byte, payloadSize int) ([]byte, []byte, error) {
 	if len(b) < 4 {
 		return nil, nil, fmt.Errorf("short WAL value")
 	}
@@ -1238,15 +1342,11 @@ func decodeFlatMetaWALValue(b []byte, dim int) ([]byte, []float32, error) {
 		return nil, nil, fmt.Errorf("truncated WAL metadata")
 	}
 	meta := b[4 : 4+metaLen]
-	vecBytes := b[4+metaLen:]
-	if len(vecBytes) != 4*dim {
-		return nil, nil, fmt.Errorf("WAL vector length mismatch: expected %d bytes, got %d", 4*dim, len(vecBytes))
+	payload := b[4+metaLen:]
+	if len(payload) != payloadSize {
+		return nil, nil, fmt.Errorf("WAL vector length mismatch: expected %d bytes, got %d", payloadSize, len(payload))
 	}
-	vec := make([]float32, dim)
-	for i := 0; i < dim; i++ {
-		vec[i] = math.Float32frombits(binary.LittleEndian.Uint32(vecBytes[i*4:]))
-	}
-	return append([]byte(nil), meta...), vec, nil
+	return append([]byte(nil), meta...), append([]byte(nil), payload...), nil
 }
 
 // === distances ===

--- a/internal/storage/flat_meta_vector_storage_test.go
+++ b/internal/storage/flat_meta_vector_storage_test.go
@@ -377,7 +377,7 @@ func TestFlatMetaWALReplay(t *testing.T) {
 	key := make([]byte, 8)
 	binary.LittleEndian.PutUint64(key, uint64(7))
 	meta, _ := json.Marshal(map[string]any{"user_id": "alice"})
-	if err := w.WriteEntry(string(key), string(encodeFlatMetaWALValue(meta, []float32{1, 2}))); err != nil {
+	if err := w.WriteEntry(string(key), string(encodeFlatMetaWALValue(meta, encodeFloat32Vector([]float32{1, 2})))); err != nil {
 		t.Fatalf("wal write: %v", err)
 	}
 	_ = w.Close()
@@ -648,5 +648,125 @@ func TestFlatMetaFAISSParity(t *testing.T) {
 				t.Errorf("metric %s: nearest id mismatch faiss=%d meta=%d", name, faissIDs[0], metaIDs[0])
 			}
 		})
+	}
+}
+
+func newTestFlatMetaEngineWithCompression(t *testing.T, dim, metric int, specs []MetadataFieldSpec, compression string, enableWAL bool) *FlatMetaVectorEngine {
+	t.Helper()
+	dir := t.TempDir()
+	e, err := NewFlatMetaVectorEngineWithCompression(
+		filepath.Join(dir, "flat_meta_data.db"),
+		filepath.Join(dir, "flat_meta_wal.db"),
+		dim, metric, specs, enableWAL, SpaceSettings{}, compression,
+	)
+	if err != nil {
+		t.Fatalf("NewFlatMetaVectorEngineWithCompression(%s): %v", compression, err)
+	}
+	t.Cleanup(func() { _ = e.Close() })
+	return e
+}
+
+func TestFlatMetaTurboQuantSearchAndFilter(t *testing.T) {
+	specs := []MetadataFieldSpec{{Name: "user_id", Type: MetadataTypeString}}
+	const dim = 8
+	query := []float32{1, 0, 0, 0, 0, 0, 0, 0}
+	alice := []float32{1, 0, 0, 0, 0, 0, 0, 0}
+	bob := []float32{0, 1, 0, 0, 0, 0, 0, 0}
+	carol := []float32{0, 0, 1, 0, 0, 0, 0, 0}
+
+	for _, scheme := range []string{VectorCompressionTurboQuant2Bits, VectorCompressionTurboQuant3Bits, VectorCompressionTurboQuant4Bits} {
+		t.Run(scheme, func(t *testing.T) {
+			e := newTestFlatMetaEngineWithCompression(t, dim, faiss.MetricL2, specs, scheme, false)
+			if e.quantizer == nil {
+				t.Fatal("expected quantizer to be initialized")
+			}
+			mustInsert := func(id int64, vec []float32, user string) {
+				if err := e.InsertVectorWithMetadata(id, vec, map[string]any{"user_id": user}); err != nil {
+					t.Fatalf("insert %d: %v", id, err)
+				}
+			}
+			mustInsert(1, alice, "alice")
+			mustInsert(2, bob, "bob")
+			mustInsert(3, carol, "alice")
+
+			ids, _, err := e.SearchTopK(query, 1)
+			if err != nil {
+				t.Fatalf("SearchTopK: %v", err)
+			}
+			if len(ids) != 1 || ids[0] != 1 {
+				t.Fatalf("expected nearest id 1, got %v", ids)
+			}
+
+			got, err := e.GetVectorByID(1)
+			if err != nil {
+				t.Fatalf("GetVectorByID: %v", err)
+			}
+			if cosineSimilarity(alice, got) < 0.7 {
+				t.Fatalf("reconstructed vector cosine too low: %f", cosineSimilarity(alice, got))
+			}
+
+			filtered, _, err := e.SearchTopKFiltered(query, 10, &MetadataFilter{Op: FilterOpEq, Field: "user_id", Value: "alice"})
+			if err != nil {
+				t.Fatalf("filtered search: %v", err)
+			}
+			assertIDSet(t, filtered, 1, 3)
+		})
+	}
+}
+
+func TestFlatMetaTurboQuantPersistenceRebuild(t *testing.T) {
+	dir := t.TempDir()
+	dataPath := filepath.Join(dir, "flat_meta_data.db")
+	walPath := filepath.Join(dir, "flat_meta_wal.db")
+	specs := []MetadataFieldSpec{{Name: "user_id", Type: MetadataTypeString}}
+	const dim = 8
+	alice := []float32{1, 0, 0, 0, 0, 0, 0, 0}
+	bob := []float32{0, 1, 0, 0, 0, 0, 0, 0}
+
+	e1, err := NewFlatMetaVectorEngineWithCompression(dataPath, walPath, dim, faiss.MetricL2, specs, false, SpaceSettings{}, VectorCompressionTurboQuant4Bits)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := e1.InsertVectorWithMetadata(1, alice, map[string]any{"user_id": "alice"}); err != nil {
+		t.Fatalf("insert 1: %v", err)
+	}
+	if err := e1.InsertVectorWithMetadata(2, bob, map[string]any{"user_id": "bob"}); err != nil {
+		t.Fatalf("insert 2: %v", err)
+	}
+	if err := e1.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	e2, err := NewFlatMetaVectorEngineWithCompression(dataPath, walPath, dim, faiss.MetricL2, specs, false, SpaceSettings{}, VectorCompressionTurboQuant4Bits)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	t.Cleanup(func() { _ = e2.Close() })
+
+	ids, _, err := e2.SearchTopK(alice, 1)
+	if err != nil {
+		t.Fatalf("search after restart: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != 1 {
+		t.Fatalf("expected nearest id 1 after restart, got %v", ids)
+	}
+	filtered, _, err := e2.SearchTopKFiltered(alice, 10, &MetadataFilter{Op: FilterOpEq, Field: "user_id", Value: "bob"})
+	if err != nil {
+		t.Fatalf("filtered search after restart: %v", err)
+	}
+	assertIDSet(t, filtered, 2)
+}
+
+func TestNewFlatMetaVectorEngineRejectsUnknownCompression(t *testing.T) {
+	dir := t.TempDir()
+	_, err := NewFlatMetaVectorEngineWithCompression(
+		filepath.Join(dir, "flat_meta_data.db"),
+		filepath.Join(dir, "flat_meta_wal.db"),
+		8, faiss.MetricL2,
+		[]MetadataFieldSpec{{Name: "user_id", Type: MetadataTypeString}},
+		false, SpaceSettings{}, "TurboQuant8Bits",
+	)
+	if err == nil {
+		t.Fatal("expected error for unsupported compression")
 	}
 }

--- a/internal/storage/vector_compression.go
+++ b/internal/storage/vector_compression.go
@@ -1,0 +1,152 @@
+package storage
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mredencom/turboquant"
+)
+
+// Vector compression schemes for the filterable Flat (flat-meta) engine.
+// These names are the CREATE-SPACE --compression values.
+const (
+	VectorCompressionNone            = ""
+	VectorCompressionTurboQuant2Bits = "TurboQuant2Bits"
+	VectorCompressionTurboQuant3Bits = "TurboQuant3Bits"
+	VectorCompressionTurboQuant4Bits = "TurboQuant4Bits"
+)
+
+// turboQuantRotationSeed is the orthogonal-rotation seed passed to TurboQuant.
+// It must stay constant so persisted quantized payloads dequantize with the same
+// rotation that produced them.
+const turboQuantRotationSeed int64 = 42
+
+// NormalizeVectorCompression validates a user-supplied --compression value
+// (empty means uncompressed). Comparison is case-sensitive to match the
+// documented names.
+func NormalizeVectorCompression(s string) (string, error) {
+	switch s {
+	case VectorCompressionNone:
+		return VectorCompressionNone, nil
+	case VectorCompressionTurboQuant2Bits, VectorCompressionTurboQuant3Bits, VectorCompressionTurboQuant4Bits:
+		return s, nil
+	default:
+		return "", fmt.Errorf("unsupported compression %q; valid values: %s", s, SupportedVectorCompressions())
+	}
+}
+
+// ValidateVectorCompression checks that compression is valid for the given
+// dimension. TurboQuant requires dimension >= 2.
+func ValidateVectorCompression(dim int, compression string) error {
+	c, err := NormalizeVectorCompression(compression)
+	if err != nil {
+		return err
+	}
+	if c == VectorCompressionNone {
+		return nil
+	}
+	if dim < 2 {
+		return fmt.Errorf("TurboQuant compression requires dimension >= 2, got %d", dim)
+	}
+	return nil
+}
+
+func turboQuantBitWidth(compression string) (int, error) {
+	switch compression {
+	case VectorCompressionTurboQuant2Bits:
+		return turboquant.Bit2, nil
+	case VectorCompressionTurboQuant3Bits:
+		return turboquant.Bit3, nil
+	case VectorCompressionTurboQuant4Bits:
+		return turboquant.Bit4, nil
+	default:
+		return 0, fmt.Errorf("not a TurboQuant compression: %q", compression)
+	}
+}
+
+// VectorQuantizer wraps a TurboQuant instance for a space's dimension and bit width.
+type VectorQuantizer struct {
+	compression string
+	bitWidth    int
+	payloadSize int
+	tq          *turboquant.TurboQuant
+}
+
+// NewVectorQuantizer builds a quantizer for dim and compression.
+// compression must already be a recognized TurboQuant scheme (not empty).
+func NewVectorQuantizer(dim int, compression string) (*VectorQuantizer, error) {
+	if err := ValidateVectorCompression(dim, compression); err != nil {
+		return nil, err
+	}
+	c, err := NormalizeVectorCompression(compression)
+	if err != nil {
+		return nil, err
+	}
+	if c == VectorCompressionNone {
+		return nil, fmt.Errorf("NewVectorQuantizer requires a TurboQuant compression scheme")
+	}
+	bitWidth, err := turboQuantBitWidth(c)
+	if err != nil {
+		return nil, err
+	}
+	tq, err := turboquant.NewTurboQuant(dim, bitWidth, turboQuantRotationSeed)
+	if err != nil {
+		return nil, fmt.Errorf("init TurboQuant (dim=%d bits=%d): %w", dim, bitWidth, err)
+	}
+	return &VectorQuantizer{
+		compression: c,
+		bitWidth:    bitWidth,
+		payloadSize: quantizedPayloadSize(dim, bitWidth),
+		tq:          tq,
+	}, nil
+}
+
+// Compression returns the scheme name (e.g. TurboQuant4Bits).
+func (q *VectorQuantizer) Compression() string { return q.compression }
+
+// PayloadSize is the on-disk / in-memory byte length of one quantized vector.
+func (q *VectorQuantizer) PayloadSize() int { return q.payloadSize }
+
+// Quantize compresses a float32 vector into the compact serialized form.
+func (q *VectorQuantizer) Quantize(vec []float32) ([]byte, error) {
+	qv, err := q.tq.Quantize(vec)
+	if err != nil {
+		return nil, err
+	}
+	return q.tq.Serialize(qv)
+}
+
+// Dequantize reconstructs an approximate float32 vector from a serialized payload.
+func (q *VectorQuantizer) Dequantize(data []byte) ([]float32, error) {
+	qv, err := q.tq.Deserialize(data)
+	if err != nil {
+		return nil, err
+	}
+	return q.tq.Dequantize(qv)
+}
+
+func quantizedPayloadSize(dimension, bitWidth int) int {
+	return 4 + quantizedIndexBytes(dimension, bitWidth)
+}
+
+func quantizedIndexBytes(dimension, bitWidth int) int {
+	switch bitWidth {
+	case turboquant.Bit2:
+		return (dimension + 3) / 4
+	case turboquant.Bit3:
+		return (dimension*3 + 7) / 8
+	case turboquant.Bit4:
+		return (dimension + 1) / 2
+	default:
+		return 0
+	}
+}
+
+// SupportedVectorCompressions is a comma-separated list for CLI/help text.
+func SupportedVectorCompressions() string {
+	return strings.Join([]string{
+		VectorCompressionTurboQuant2Bits,
+		VectorCompressionTurboQuant3Bits,
+		VectorCompressionTurboQuant4Bits,
+	}, ", ")
+}

--- a/internal/storage/vector_compression_test.go
+++ b/internal/storage/vector_compression_test.go
@@ -1,0 +1,94 @@
+package storage
+
+import (
+	"math"
+	"testing"
+)
+
+func TestNormalizeVectorCompression(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"", VectorCompressionNone, false},
+		{VectorCompressionTurboQuant2Bits, VectorCompressionTurboQuant2Bits, false},
+		{VectorCompressionTurboQuant3Bits, VectorCompressionTurboQuant3Bits, false},
+		{VectorCompressionTurboQuant4Bits, VectorCompressionTurboQuant4Bits, false},
+		{"TurboQuant6Bits", "", true},
+		{"TurboQuant8Bits", "", true},
+		{"turboquant4bits", "", true},
+	}
+	for _, tc := range cases {
+		got, err := NormalizeVectorCompression(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Fatalf("NormalizeVectorCompression(%q) error = nil, want error", tc.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("NormalizeVectorCompression(%q): %v", tc.in, err)
+		}
+		if got != tc.want {
+			t.Fatalf("NormalizeVectorCompression(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestValidateVectorCompressionDimension(t *testing.T) {
+	t.Parallel()
+	if err := ValidateVectorCompression(1, VectorCompressionTurboQuant4Bits); err == nil {
+		t.Fatal("expected error for dim < 2")
+	}
+	if err := ValidateVectorCompression(8, VectorCompressionTurboQuant4Bits); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestVectorQuantizerRoundTrip(t *testing.T) {
+	dim := 8
+	vec := []float32{1, 0, 0, 0, 0, 0, 0, 0}
+	for _, scheme := range []string{VectorCompressionTurboQuant2Bits, VectorCompressionTurboQuant3Bits, VectorCompressionTurboQuant4Bits} {
+		q, err := NewVectorQuantizer(dim, scheme)
+		if err != nil {
+			t.Fatalf("%s: NewVectorQuantizer: %v", scheme, err)
+		}
+		if q.PayloadSize() >= 4*dim {
+			t.Fatalf("%s: payload size %d is not smaller than float32 (%d)", scheme, q.PayloadSize(), 4*dim)
+		}
+		payload, err := q.Quantize(vec)
+		if err != nil {
+			t.Fatalf("%s: Quantize: %v", scheme, err)
+		}
+		if len(payload) != q.PayloadSize() {
+			t.Fatalf("%s: quantized bytes %d, want %d", scheme, len(payload), q.PayloadSize())
+		}
+		got, err := q.Dequantize(payload)
+		if err != nil {
+			t.Fatalf("%s: Dequantize: %v", scheme, err)
+		}
+		if len(got) != dim {
+			t.Fatalf("%s: reconstructed dim %d, want %d", scheme, len(got), dim)
+		}
+		if cosineSimilarity(vec, got) < 0.7 {
+			t.Fatalf("%s: cosine similarity too low: %f", scheme, cosineSimilarity(vec, got))
+		}
+	}
+}
+
+func cosineSimilarity(a, b []float32) float64 {
+	var dot, na, nb float64
+	for i := range a {
+		ai := float64(a[i])
+		bi := float64(b[i])
+		dot += ai * bi
+		na += ai * ai
+		nb += bi * bi
+	}
+	if na == 0 || nb == 0 {
+		return 0
+	}
+	return dot / (math.Sqrt(na) * math.Sqrt(nb))
+}

--- a/main.go
+++ b/main.go
@@ -526,6 +526,7 @@ Space management
                                     --segment-rollover-bytes N
                                     --max-segments-before-merge N
                                     --metadata-fields name:type,...  (Flat vector only; type: string|int|float)
+                                    --compression SCHEME            (Flat+metadata only; TurboQuant2Bits, TurboQuant3Bits, or TurboQuant4Bits)
   update-space-settings <name> [--segment-rollover-bytes N] [--max-segments-before-merge N]
   delete-space <name>             Delete a space and its data
 
@@ -567,6 +568,9 @@ User management (admin)
 
 Notes
   - --metadata-fields and --meta are comma-separated and must not contain spaces.
+  - --compression is only valid on Flat vector spaces created with --metadata-fields.
+    Stored vectors are TurboQuant-quantized (2, 3, or 4 bits); search reconstructs approximate float32.
+    6-bit and 8-bit schemes are not available — the TurboQuant library only supports 2/3/4-bit.
   - Vector ids are parsed as int64; query vector length must match the space dimension.
 `)
 }
@@ -787,7 +791,7 @@ func connectToServer(port, providedUser, providedPass string) {
 			query = models.Query{Type: models.TypeGetUser, Data: parts[1]}
 		case "create-space":
 			if len(parts) < 2 {
-				fmt.Println("Usage: create-space <name> [--engine key-value|vector] [--dimension N] [--index-type TYPE] [--metric METRIC] [--enable-wal] [--disable-wal] [--segment-rollover-bytes N] [--max-segments-before-merge N] [--metadata-fields name:type,...]")
+				fmt.Println("Usage: create-space <name> [--engine key-value|vector] [--dimension N] [--index-type TYPE] [--metric METRIC] [--enable-wal] [--disable-wal] [--segment-rollover-bytes N] [--max-segments-before-merge N] [--metadata-fields name:type,...] [--compression TurboQuant2Bits|TurboQuant3Bits|TurboQuant4Bits]")
 				continue
 			}
 			engineType := "key-value"
@@ -799,6 +803,7 @@ func connectToServer(port, providedUser, providedPass string) {
 			segmentRolloverBytes := int64(0)
 			maxSegmentsBeforeMerge := 0
 			metadataFieldsSpec := ""
+			compression := ""
 			for i := 2; i < len(parts); i++ {
 				if parts[i] == "--engine" && i+1 < len(parts) {
 					engineType = parts[i+1]
@@ -837,6 +842,9 @@ func connectToServer(port, providedUser, providedPass string) {
 				} else if parts[i] == "--metadata-fields" && i+1 < len(parts) {
 					metadataFieldsSpec = parts[i+1]
 					i++
+				} else if parts[i] == "--compression" && i+1 < len(parts) {
+					compression = parts[i+1]
+					i++
 				}
 			}
 
@@ -866,6 +874,7 @@ func connectToServer(port, providedUser, providedPass string) {
 				SegmentRolloverBytes:   segmentRolloverBytes,
 				MaxSegmentsBeforeMerge: maxSegmentsBeforeMerge,
 				IndexedMetadataFields:  indexedFields,
+				Compression:            compression,
 			}
 		case "update-space-settings":
 			if len(parts) < 2 {

--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -7,7 +7,7 @@ VERSION="${SHIBUDB_VERSION:-latest}"
 PREFIX="${SHIBUDB_PREFIX:-/usr/local}"
 SKIP_DEPS="${SHIBUDB_SKIP_DEPS:-0}"
 KEEP_BUILD_DIR="${SHIBUDB_KEEP_BUILD_DIR:-0}"
-GO_VERSION="${SHIBUDB_GO_VERSION:-1.23.7}"
+GO_VERSION="${SHIBUDB_GO_VERSION:-1.24.0}"
 
 usage() {
 	cat <<EOF
@@ -201,7 +201,7 @@ prepare_go() {
 	if command -v go >/dev/null 2>&1; then
 		local current
 		current="$(go env GOVERSION 2>/dev/null | sed 's/^go//')"
-		if [[ -n "$current" ]] && version_at_least "$current" "1.23.0"; then
+		if [[ -n "$current" ]] && version_at_least "$current" "1.24.0"; then
 			echo "Using existing Go: $(go version)"
 			return
 		fi


### PR DESCRIPTION
## Description

Adds optional TurboQuant compression for filterable Flat (flat-meta) vector spaces so vectors can be stored quantized in memory and on disk instead of float32. At `CREATE-SPACE` time, `--compression` can be `TurboQuant2Bits`, `TurboQuant3Bits`, or `TurboQuant4Bits` (~16× / ~10× / ~8× smaller than float32). Search and `GET-VECTOR` reconstruct approximate float32 values, so ranking is approximate.

This is only valid for `--engine vector --index-type Flat` with `--metadata-fields` and dimension ≥ 2. Existing uncompressed spaces are unchanged. 6-bit and 8-bit schemes are not offered because `github.com/mredencom/turboquant` only implements 2/3/4-bit quantization.

The Go toolchain requirement is bumped to 1.24.0 to match the TurboQuant library.

Fixes #35 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Verified locally with the new TurboQuant units and the existing flat-meta / space / query tests:

- `go test ./internal/storage/ ./internal/spaces/ ./internal/queryengine/ -count=1 -timeout 180s`
  - compression parse/validate and 2/3/4-bit quantize round-trip
  - compressed insert, filtered search, persistence rebuild
  - space-manager rejects compression on key-value, HNSW, and Flat without metadata fields
  - query-engine create/search with `TurboQuant4Bits`
  - dump/restore of compressed flat-meta records
- New E2E: `TestVectorFlatMetadataTurboQuantE2E` (create compressed space, insert, top-k and metadata filter)

Example:

```bash
create-space products --engine vector --dimension 128 --index-type Flat --metric L2 \
    --metadata-fields user_id:string \
    --compression TurboQuant4Bits
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional Notes

- Compression is fixed at space creation (stored in `space.meta.json`) and cannot be changed later.
- First open of a given (dimension, bit-width) builds a TurboQuant codebook; later spaces reuse the cache.
- Docs updated in `README.md`, `docs/VECTOR_ENGINE.md`, `docs/API_REFERENCE.md`, and `docs/TROUBLESHOOTING.md`.